### PR TITLE
Add Hardware page for memory, chipset, and the other units

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ A second launch focuses the window that is already open. Pass a page if you want
 ```bash
 ./bin/atmos appearance
 ./bin/atmos windows/bindings
+./bin/atmos hardware
 ./bin/atmos network/wifi
 ```
 
-Hubs include appearance, displays, windows, input, accessibility, sound, capture, disks, bar, notifications, defaults, applications, software, network, power, idle, security, hooks, and system.
+Hubs include appearance, displays, windows, input, accessibility, sound, capture, disks, hardware, bar, notifications, defaults, applications, software, network, power, idle, security, hooks, and system.
 
 ## Install
 

--- a/bin/atmos
+++ b/bin/atmos
@@ -12,8 +12,8 @@ if ! command -v quickshell >/dev/null 2>&1; then
 fi
 
 HUB=${PAGE%%/*}
-if [[ -n $PAGE && $HUB != appearance && $HUB != display && $HUB != windows && $HUB != input && $HUB != accessibility && $HUB != sound && $HUB != capture && $HUB != disks && $HUB != bar && $HUB != notifications && $HUB != defaults && $HUB != applications && $HUB != software && $HUB != network && $HUB != power && $HUB != idle && $HUB != security && $HUB != hooks && $HUB != system ]]; then
-  echo "Usage: atmos [appearance|display|windows|input|accessibility|sound|capture|disks|bar|notifications|defaults|applications|software|network|power|idle|security|hooks|system][/theme|background|boot|speedtest|wifi|bluetooth|bindings|rules]" >&2
+if [[ -n $PAGE && $HUB != appearance && $HUB != display && $HUB != windows && $HUB != input && $HUB != accessibility && $HUB != sound && $HUB != capture && $HUB != disks && $HUB != hardware && $HUB != bar && $HUB != notifications && $HUB != defaults && $HUB != applications && $HUB != software && $HUB != network && $HUB != power && $HUB != idle && $HUB != security && $HUB != hooks && $HUB != system ]]; then
+  echo "Usage: atmos [appearance|display|windows|input|accessibility|sound|capture|disks|hardware|bar|notifications|defaults|applications|software|network|power|idle|security|hooks|system][/theme|background|boot|speedtest|wifi|bluetooth|bindings|rules]" >&2
   exit 1
 fi
 

--- a/packaging/omarchy-menu.jsonc
+++ b/packaging/omarchy-menu.jsonc
@@ -41,6 +41,14 @@
     "keywords": "settings prefs disks drive snapshot luks",
     "description": "Drive space, encryption, snapshots, and hibernation"
   },
+  "setup.hardware": {
+    "icon": "",
+    "label": "Hardware",
+    "action": "atmos hardware",
+    "when": "command -v atmos",
+    "keywords": "settings prefs hardware cpu memory chipset motherboard bios gpu",
+    "description": "Processor, memory, chipset, firmware, and the other units in this machine"
+  },
   "style.sound.preferences": {
     "icon": "",
     "label": "Atmos",

--- a/pages/HardwarePage.qml
+++ b/pages/HardwarePage.qml
@@ -1,0 +1,341 @@
+import QtQuick
+import "../components"
+import "../services"
+import "../services/Hardware.js" as HardwareJs
+import "../services/RichUi.js" as RichUi
+
+PrefsPage {
+  id: root
+  title: "Hardware"
+  description: "What this machine is made of. Processor, memory, chipset, firmware, and the rest of the units the kernel can see."
+
+  readonly property var hw: HardwareJs.normalize(Omarchy.hardware)
+
+  function hasText() {
+    for (var i = 0; i < arguments.length; i++) {
+      if (String(arguments[i] || "").length) return true
+    }
+    return false
+  }
+
+  function listQuery(list) {
+    return (list instanceof Array) && list.length > 0 ? root.query : "."
+  }
+
+  function objectQuery(obj, keys) {
+    if (!obj) return "."
+    for (var i = 0; i < keys.length; i++) {
+      var value = obj[keys[i]]
+      if (value === true) return root.query
+      if (typeof value === "number" && value) return root.query
+      if (String(value || "").length) return root.query
+    }
+    return "."
+  }
+
+  function firmwareQuery() {
+    if (root.objectQuery(root.hw.bios, ["vendor", "version", "date"]) !== ".")
+      return root.query
+    if (root.hw.bios.uefi || root.hw.tpm.present || root.hw.secureBoot.available)
+      return root.query
+    return "."
+  }
+
+  PrefsGroup {
+    title: "Machine"
+    query: root.objectQuery(root.hw.machine, ["vendor", "name", "family", "chassis", "version", "serial", "sku"])
+    detail: "Name and chassis from DMI. Refresh reads the machine again, including memory use."
+
+    PrefsRow {
+      available: root.hasText(root.hw.machine.vendor, root.hw.machine.name, root.hw.machine.family, root.hw.machine.chassis)
+      label: root.hw.machine.name || root.hw.machine.family || "This machine"
+      description: HardwareJs.machineSummary(root.hw.machine) || "The firmware did not name this chassis."
+      hint: "/sys/class/dmi/id"
+      query: root.query
+      keywords: ["machine", "system", "product", "chassis", "laptop", "desktop", "dmi", "smbios"]
+    }
+
+    PrefsRow {
+      available: root.hasText(root.hw.machine.serial, root.hw.machine.sku)
+      label: "Identity"
+      description: root.hasText(root.hw.machine.serial)
+        ? ("Serial " + root.hw.machine.serial + (root.hw.machine.sku ? (". SKU " + root.hw.machine.sku) : "") + ".")
+        : ("SKU " + root.hw.machine.sku + ".")
+      hint: "/sys/class/dmi/id/product_serial"
+      query: root.query
+      keywords: ["serial", "sku", "service tag"]
+    }
+
+    PrefsRow {
+      label: "Refresh"
+      description: "Read the units again. Memory use and temperatures change while the machine runs."
+      hint: "snapshot"
+      query: root.query
+      keywords: ["reload", "rescan", "inventory"]
+
+      PrefsButton {
+        text: "Refresh"
+        enabled: !Omarchy.busy
+        onClicked: Omarchy.refresh()
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Motherboard"
+    query: root.objectQuery(root.hw.board, ["vendor", "name", "version"])
+    detail: "The board DMI names. Chipset is the host bridge on that board, listed next."
+
+    PrefsRow {
+      available: root.hasText(root.hw.board.vendor, root.hw.board.name)
+      label: root.hw.board.name || "Board"
+      description: HardwareJs.boardSummary(root.hw.board)
+      hint: "/sys/class/dmi/id/board_name"
+      query: root.query
+      keywords: ["motherboard", "mainboard", "board", "baseboard"]
+    }
+  }
+
+  PrefsGroup {
+    title: "Chipset"
+    query: root.objectQuery(root.hw.chipset, ["name", "vendor", "pciId", "southbridge"])
+    detail: "The PCI host bridge, and the ISA or LPC bridge when the kernel names one. That is the chipset the CPU talks to."
+
+    PrefsRow {
+      available: root.hasText(root.hw.chipset.name, root.hw.chipset.vendor, root.hw.chipset.pciId)
+      label: root.hw.chipset.name || "Host bridge"
+      description: HardwareJs.chipsetSummary(root.hw.chipset)
+      hint: "lspci"
+      query: root.query
+      keywords: ["chipset", "northbridge", "southbridge", "host bridge", "isa", "lpc", "pch", "pci"]
+    }
+  }
+
+  PrefsGroup {
+    title: "Firmware"
+    query: root.firmwareQuery()
+    detail: "BIOS or UEFI from DMI, plus TPM and Secure Boot when the firmware exposes them."
+
+    PrefsRow {
+      available: root.hasText(root.hw.bios.vendor, root.hw.bios.version, root.hw.bios.date) || root.hw.bios.uefi
+      label: "BIOS"
+      description: HardwareJs.biosSummary(root.hw.bios) || (root.hw.bios.uefi ? "UEFI is present." : "")
+      hint: "/sys/class/dmi/id/bios_version"
+      query: root.query
+      keywords: ["bios", "uefi", "firmware", "efi"]
+    }
+
+    PrefsRow {
+      available: root.hw.secureBoot.available
+      label: "Secure Boot"
+      description: root.hw.secureBoot.enabled
+        ? "Secure Boot is on."
+        : "UEFI is present. Secure Boot is off."
+      hint: "/sys/firmware/efi"
+      query: root.query
+      keywords: ["secure boot", "efi", "mok"]
+    }
+
+    PrefsRow {
+      available: root.hw.tpm.present
+      label: "TPM"
+      description: HardwareJs.tpmSummary(root.hw.tpm)
+      hint: "/sys/class/tpm"
+      query: root.query
+      keywords: ["tpm", "trusted platform"]
+    }
+  }
+
+  PrefsGroup {
+    title: "Processor"
+    query: root.objectQuery(root.hw.cpu, ["model", "vendor", "arch", "cores"])
+    detail: "Cores and threads from the kernel. Flags are the ones that matter for guests and SIMD."
+
+    PrefsRow {
+      available: root.hasText(root.hw.cpu.model, root.hw.cpu.vendor)
+      label: root.hw.cpu.model || "CPU"
+      description: HardwareJs.cpuSummary(root.hw.cpu)
+      hint: "lscpu"
+      query: root.query
+      keywords: ["cpu", "processor", "core", "thread", "avx", "intel", "amd", "arm"]
+    }
+  }
+
+  PrefsGroup {
+    title: "Memory"
+    query: root.hw.memory.total > 0 || root.hw.memory.modules.length > 0 ? root.query : "."
+    detail: "Use comes from /proc/meminfo. Modules are SMBIOS type 17 when the firmware table is readable without root."
+
+    PrefsRow {
+      available: root.hw.memory.total > 0
+      stretchControl: true
+      label: "Installed"
+      description: ""
+      hint: "/proc/meminfo"
+      query: root.query
+      keywords: ["ram", "memory", "dimm", "ddr", "swap"]
+
+      PrefsUsageBar {
+        width: parent.width
+        used: root.hw.memory.used
+        size: root.hw.memory.total
+        avail: root.hw.memory.available
+      }
+    }
+
+    PrefsRow {
+      available: root.hw.memory.swapTotal > 0
+      label: "Swap"
+      description: RichUi.formatBytes(root.hw.memory.swapUsed) + " of " + RichUi.formatBytes(root.hw.memory.swapTotal) + " in use."
+      hint: "/proc/meminfo"
+      query: root.query
+      keywords: ["swap", "zram"]
+    }
+
+    Repeater {
+      model: root.hw.memory.modules
+
+      PrefsRow {
+        required property var modelData
+        sectionHelp: false
+        label: (modelData && modelData.locator) || "DIMM"
+        description: HardwareJs.moduleSummary(modelData)
+        hint: "dmidecode -t memory"
+        query: root.query
+        keywords: ["dimm", "sodimm", "ddr4", "ddr5", "module", "bank"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Graphics"
+    query: root.listQuery(root.hw.gpus)
+    detail: "PCI display devices, plus the DRM driver when the kernel bound one."
+
+    Repeater {
+      model: root.hw.gpus
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && modelData.name) || "GPU"
+        description: HardwareJs.gpuSummary(modelData)
+        hint: "lspci"
+        query: root.query
+        keywords: ["gpu", "graphics", "vga", "nvidia", "amd", "intel", "drm"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Network adapters"
+    query: root.listQuery(root.hw.nics)
+    detail: "Physical interfaces the kernel registered. Virtual bridges and containers stay off this list."
+
+    Repeater {
+      model: root.hw.nics
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && (modelData.iface || modelData.name)) || "NIC"
+        description: HardwareJs.nicSummary(modelData)
+        hint: "/sys/class/net"
+        query: root.query
+        keywords: ["nic", "ethernet", "wifi", "wlan", "adapter", "mac"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Audio"
+    query: root.listQuery(root.hw.audio)
+    detail: "Sound cards from ALSA. Volume and sinks stay on the Sound page."
+
+    Repeater {
+      model: root.hw.audio
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && modelData.name) || "Audio"
+        description: modelData && modelData.driver ? ("ALSA " + modelData.driver + ".") : "ALSA card."
+        hint: "/proc/asound/cards"
+        query: root.query
+        keywords: ["audio", "sound", "alsa", "card"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "USB"
+    query: root.listQuery(root.hw.usb)
+    detail: "Devices on the USB buses that published a product name."
+
+    Repeater {
+      model: root.hw.usb
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && modelData.name) || "USB"
+        description: [
+          modelData && modelData.vendor ? modelData.vendor : "",
+          modelData && modelData.speed ? (modelData.speed + " Mb/s") : ""
+        ].filter(function(bit) { return bit.length }).join(". ") + ((modelData && (modelData.vendor || modelData.speed)) ? "." : "")
+        hint: "/sys/bus/usb/devices"
+        query: root.query
+        keywords: ["usb", "hub", "keyboard", "mouse", "storage"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Battery"
+    query: root.listQuery(root.hw.batteries)
+    detail: "Charge from sysfs. Profiles and the bar percentage stay on the Power page."
+
+    Repeater {
+      model: root.hw.batteries
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && modelData.name) || "Battery"
+        description: HardwareJs.batterySummary(modelData)
+        hint: "/sys/class/power_supply"
+        query: root.query
+        keywords: ["battery", "charge", "capacity"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Thermal"
+    query: root.listQuery(root.hw.thermals)
+    detail: "Zones the kernel exported. Refresh if you want a newer reading."
+
+    Repeater {
+      model: root.hw.thermals
+
+      PrefsRow {
+        required property var modelData
+        label: (modelData && (modelData.name || modelData.type)) || "Sensor"
+        description: HardwareJs.thermalSummary(modelData)
+        hint: "/sys/class/thermal"
+        query: root.query
+        keywords: ["thermal", "temperature", "sensor", "heat"]
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Virtualization"
+    query: root.objectQuery(root.hw.virtualization, ["hypervisor", "guest", "kvm"])
+    detail: "Whether this OS is a guest, and whether KVM can run guests here."
+
+    PrefsRow {
+      available: root.hw.virtualization.guest || root.hw.virtualization.kvm || root.hasText(root.hw.virtualization.hypervisor)
+      label: root.hw.virtualization.guest ? "Guest" : "Host"
+      description: HardwareJs.virtSummary(root.hw.virtualization) || "No hypervisor was reported."
+      hint: "lscpu"
+      query: root.query
+      keywords: ["kvm", "qemu", "hypervisor", "vm", "virtual", "guest"]
+    }
+  }
+}

--- a/pages/SearchPage.qml
+++ b/pages/SearchPage.qml
@@ -21,6 +21,7 @@ Item {
     || pageHits(soundLoader)
     || pageHits(captureLoader)
     || pageHits(disksLoader)
+    || pageHits(hardwareLoader)
     || pageHits(barLoader)
     || pageHits(notificationsLoader)
     || pageHits(defaultsLoader)
@@ -127,6 +128,12 @@ Item {
         id: disksLoader
         width: parent.width
         source: "DisksPage.qml"
+        onLoaded: root.bindPage(item, false)
+      }
+      Loader {
+        id: hardwareLoader
+        width: parent.width
+        source: "HardwarePage.qml"
         onLoaded: root.bindPage(item, false)
       }
       Loader {

--- a/scripts/hw-inventory.py
+++ b/scripts/hw-inventory.py
@@ -1,0 +1,942 @@
+#!/usr/bin/env python3
+"""Emit CPU, memory, chipset, and the rest of the machine. No sudo."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from io import StringIO
+
+
+SYS = os.environ.get("ATMOS_SYS_ROOT") or "/"
+SKIP_CMDS = bool(os.environ.get("ATMOS_HW_SKIP_CMDS"))
+
+
+def root(*parts):
+    return os.path.join(SYS, *[p.lstrip("/") for p in parts])
+
+
+def read_text(path, limit=8192):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read(limit)
+    except OSError:
+        return ""
+
+
+def read_strip(path, limit=512):
+    return read_text(path, limit).strip()
+
+
+def read_int(path):
+    text = read_strip(path)
+    if not text:
+        return 0
+    try:
+        return int(text.split()[0], 0)
+    except ValueError:
+        return 0
+
+
+def run(argv):
+    if SKIP_CMDS:
+        return ""
+    try:
+        return subprocess.check_output(argv, text=True, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+
+def parse_key_values(raw, sep=":"):
+    out = {}
+    for line in StringIO(raw):
+        cut = line.find(sep)
+        if cut < 1:
+            continue
+        key = line[:cut].strip()
+        value = line[cut + len(sep) :].strip()
+        if key:
+            out[key] = value
+    return out
+
+
+def kb_to_bytes(value):
+    try:
+        return int(float(re.sub(r"[^0-9.].*", "", str(value) or "0")) * 1024)
+    except ValueError:
+        return 0
+
+
+def clean(value, limit=240):
+    text = re.sub(r"[\r\n\t]+", " ", str(value or "")).strip()
+    if not text:
+        return ""
+    lower = text.lower()
+    if lower in {
+        "not specified",
+        "unknown",
+        "none",
+        "to be filled by o.e.m.",
+        "default string",
+        "fill by oem",
+        "system product name",
+        "system manufacturer",
+        "oem",
+        "1234567890",
+    } or re.fullmatch(r"0+", text) or re.fullmatch(r"[fF]+", text):
+        return ""
+    return text[:limit]
+
+
+CHASSIS_TYPES = {
+    1: "Other",
+    2: "Unknown",
+    3: "Desktop",
+    4: "Low-profile desktop",
+    5: "Pizza box",
+    6: "Mini tower",
+    7: "Tower",
+    8: "Portable",
+    9: "Laptop",
+    10: "Notebook",
+    11: "Handheld",
+    12: "Docking station",
+    13: "All-in-one",
+    14: "Sub-notebook",
+    15: "Space-saving",
+    16: "Lunch box",
+    17: "Main server",
+    18: "Expansion",
+    19: "Sub-chassis",
+    20: "Bus expansion",
+    21: "Peripheral",
+    22: "RAID",
+    23: "Rack mount",
+    24: "Sealed-case PC",
+    25: "Multi-system",
+    26: "Compact PCI",
+    27: "Advanced TCA",
+    28: "Blade",
+    29: "Blade enclosure",
+    30: "Tablet",
+    31: "Convertible",
+    32: "Detachable",
+    33: "IoT gateway",
+    34: "Embedded PC",
+    35: "Mini PC",
+    36: "Stick PC",
+}
+
+MEMORY_TYPES = {
+    1: "Other",
+    2: "Unknown",
+    3: "DRAM",
+    18: "DDR",
+    19: "DDR2",
+    24: "DDR3",
+    26: "DDR4",
+    27: "LPDDR",
+    29: "LPDDR3",
+    30: "LPDDR4",
+    32: "HBM",
+    33: "HBM2",
+    34: "DDR5",
+    35: "LPDDR5",
+    36: "LPDDR5X",
+    37: "HBM3",
+}
+
+MEMORY_FORMS = {
+    8: "DIMM",
+    13: "SODIMM",
+    15: "FB-DIMM",
+    16: "Die",
+}
+
+
+def chassis_name(value):
+    text = clean(value, 40)
+    if not text:
+        return ""
+    if text.isdigit():
+        return CHASSIS_TYPES.get(int(text), "")
+    return text
+
+
+def decode_memory_size(word, extended=0):
+    try:
+        size = int(word)
+    except (TypeError, ValueError):
+        return 0
+    if size in (0, 0xFFFF):
+        return 0
+    if size == 0x7FFF:
+        try:
+            ext = int(extended)
+        except (TypeError, ValueError):
+            return 0
+        return ext * 1024 * 1024 if ext > 0 else 0
+    value = size & 0x7FFF
+    if size & 0x8000:
+        return value * 1024
+    return value * 1024 * 1024
+
+
+def dmi_string(payload, strings, index):
+    if index <= 0 or index > len(strings):
+        return ""
+    return clean(strings[index - 1], 160)
+
+
+def parse_dmi_table(blob):
+    structs = []
+    i = 0
+    n = len(blob)
+    while i + 4 <= n:
+        typ = blob[i]
+        length = blob[i + 1]
+        handle = int.from_bytes(blob[i + 2 : i + 4], "little")
+        if length < 4 or i + length > n:
+            break
+        formatted = blob[i : i + length]
+        j = i + length
+        strings = []
+        if j < n and blob[j] == 0:
+            j += 1
+            if j < n and blob[j] == 0:
+                j += 1
+        else:
+            start = j
+            while j < n:
+                if blob[j] == 0:
+                    if j > start:
+                        strings.append(blob[start:j].decode("latin-1", "replace"))
+                    j += 1
+                    start = j
+                    if j < n and blob[j] == 0:
+                        j += 1
+                        break
+                else:
+                    j += 1
+        structs.append({"type": typ, "handle": handle, "data": formatted, "strings": strings})
+        i = j
+        if typ == 127:
+            break
+    return structs
+
+
+def read_dmi_blob():
+    path = root("sys/firmware/dmi/tables/DMI")
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(1 << 20)
+    except OSError:
+        return b""
+
+
+def apply_dmi(hw):
+    blob = read_dmi_blob()
+    if not blob:
+        return
+    for item in parse_dmi_table(blob):
+        data = item["data"]
+        strings = item["strings"]
+        typ = item["type"]
+        if typ == 0 and len(data) >= 9:
+            hw["bios"]["vendor"] = hw["bios"]["vendor"] or dmi_string(data, strings, data[4])
+            hw["bios"]["version"] = hw["bios"]["version"] or dmi_string(data, strings, data[5])
+            hw["bios"]["date"] = hw["bios"]["date"] or dmi_string(data, strings, data[8])
+        elif typ == 1 and len(data) >= 8:
+            hw["machine"]["vendor"] = hw["machine"]["vendor"] or dmi_string(data, strings, data[4])
+            hw["machine"]["name"] = hw["machine"]["name"] or dmi_string(data, strings, data[5])
+            hw["machine"]["version"] = hw["machine"]["version"] or dmi_string(data, strings, data[6])
+            hw["machine"]["serial"] = hw["machine"]["serial"] or dmi_string(data, strings, data[7])
+            if len(data) > 0x19:
+                hw["machine"]["sku"] = hw["machine"]["sku"] or dmi_string(data, strings, data[0x19])
+            if len(data) > 0x1A:
+                hw["machine"]["family"] = hw["machine"]["family"] or dmi_string(data, strings, data[0x1A])
+        elif typ == 2 and len(data) >= 8:
+            hw["board"]["vendor"] = hw["board"]["vendor"] or dmi_string(data, strings, data[4])
+            hw["board"]["name"] = hw["board"]["name"] or dmi_string(data, strings, data[5])
+            hw["board"]["version"] = hw["board"]["version"] or dmi_string(data, strings, data[6])
+            hw["board"]["serial"] = hw["board"]["serial"] or dmi_string(data, strings, data[7])
+        elif typ == 3 and len(data) >= 6:
+            if not hw["machine"]["chassis"]:
+                hw["machine"]["chassis"] = chassis_name(data[5] & 0x7F)
+        elif typ == 4 and len(data) >= 0x11:
+            version = dmi_string(data, strings, data[0x10])
+            if version and not hw["cpu"]["model"]:
+                hw["cpu"]["model"] = version
+            vendor = dmi_string(data, strings, data[7])
+            if vendor and not hw["cpu"]["vendor"]:
+                hw["cpu"]["vendor"] = vendor
+        elif typ == 17 and len(data) >= 0x13:
+            size_word = int.from_bytes(data[0x0C:0x0E], "little")
+            extended = 0
+            if len(data) >= 0x20:
+                extended = int.from_bytes(data[0x1C:0x20], "little")
+            size = decode_memory_size(size_word, extended)
+            locator = dmi_string(data, strings, data[0x10])
+            if not size and not locator:
+                continue
+            form = MEMORY_FORMS.get(data[0x0E], "")
+            mem_type = MEMORY_TYPES.get(data[0x12], "")
+            speed = int.from_bytes(data[0x15:0x17], "little") if len(data) >= 0x17 else 0
+            manufacturer = dmi_string(data, strings, data[0x17]) if len(data) > 0x17 else ""
+            part = dmi_string(data, strings, data[0x1A]) if len(data) > 0x1A else ""
+            bank = dmi_string(data, strings, data[0x11]) if len(data) > 0x11 else ""
+            rank = (data[0x1B] & 0x0F) if len(data) > 0x1B else 0
+            hw["memory"]["modules"].append(
+                {
+                    "locator": locator,
+                    "bank": bank,
+                    "size": size,
+                    "type": mem_type,
+                    "form": form,
+                    "speed": speed if speed not in (0, 0xFFFF) else 0,
+                    "manufacturer": manufacturer,
+                    "part": part,
+                    "rank": rank,
+                }
+            )
+
+
+def dmi_id():
+    base = root("sys/class/dmi/id")
+    if not os.path.isdir(base):
+        return {}
+    keys = (
+        "bios_date",
+        "bios_vendor",
+        "bios_version",
+        "board_name",
+        "board_serial",
+        "board_vendor",
+        "board_version",
+        "chassis_type",
+        "product_family",
+        "product_name",
+        "product_serial",
+        "product_sku",
+        "product_version",
+        "sys_vendor",
+    )
+    out = {}
+    for key in keys:
+        out[key] = clean(read_strip(os.path.join(base, key)), 160)
+    return out
+
+
+def apply_dmi_id(hw, info):
+    hw["bios"]["vendor"] = hw["bios"]["vendor"] or info.get("bios_vendor", "")
+    hw["bios"]["version"] = hw["bios"]["version"] or info.get("bios_version", "")
+    hw["bios"]["date"] = hw["bios"]["date"] or info.get("bios_date", "")
+    hw["machine"]["vendor"] = hw["machine"]["vendor"] or info.get("sys_vendor", "")
+    hw["machine"]["name"] = hw["machine"]["name"] or info.get("product_name", "")
+    hw["machine"]["family"] = hw["machine"]["family"] or info.get("product_family", "")
+    hw["machine"]["version"] = hw["machine"]["version"] or info.get("product_version", "")
+    hw["machine"]["serial"] = hw["machine"]["serial"] or info.get("product_serial", "")
+    hw["machine"]["sku"] = hw["machine"]["sku"] or info.get("product_sku", "")
+    if not hw["machine"]["chassis"]:
+        hw["machine"]["chassis"] = chassis_name(info.get("chassis_type", ""))
+    hw["board"]["vendor"] = hw["board"]["vendor"] or info.get("board_vendor", "")
+    hw["board"]["name"] = hw["board"]["name"] or info.get("board_name", "")
+    hw["board"]["version"] = hw["board"]["version"] or info.get("board_version", "")
+    hw["board"]["serial"] = hw["board"]["serial"] or info.get("board_serial", "")
+
+
+def parse_meminfo():
+    raw = read_text(root("proc/meminfo"), 16384)
+    kv = parse_key_values(raw)
+    total = kb_to_bytes(kv.get("MemTotal"))
+    available = kb_to_bytes(kv.get("MemAvailable"))
+    if not available:
+        available = kb_to_bytes(kv.get("MemFree")) + kb_to_bytes(kv.get("Cached")) + kb_to_bytes(kv.get("Buffers"))
+    if available > total:
+        available = total
+    used = total - available if total > available else 0
+    swap_total = kb_to_bytes(kv.get("SwapTotal"))
+    swap_free = kb_to_bytes(kv.get("SwapFree"))
+    swap_used = swap_total - swap_free if swap_total > swap_free else 0
+    return {
+        "total": total,
+        "used": used,
+        "available": available,
+        "swapTotal": swap_total,
+        "swapUsed": swap_used,
+        "modules": [],
+    }
+
+
+def parse_cpuinfo():
+    raw = read_text(root("proc/cpuinfo"), 1 << 18)
+    blocks = re.split(r"\n\n+", raw)
+    model = ""
+    vendor = ""
+    flags = []
+    mhz = 0.0
+    physical = {}
+    threads = 0
+    for block in blocks:
+        kv = parse_key_values(block)
+        if "processor" not in kv and "model name" not in kv and "Hardware" not in kv:
+            continue
+        threads += 1
+        model = model or clean(kv.get("model name") or kv.get("Hardware") or kv.get("model"), 160)
+        vendor = vendor or clean(kv.get("vendor_id") or kv.get("Hardware"), 80)
+        if not flags and kv.get("flags"):
+            flags = [f for f in kv["flags"].split() if f]
+        try:
+            hz = float(kv.get("cpu MHz") or 0)
+        except ValueError:
+            hz = 0
+        if hz > mhz:
+            mhz = hz
+        phys = kv.get("physical id") or "0"
+        try:
+            cores = int(kv.get("cpu cores") or 0)
+        except ValueError:
+            cores = 0
+        physical[phys] = max(physical.get(phys, 0), cores or 1)
+    cores = sum(physical.values()) or threads
+    return {
+        "model": model,
+        "vendor": vendor,
+        "arch": "",
+        "cores": cores,
+        "threads": threads,
+        "sockets": len(physical) or 1,
+        "mhz": int(round(mhz)),
+        "maxMhz": 0,
+        "caches": "",
+        "flags": flags,
+        "virtualization": "",
+        "hypervisor": "",
+    }
+
+
+def apply_lscpu(cpu):
+    raw = run(["lscpu"])
+    if not raw:
+        return
+    kv = parse_key_values(raw)
+
+    def num(key):
+        text = re.sub(r"[^0-9.].*", "", kv.get(key) or "")
+        try:
+            return int(float(text)) if text else 0
+        except ValueError:
+            return 0
+
+    cpu["model"] = cpu["model"] or clean(kv.get("Model name") or kv.get("Model Name"), 160)
+    cpu["vendor"] = cpu["vendor"] or clean(kv.get("Vendor ID") or kv.get("BIOS Vendor ID"), 80)
+    cpu["arch"] = clean(kv.get("Architecture"), 40)
+    sockets = num("Socket(s)") or cpu["sockets"] or 1
+    per = num("Core(s) per socket")
+    cpu["sockets"] = sockets
+    if per:
+        cpu["cores"] = per * sockets
+    cpu["threads"] = num("CPU(s)") or cpu["threads"]
+    cpu["mhz"] = cpu["mhz"] or num("CPU MHz")
+    cpu["maxMhz"] = num("CPU max MHz")
+    caches = []
+    for key, label in (
+        ("L1d cache", "L1d"),
+        ("L1i cache", "L1i"),
+        ("L2 cache", "L2"),
+        ("L3 cache", "L3"),
+    ):
+        if kv.get(key):
+            caches.append(f"{label} {kv[key]}")
+    cpu["caches"] = ", ".join(caches)
+    if not cpu["flags"] and kv.get("Flags"):
+        cpu["flags"] = [f for f in kv["Flags"].split() if f]
+    cpu["virtualization"] = clean(kv.get("Virtualization"), 40)
+    cpu["hypervisor"] = clean(kv.get("Hypervisor vendor"), 40)
+
+
+def apply_cpufreq(cpu):
+    max_hz = read_int(root("sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"))
+    cur_hz = read_int(root("sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"))
+    if max_hz:
+        cpu["maxMhz"] = cpu["maxMhz"] or max_hz // 1000
+    if cur_hz:
+        cpu["mhz"] = cpu["mhz"] or cur_hz // 1000
+
+
+def pci_ids_paths():
+    return [
+        root("usr/share/hwdata/pci.ids"),
+        root("usr/share/misc/pci.ids"),
+        "/usr/share/hwdata/pci.ids",
+        "/usr/share/misc/pci.ids",
+    ]
+
+
+def lookup_pci_names(pairs):
+    needed = {vendor: set() for vendor, _device in pairs}
+    for vendor, device in pairs:
+        needed.setdefault(vendor, set()).add(device)
+    names = {}
+    path = next((p for p in pci_ids_paths() if os.path.isfile(p)), "")
+    if not path:
+        return names
+    vendor = ""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if not line or line[0] == "#" or line.startswith("C "):
+                    continue
+                if line[0] != "\t":
+                    parts = line.split(None, 1)
+                    if len(parts) != 2:
+                        continue
+                    vendor = parts[0].lower()
+                    if vendor in needed:
+                        names[vendor] = parts[1].strip()
+                    continue
+                if line.startswith("\t\t") or vendor not in needed:
+                    continue
+                parts = line.strip().split(None, 1)
+                if len(parts) != 2:
+                    continue
+                device = parts[0].lower()
+                if device in needed[vendor]:
+                    names[f"{vendor}:{device}"] = parts[1].strip()
+    except OSError:
+        return names
+    return names
+
+
+def sysfs_pci_devices():
+    base = root("sys/bus/pci/devices")
+    if not os.path.isdir(base):
+        return []
+    rows = []
+    for name in sorted(os.listdir(base)):
+        path = os.path.join(base, name)
+        vendor = read_strip(os.path.join(path, "vendor")).replace("0x", "").lower()
+        device = read_strip(os.path.join(path, "device")).replace("0x", "").lower()
+        cls = read_strip(os.path.join(path, "class")).replace("0x", "").lower()
+        if len(vendor) < 4 or len(device) < 4:
+            continue
+        rows.append(
+            {
+                "slot": name.replace("0000:", ""),
+                "classId": cls[:4] if len(cls) >= 4 else cls,
+                "className": "",
+                "vendor": "",
+                "name": "",
+                "pciId": f"{vendor}:{device}",
+                "vendorId": vendor,
+                "deviceId": device,
+            }
+        )
+    names = lookup_pci_names([(r["vendorId"], r["deviceId"]) for r in rows])
+    class_names = {
+        "0600": "Host bridge",
+        "0601": "ISA bridge",
+        "0300": "VGA compatible controller",
+        "0302": "3D controller",
+        "0380": "Display controller",
+        "0200": "Ethernet controller",
+        "0280": "Network controller",
+        "0403": "Audio device",
+        "0c03": "USB controller",
+        "0c05": "SMBus",
+    }
+    for row in rows:
+        row["vendor"] = names.get(row["vendorId"], "")
+        row["name"] = names.get(row["pciId"], "")
+        row["className"] = class_names.get(row["classId"], "")
+    return rows
+
+
+def parse_lspci():
+    raw = run(["lspci", "-nnmm"]) or run(["lspci", "-nn"])
+    if not raw:
+        return sysfs_pci_devices()
+    rows = []
+    mm = re.compile(
+        r'^(\S+)\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"'
+    )
+    classic = re.compile(r"^(\S+)\s+([^:]+):\s+(.*)$")
+    for line in raw.splitlines():
+        match = mm.match(line)
+        if match:
+            cls, ven, dev = match.group(2), match.group(3), match.group(4)
+            class_id = (re.search(r"\[([0-9a-fA-F]{4})\]", cls) or [None, ""])[1].lower()
+            vendor_id = (re.search(r"\[([0-9a-fA-F]{4})\]", ven) or [None, ""])[1].lower()
+            device_id = (re.search(r"\[([0-9a-fA-F]{4,8})\]", dev) or [None, ""])[1].lower()
+            rows.append(
+                {
+                    "slot": match.group(1),
+                    "className": clean(re.sub(r"\s*\[[0-9a-fA-F]{4}\]\s*$", "", cls), 80),
+                    "classId": class_id,
+                    "vendor": clean(re.sub(r"\s*\[[0-9a-fA-F]{4}\]\s*$", "", ven), 80),
+                    "name": clean(re.sub(r"\s*\[[0-9a-fA-F]{4,8}\]\s*$", "", dev), 160),
+                    "pciId": f"{vendor_id}:{device_id}" if vendor_id and device_id else "",
+                }
+            )
+            continue
+        match = classic.match(line)
+        if not match:
+            continue
+        ids = re.search(r"\[([0-9a-fA-F]{4}):([0-9a-fA-F]{4})\]", match.group(3))
+        rows.append(
+            {
+                "slot": match.group(1),
+                "className": clean(match.group(2), 80),
+                "classId": "",
+                "vendor": "",
+                "name": clean(re.sub(r"\s*\[[0-9a-fA-F]{4}:[0-9a-fA-F]{4}\]\s*$", "", match.group(3)), 160),
+                "pciId": f"{ids.group(1).lower()}:{ids.group(2).lower()}" if ids else "",
+            }
+        )
+    return rows
+
+
+def is_host_bridge(row):
+    return row.get("classId") == "0600" or "host bridge" in (row.get("className") or "").lower()
+
+
+def is_isa_bridge(row):
+    name = (row.get("className") or "").lower()
+    return row.get("classId") == "0601" or "isa bridge" in name or "lpc" in name
+
+
+def is_gpu(row):
+    if row.get("classId") in {"0300", "0302", "0380"}:
+        return True
+    name = (row.get("className") or "").lower()
+    return "vga" in name or "3d controller" in name or "display controller" in name
+
+
+def pick_chipset(devices):
+    host = next((r for r in devices if is_host_bridge(r)), None)
+    south = next((r for r in devices if is_isa_bridge(r)), None)
+    primary = host or south
+    if not primary:
+        return {"name": "", "vendor": "", "pciId": "", "role": "", "southbridge": ""}
+    south_name = ""
+    if host and south and south.get("name") and south.get("name") != host.get("name"):
+        south_name = south.get("name") or ""
+    return {
+        "name": clean(primary.get("name"), 160),
+        "vendor": clean(primary.get("vendor"), 80),
+        "pciId": clean(primary.get("pciId"), 20),
+        "role": "Host bridge" if host else "ISA bridge",
+        "southbridge": clean(south_name, 160),
+    }
+
+
+def drm_driver(pci_id):
+    base = root("sys/class/drm")
+    if not os.path.isdir(base):
+        return ""
+    for name in os.listdir(base):
+        if not name.startswith("card") or "-" in name:
+            continue
+        device = os.path.join(base, name, "device")
+        vendor = read_strip(os.path.join(device, "vendor")).replace("0x", "").lower()
+        dev = read_strip(os.path.join(device, "device")).replace("0x", "").lower()
+        if pci_id and f"{vendor}:{dev}" != pci_id:
+            continue
+        driver = os.path.basename(os.path.realpath(os.path.join(device, "driver")))
+        if driver and driver != "driver":
+            return driver
+    return ""
+
+
+def collect_gpus(devices):
+    out = []
+    for row in devices:
+        if not is_gpu(row):
+            continue
+        pci_id = row.get("pciId") or ""
+        out.append(
+            {
+                "name": clean(row.get("name"), 160),
+                "vendor": clean(row.get("vendor"), 80),
+                "pciId": pci_id,
+                "driver": drm_driver(pci_id),
+                "vram": 0,
+            }
+        )
+    if out:
+        return out
+    base = root("sys/class/drm")
+    if not os.path.isdir(base):
+        return out
+    seen = set()
+    for name in sorted(os.listdir(base)):
+        if not name.startswith("card") or "-" in name:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        device = os.path.join(base, name, "device")
+        driver = os.path.basename(os.path.realpath(os.path.join(device, "driver")))
+        if driver == "driver":
+            driver = ""
+        out.append({"name": name, "vendor": "", "pciId": "", "driver": driver, "vram": 0})
+    return out
+
+
+VIRTUAL_NET = re.compile(
+    r"^(lo|docker\d*|veth|br-|virbr|cni|flannel|tun|tap|wg|tailscale|zt)"
+)
+
+
+def collect_nics():
+    base = root("sys/class/net")
+    if not os.path.isdir(base):
+        return []
+    rows = []
+    for name in sorted(os.listdir(base)):
+        path = os.path.join(base, name)
+        if VIRTUAL_NET.match(name):
+            continue
+        if not os.path.isdir(path):
+            continue
+        iface_type = read_strip(os.path.join(path, "type"))
+        if iface_type == "772":
+            continue
+        driver_path = os.path.join(path, "device", "driver")
+        driver = ""
+        if os.path.exists(driver_path):
+            driver = os.path.basename(os.path.realpath(driver_path))
+            if driver == "driver":
+                driver = ""
+        wireless = os.path.isdir(os.path.join(path, "wireless"))
+        speed = read_int(os.path.join(path, "speed"))
+        if speed < 0:
+            speed = 0
+        rows.append(
+            {
+                "name": name,
+                "iface": name,
+                "mac": clean(read_strip(os.path.join(path, "address")), 20),
+                "driver": driver,
+                "speed": speed,
+                "wireless": wireless,
+            }
+        )
+    return rows
+
+
+def collect_audio():
+    cards = read_text(root("proc/asound/cards"), 8192)
+    out = []
+    for match in re.finditer(r"^\s*(\d+)\s+\[([^\]]+)\]:\s+(.*)$", cards, re.M):
+        out.append({"id": match.group(1), "name": clean(match.group(3) or match.group(2), 160), "driver": clean(match.group(2), 40)})
+    if out:
+        return out
+    base = root("sys/class/sound")
+    if not os.path.isdir(base):
+        return out
+    for name in sorted(os.listdir(base)):
+        if not name.startswith("card") or name.endswith("c"):
+            continue
+        ident = read_strip(os.path.join(base, name, "id"))
+        if ident:
+            out.append({"id": name, "name": ident, "driver": ""})
+    return out
+
+
+def collect_usb():
+    base = root("sys/bus/usb/devices")
+    if not os.path.isdir(base):
+        return []
+    out = []
+    for name in sorted(os.listdir(base)):
+        path = os.path.join(base, name)
+        product = clean(read_strip(os.path.join(path, "product")), 160)
+        manufacturer = clean(read_strip(os.path.join(path, "manufacturer")), 80)
+        if not product and not manufacturer:
+            continue
+        if name.startswith("usb"):
+            continue
+        speed = clean(read_strip(os.path.join(path, "speed")), 20)
+        out.append({"name": product or manufacturer, "vendor": manufacturer, "product": product, "speed": speed})
+    return out
+
+
+def collect_batteries():
+    base = root("sys/class/power_supply")
+    if not os.path.isdir(base):
+        return []
+    out = []
+    for name in sorted(os.listdir(base)):
+        path = os.path.join(base, name)
+        kind = read_strip(os.path.join(path, "type")).lower()
+        if kind and kind != "battery":
+            continue
+        if not os.path.isfile(os.path.join(path, "capacity")) and kind != "battery":
+            continue
+        if not os.path.isfile(os.path.join(path, "capacity")):
+            continue
+        out.append(
+            {
+                "name": clean(read_strip(os.path.join(path, "model_name")) or name, 80),
+                "status": clean(read_strip(os.path.join(path, "status")), 20),
+                "capacity": read_int(os.path.join(path, "capacity")),
+                "technology": clean(read_strip(os.path.join(path, "technology")), 20),
+                "energy": read_int(os.path.join(path, "energy_now")),
+                "voltage": read_int(os.path.join(path, "voltage_now")),
+            }
+        )
+    return out
+
+
+def collect_thermals():
+    base = root("sys/class/thermal")
+    if not os.path.isdir(base):
+        return []
+    out = []
+    for name in sorted(os.listdir(base)):
+        if not name.startswith("thermal_zone"):
+            continue
+        path = os.path.join(base, name)
+        milli = read_int(os.path.join(path, "temp"))
+        if milli <= 0:
+            continue
+        kind = clean(read_strip(os.path.join(path, "type")), 40)
+        out.append({"name": kind or name, "type": kind, "temp": milli / 1000.0})
+    return out
+
+
+def collect_tpm():
+    tpm0 = root("sys/class/tpm/tpm0")
+    if os.path.isdir(tpm0):
+        version = clean(read_strip(os.path.join(tpm0, "tpm_version_major")), 12)
+        return {"present": True, "version": version}
+    if os.path.exists(root("dev/tpm0")) or os.path.exists(root("dev/tpmrm0")):
+        return {"present": True, "version": ""}
+    return {"present": False, "version": ""}
+
+
+def collect_secure_boot():
+    efi = root("sys/firmware/efi")
+    if not os.path.isdir(efi):
+        return {"available": False, "enabled": False}
+    var_dir = os.path.join(efi, "efivars")
+    enabled = False
+    if os.path.isdir(var_dir):
+        for name in os.listdir(var_dir):
+            if not name.startswith("SecureBoot-"):
+                continue
+            try:
+                with open(os.path.join(var_dir, name), "rb") as fh:
+                    blob = fh.read(8)
+                if len(blob) >= 5:
+                    enabled = blob[4] == 1
+            except OSError:
+                pass
+            break
+    return {"available": True, "enabled": enabled}
+
+
+def collect_virt(cpu):
+    hypervisor = clean(cpu.get("hypervisor"), 40)
+    flags = cpu.get("flags") or []
+    guest = bool(hypervisor) or "hypervisor" in flags
+    kvm = os.path.exists(root("dev/kvm"))
+    if not hypervisor:
+        for path in (
+            root("sys/hypervisor/type"),
+            root("sys/class/dmi/id/product_name"),
+        ):
+            text = clean(read_strip(path), 40)
+            if text.lower() in {"kvm", "qemu", "vmware", "virtualbox", "xen", "microsoft", "bhyve", "parallels"}:
+                hypervisor = text
+                guest = True
+                break
+    detect = run(["systemd-detect-virt"])
+    if detect:
+        virt = clean(detect.splitlines()[0], 40)
+        if virt and virt.lower() != "none":
+            hypervisor = hypervisor or virt
+            guest = True
+    return {"hypervisor": hypervisor, "guest": guest, "kvm": kvm}
+
+
+def empty_hardware():
+    return {
+        "machine": {
+            "vendor": "",
+            "name": "",
+            "family": "",
+            "version": "",
+            "serial": "",
+            "sku": "",
+            "chassis": "",
+        },
+        "board": {"vendor": "", "name": "", "version": "", "serial": ""},
+        "chipset": {"name": "", "vendor": "", "pciId": "", "role": "", "southbridge": ""},
+        "bios": {"vendor": "", "version": "", "date": "", "uefi": os.path.isdir(root("sys/firmware/efi"))},
+        "cpu": {
+            "model": "",
+            "vendor": "",
+            "arch": "",
+            "cores": 0,
+            "threads": 0,
+            "sockets": 1,
+            "mhz": 0,
+            "maxMhz": 0,
+            "caches": "",
+            "flags": [],
+            "virtualization": "",
+            "hypervisor": "",
+        },
+        "memory": {"total": 0, "used": 0, "available": 0, "swapTotal": 0, "swapUsed": 0, "modules": []},
+        "gpus": [],
+        "nics": [],
+        "audio": [],
+        "usb": [],
+        "batteries": [],
+        "thermals": [],
+        "tpm": {"present": False, "version": ""},
+        "secureBoot": {"available": False, "enabled": False},
+        "virtualization": {"hypervisor": "", "guest": False, "kvm": False},
+        "pci": [],
+    }
+
+
+def main():
+    hw = empty_hardware()
+    hw["memory"] = parse_meminfo()
+    hw["cpu"] = parse_cpuinfo()
+    apply_lscpu(hw["cpu"])
+    apply_cpufreq(hw["cpu"])
+    apply_dmi_id(hw, dmi_id())
+    apply_dmi(hw)
+    devices = parse_lspci()
+    hw["chipset"] = pick_chipset(devices)
+    hw["gpus"] = collect_gpus(devices)
+    hw["pci"] = [
+        {
+            "slot": r.get("slot", ""),
+            "className": r.get("className", ""),
+            "classId": r.get("classId", ""),
+            "vendor": r.get("vendor", ""),
+            "name": r.get("name", ""),
+            "pciId": r.get("pciId", ""),
+        }
+        for r in devices
+        if is_host_bridge(r) or is_isa_bridge(r) or is_gpu(r) or r.get("classId") in {"0200", "0280", "0403", "0c05"}
+    ]
+    hw["nics"] = collect_nics()
+    hw["audio"] = collect_audio()
+    hw["usb"] = collect_usb()
+    hw["batteries"] = collect_batteries()
+    hw["thermals"] = collect_thermals()
+    hw["tpm"] = collect_tpm()
+    hw["secureBoot"] = collect_secure_boot()
+    hw["virtualization"] = collect_virt(hw["cpu"])
+    json.dump(hw, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -283,6 +283,15 @@ fi
 [[ -n $swap_devices_json ]] || swap_devices_json='[]'
 [[ -n $snapshots_json ]] || snapshots_json='[]'
 
+hardware_json='{}'
+if present python3 && [[ -x $SNAP_DIR/hw-inventory.py ]]; then
+  hw_inv=$(python3 "$SNAP_DIR/hw-inventory.py" 2>/dev/null || true)
+  if [[ -n $hw_inv ]]; then
+    hardware_json=$(jq -c '.' <<<"$hw_inv" 2>/dev/null || echo '{}')
+  fi
+fi
+[[ -n $hardware_json ]] || hardware_json='{}'
+
 desktop_apps_json='[]'
 tui_apps_json='[]'
 web_apps_json='[]'
@@ -1341,6 +1350,7 @@ jq -n \
   --argjson audioTuningMatch "$audio_tuning_match" \
   --argjson audioTuningOn "$audio_tuning_on" \
   --argjson disks "$disks_json" \
+  --argjson hardware "$hardware_json" \
   --argjson luksDevices "$luks_devices_json" \
   --argjson swapDevices "$swap_devices_json" \
   --argjson snapperPresent "$snapper_present" \
@@ -1552,6 +1562,7 @@ jq -n \
     audioTuningMatch: $audioTuningMatch,
     audioTuningOn: $audioTuningOn,
     disks: $disks,
+    hardware: $hardware,
     luksDevices: $luksDevices,
     swapDevices: $swapDevices,
     snapperPresent: $snapperPresent,

--- a/services/Hardware.js
+++ b/services/Hardware.js
@@ -1,0 +1,670 @@
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {}
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function cleanText(value, max) {
+  var s = String(value == null ? "" : value).replace(/[\r\n\t]+/g, " ").replace(/^\s+|\s+$/g, "")
+  if (!s) return ""
+  var lower = s.toLowerCase()
+  if (lower === "not specified" || lower === "unknown" || lower === "none" ||
+      lower === "to be filled by o.e.m." || lower === "default string" ||
+      lower === "fill by oem" || lower === "system product name" ||
+      lower === "system manufacturer" || lower === "oem" ||
+      lower === "1234567890" || /^0+$/.test(s) || /^f+$/i.test(s))
+    return ""
+  var limit = max || 240
+  if (s.length > limit) s = s.substring(0, limit)
+  return s
+}
+
+function intOrZero(value) {
+  var n = Math.round(Number(value))
+  return isFinite(n) && n > 0 ? n : 0
+}
+
+function joinParts(parts, sep) {
+  var out = []
+  var list = Array.isArray(parts) ? parts : []
+  for (var i = 0; i < list.length; i++) {
+    var bit = cleanText(list[i], 200)
+    if (bit) out.push(bit)
+  }
+  return out.join(sep == null ? ". " : sep)
+}
+
+function sentence(parts) {
+  var text = joinParts(parts, ". ")
+  if (!text) return ""
+  return /[.!?]$/.test(text) ? text : text + "."
+}
+
+function emptyHardware() {
+  return {
+    machine: { vendor: "", name: "", family: "", version: "", serial: "", sku: "", chassis: "" },
+    board: { vendor: "", name: "", version: "", serial: "" },
+    chipset: { name: "", vendor: "", pciId: "", role: "", southbridge: "" },
+    bios: { vendor: "", version: "", date: "", uefi: false },
+    cpu: {
+      model: "", vendor: "", arch: "", cores: 0, threads: 0, sockets: 1,
+      mhz: 0, maxMhz: 0, caches: "", flags: [], virtualization: "", hypervisor: ""
+    },
+    memory: { total: 0, used: 0, available: 0, swapTotal: 0, swapUsed: 0, modules: [] },
+    gpus: [],
+    nics: [],
+    audio: [],
+    usb: [],
+    batteries: [],
+    thermals: [],
+    tpm: { present: false, version: "" },
+    secureBoot: { available: false, enabled: false },
+    virtualization: { hypervisor: "", guest: false, kvm: false },
+    pci: []
+  }
+}
+
+function parseKeyValues(raw, sep) {
+  var out = {}
+  var lines = String(raw || "").replace(/\r/g, "").split("\n")
+  var delim = sep == null ? ":" : sep
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i]
+    var cut = line.indexOf(delim)
+    if (cut < 1) continue
+    var key = line.substring(0, cut).replace(/^\s+|\s+$/g, "")
+    var value = line.substring(cut + delim.length).replace(/^\s+|\s+$/g, "")
+    if (key) out[key] = value
+  }
+  return out
+}
+
+function kbToBytes(value) {
+  var n = Number(String(value || "").replace(/[^0-9.].*/g, ""))
+  if (!isFinite(n) || n < 0) return 0
+  return Math.round(n * 1024)
+}
+
+function parseMeminfo(raw) {
+  var map = parseKeyValues(raw)
+  var total = kbToBytes(map.MemTotal)
+  var available = kbToBytes(map.MemAvailable)
+  if (!available) available = kbToBytes(map.MemFree) + kbToBytes(map.Cached) + kbToBytes(map.Buffers)
+  if (available > total) available = total
+  var used = total > available ? total - available : 0
+  var swapTotal = kbToBytes(map.SwapTotal)
+  var swapFree = kbToBytes(map.SwapFree)
+  var swapUsed = swapTotal > swapFree ? swapTotal - swapFree : 0
+  return {
+    total: total,
+    used: used,
+    available: available,
+    swapTotal: swapTotal,
+    swapUsed: swapUsed
+  }
+}
+
+function parseCpuinfo(raw) {
+  var text = String(raw || "").replace(/\r/g, "")
+  var blocks = text.split(/\n\n+/)
+  var model = ""
+  var vendor = ""
+  var flags = []
+  var mhz = 0
+  var physical = {}
+  var threads = 0
+  for (var i = 0; i < blocks.length; i++) {
+    var map = parseKeyValues(blocks[i])
+    if (!map["model name"] && !map.processor && map.processor !== "0") continue
+    threads += 1
+    if (!model) model = cleanText(map["model name"] || map.Hardware || map.model, 160)
+    if (!vendor) vendor = cleanText(map.vendor_id || map.Hardware, 80)
+    if (!flags.length && map.flags)
+      flags = String(map.flags).split(/\s+/).filter(function(f) { return !!f })
+    var hz = Number(map["cpu MHz"])
+    if (isFinite(hz) && hz > mhz) mhz = hz
+    var phys = String(map["physical id"] || "0")
+    var cores = intOrZero(map["cpu cores"])
+    if (!physical[phys] || cores > physical[phys]) physical[phys] = cores || 1
+  }
+  var sockets = Object.keys(physical).length
+  var cores = 0
+  var keys = Object.keys(physical)
+  for (var k = 0; k < keys.length; k++) cores += physical[keys[k]] || 0
+  if (!cores) cores = threads
+  if (!sockets) sockets = 1
+  return {
+    model: model,
+    vendor: vendor,
+    cores: cores,
+    threads: threads,
+    sockets: sockets,
+    mhz: Math.round(mhz),
+    flags: flags
+  }
+}
+
+function parseLscpu(raw) {
+  var map = parseKeyValues(raw)
+  function num(key) {
+    return intOrZero(String(map[key] || "").replace(/[^0-9.].*/g, ""))
+  }
+  var flags = []
+  var flagText = map.Flags || map.flags || ""
+  if (flagText) flags = flagText.split(/\s+/).filter(function(f) { return !!f })
+  return {
+    model: cleanText(map["Model name"] || map["Model Name"], 160),
+    vendor: cleanText(map["Vendor ID"] || map["BIOS Vendor ID"], 80),
+    arch: cleanText(map.Architecture, 40),
+    cores: num("Core(s) per socket") * (num("Socket(s)") || 1) || num("CPU(s)"),
+    threads: num("CPU(s)"),
+    sockets: num("Socket(s)") || 1,
+    mhz: num("CPU MHz") || num("CPU max MHz"),
+    maxMhz: num("CPU max MHz"),
+    caches: joinParts([
+      map["L1d cache"] ? "L1d " + map["L1d cache"] : "",
+      map["L1i cache"] ? "L1i " + map["L1i cache"] : "",
+      map["L2 cache"] ? "L2 " + map["L2 cache"] : "",
+      map["L3 cache"] ? "L3 " + map["L3 cache"] : ""
+    ], ", "),
+    flags: flags,
+    virtualization: cleanText(map.Virtualization, 40),
+    hypervisor: cleanText(map["Hypervisor vendor"], 40)
+  }
+}
+
+var PCI_CLASS_HOST = "0600"
+var PCI_CLASS_ISA = "0601"
+var PCI_CLASS_VGA = "0300"
+var PCI_CLASS_3D = "0302"
+var PCI_CLASS_DISPLAY = "0380"
+
+function pciClassCode(value) {
+  var s = String(value || "").toLowerCase().replace(/^0x/, "").replace(/[^0-9a-f]/g, "")
+  if (s.length >= 4) return s.substring(0, 4)
+  return s
+}
+
+function parseLspciLine(line) {
+  var text = String(line || "")
+  if (!text) return null
+  var mm = text.match(/^(\S+)\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"/)
+  if (mm) {
+    var cls = mm[2]
+    var ven = mm[3]
+    var dev = mm[4]
+    var classId = (cls.match(/\[([0-9a-fA-F]{4})\]/) || [])[1] || ""
+    var vendorId = (ven.match(/\[([0-9a-fA-F]{4})\]/) || [])[1] || ""
+    var deviceId = (dev.match(/\[([0-9a-fA-F]{4})\]/) || [])[1] || ""
+    return {
+      slot: mm[1],
+      className: cleanText(cls.replace(/\s*\[[0-9a-fA-F]{4}\]\s*$/, ""), 80),
+      classId: classId.toLowerCase(),
+      vendor: cleanText(ven.replace(/\s*\[[0-9a-fA-F]{4}\]\s*$/, ""), 80),
+      name: cleanText(dev.replace(/\s*\[[0-9a-fA-F]{4,8}\]\s*$/, ""), 160),
+      pciId: vendorId && deviceId ? vendorId.toLowerCase() + ":" + deviceId.toLowerCase() : ""
+    }
+  }
+  var classic = text.match(/^(\S+)\s+([^:]+):\s+(.*)$/)
+  if (!classic) return null
+  var ids = classic[3].match(/\[([0-9a-fA-F]{4}):([0-9a-fA-F]{4})\]/)
+  return {
+    slot: classic[1],
+    className: cleanText(classic[2], 80),
+    classId: "",
+    vendor: "",
+    name: cleanText(classic[3].replace(/\s*\[[0-9a-fA-F]{4}:[0-9a-fA-F]{4}\]\s*$/, ""), 160),
+    pciId: ids ? ids[1].toLowerCase() + ":" + ids[2].toLowerCase() : ""
+  }
+}
+
+function parseLspci(raw) {
+  var devices = []
+  var lines = String(raw || "").replace(/\r/g, "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var row = parseLspciLine(lines[i])
+    if (row) devices.push(row)
+  }
+  return devices
+}
+
+function isGpuClass(classId, className) {
+  var id = pciClassCode(classId)
+  if (id === PCI_CLASS_VGA || id === PCI_CLASS_3D || id === PCI_CLASS_DISPLAY) return true
+  var name = String(className || "").toLowerCase()
+  return name.indexOf("vga") !== -1 || name.indexOf("3d controller") !== -1 ||
+    name.indexOf("display controller") !== -1
+}
+
+function isHostBridge(classId, className) {
+  if (pciClassCode(classId) === PCI_CLASS_HOST) return true
+  return String(className || "").toLowerCase().indexOf("host bridge") !== -1
+}
+
+function isIsaBridge(classId, className) {
+  if (pciClassCode(classId) === PCI_CLASS_ISA) return true
+  var name = String(className || "").toLowerCase()
+  return name.indexOf("isa bridge") !== -1 || name.indexOf("lpc") !== -1
+}
+
+function pickChipset(devices) {
+  var list = asArray(devices)
+  var host = null
+  var south = null
+  for (var i = 0; i < list.length; i++) {
+    var row = list[i]
+    if (!host && isHostBridge(row.classId, row.className)) host = row
+    if (!south && isIsaBridge(row.classId, row.className)) south = row
+  }
+  if (!host && !south) return { name: "", vendor: "", pciId: "", role: "", southbridge: "" }
+  var primary = host || south
+  return {
+    name: cleanText(primary && primary.name, 160),
+    vendor: cleanText(primary && primary.vendor, 80),
+    pciId: cleanText(primary && primary.pciId, 20),
+    role: host ? "Host bridge" : "ISA bridge",
+    southbridge: host && south && south.name && south.name !== (host && host.name)
+      ? cleanText(south.name, 160)
+      : ""
+  }
+}
+
+function pickGpus(devices) {
+  var list = asArray(devices)
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var row = list[i]
+    if (!isGpuClass(row.classId, row.className)) continue
+    out.push({
+      name: cleanText(row.name, 160),
+      vendor: cleanText(row.vendor, 80),
+      pciId: cleanText(row.pciId, 20),
+      driver: "",
+      vram: 0
+    })
+  }
+  return out
+}
+
+var MEMORY_TYPES = {
+  1: "Other", 2: "Unknown", 3: "DRAM", 4: "EDRAM", 5: "VRAM", 6: "SRAM",
+  7: "RAM", 8: "ROM", 9: "Flash", 10: "EEPROM", 11: "FEPROM", 12: "EPROM",
+  13: "CDRAM", 14: "3DRAM", 15: "SDRAM", 16: "SGRAM", 17: "RDRAM",
+  18: "DDR", 19: "DDR2", 20: "DDR2 FB-DIMM", 24: "DDR3", 25: "FBD2",
+  26: "DDR4", 27: "LPDDR", 28: "LPDDR2", 29: "LPDDR3", 30: "LPDDR4",
+  31: "Logical", 32: "HBM", 33: "HBM2", 34: "DDR5", 35: "LPDDR5",
+  36: "LPDDR5X", 37: "HBM3"
+}
+
+var MEMORY_FORMS = {
+  1: "Other", 2: "Unknown", 3: "SIMM", 4: "SIP", 8: "DIMM", 9: "TSOP",
+  13: "SODIMM", 15: "FB-DIMM", 16: "Die"
+}
+
+var CHASSIS_TYPES = {
+  1: "Other", 2: "Unknown", 3: "Desktop", 4: "Low-profile desktop",
+  5: "Pizza box", 6: "Mini tower", 7: "Tower", 8: "Portable", 9: "Laptop",
+  10: "Notebook", 11: "Handheld", 12: "Docking station", 13: "All-in-one",
+  14: "Sub-notebook", 15: "Space-saving", 16: "Lunch box", 17: "Main server",
+  18: "Expansion", 19: "Sub-chassis", 20: "Bus expansion", 21: "Peripheral",
+  22: "RAID", 23: "Rack mount", 24: "Sealed-case PC", 25: "Multi-system",
+  26: "Compact PCI", 27: "Advanced TCA", 28: "Blade", 29: "Blade enclosure",
+  30: "Tablet", 31: "Convertible", 32: "Detachable", 33: "IoT gateway",
+  34: "Embedded PC", 35: "Mini PC", 36: "Stick PC"
+}
+
+function memoryTypeName(code) {
+  var n = intOrZero(code)
+  return MEMORY_TYPES[n] || ""
+}
+
+function memoryFormName(code) {
+  var n = intOrZero(code)
+  return MEMORY_FORMS[n] || ""
+}
+
+function chassisTypeName(code) {
+  var n = intOrZero(code)
+  if (!n && typeof code === "string" && code && !/^[0-9]+$/.test(code))
+    return cleanText(code, 40)
+  return CHASSIS_TYPES[n] || ""
+}
+
+// SMBIOS type 17 size: bits 0-14 are the value. Bit 15 means kilobytes.
+// 0 = empty slot, 0xFFFF = unknown, 0x7FFF = use the extended size (MiB).
+function decodeMemorySize(word, extendedMib) {
+  var size = Number(word)
+  if (!isFinite(size) || size === 0) return 0
+  if (size === 0xFFFF) return 0
+  if (size === 0x7FFF) {
+    var ext = Number(extendedMib)
+    if (!isFinite(ext) || ext <= 0) return 0
+    return Math.round(ext * 1024 * 1024)
+  }
+  var value = size & 0x7FFF
+  if (size & 0x8000) return value * 1024
+  return value * 1024 * 1024
+}
+
+function normalizeModule(item) {
+  var row = asObject(item)
+  return {
+    locator: cleanText(row.locator, 40),
+    bank: cleanText(row.bank, 40),
+    size: intOrZero(row.size),
+    type: cleanText(row.type || memoryTypeName(row.typeCode), 20),
+    form: cleanText(row.form || memoryFormName(row.formCode), 20),
+    speed: intOrZero(row.speed),
+    manufacturer: cleanText(row.manufacturer, 80),
+    part: cleanText(row.part, 80),
+    rank: intOrZero(row.rank)
+  }
+}
+
+function normalizePci(item) {
+  var row = asObject(item)
+  return {
+    slot: cleanText(row.slot, 20),
+    className: cleanText(row.className, 80),
+    classId: cleanText(row.classId, 8),
+    vendor: cleanText(row.vendor, 80),
+    name: cleanText(row.name, 160),
+    pciId: cleanText(row.pciId, 20)
+  }
+}
+
+function normalizeGpu(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name, 160),
+    vendor: cleanText(row.vendor, 80),
+    pciId: cleanText(row.pciId, 20),
+    driver: cleanText(row.driver, 40),
+    vram: intOrZero(row.vram)
+  }
+}
+
+function normalizeNic(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name || row.iface, 80),
+    iface: cleanText(row.iface, 32),
+    mac: cleanText(row.mac, 20),
+    driver: cleanText(row.driver, 40),
+    speed: intOrZero(row.speed),
+    wireless: row.wireless === true
+  }
+}
+
+function normalizeAudio(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name, 160),
+    driver: cleanText(row.driver, 40),
+    id: cleanText(row.id, 20)
+  }
+}
+
+function normalizeUsb(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name || row.product, 160),
+    vendor: cleanText(row.vendor, 80),
+    product: cleanText(row.product, 80),
+    speed: cleanText(row.speed, 20)
+  }
+}
+
+function normalizeBattery(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name, 80),
+    status: cleanText(row.status, 20),
+    capacity: intOrZero(row.capacity),
+    technology: cleanText(row.technology, 20),
+    energy: intOrZero(row.energy),
+    voltage: intOrZero(row.voltage)
+  }
+}
+
+function normalizeThermal(item) {
+  var row = asObject(item)
+  return {
+    name: cleanText(row.name || row.type, 80),
+    type: cleanText(row.type, 40),
+    temp: Number(row.temp)
+  }
+}
+
+function normalize(raw) {
+  var data = asObject(raw)
+  var out = emptyHardware()
+  var machine = asObject(data.machine)
+  out.machine.vendor = cleanText(machine.vendor, 80)
+  out.machine.name = cleanText(machine.name, 160)
+  out.machine.family = cleanText(machine.family, 80)
+  out.machine.version = cleanText(machine.version, 80)
+  out.machine.serial = cleanText(machine.serial, 80)
+  out.machine.sku = cleanText(machine.sku, 80)
+  out.machine.chassis = chassisTypeName(machine.chassis) || cleanText(machine.chassis, 40)
+
+  var board = asObject(data.board)
+  out.board.vendor = cleanText(board.vendor, 80)
+  out.board.name = cleanText(board.name, 160)
+  out.board.version = cleanText(board.version, 40)
+  out.board.serial = cleanText(board.serial, 80)
+
+  var chip = asObject(data.chipset)
+  out.chipset.name = cleanText(chip.name, 160)
+  out.chipset.vendor = cleanText(chip.vendor, 80)
+  out.chipset.pciId = cleanText(chip.pciId, 20)
+  out.chipset.role = cleanText(chip.role, 40)
+  out.chipset.southbridge = cleanText(chip.southbridge, 160)
+
+  var bios = asObject(data.bios)
+  out.bios.vendor = cleanText(bios.vendor, 80)
+  out.bios.version = cleanText(bios.version, 80)
+  out.bios.date = cleanText(bios.date, 40)
+  out.bios.uefi = bios.uefi === true
+
+  var cpu = asObject(data.cpu)
+  out.cpu.model = cleanText(cpu.model, 160)
+  out.cpu.vendor = cleanText(cpu.vendor, 80)
+  out.cpu.arch = cleanText(cpu.arch, 40)
+  out.cpu.cores = intOrZero(cpu.cores)
+  out.cpu.threads = intOrZero(cpu.threads)
+  out.cpu.sockets = intOrZero(cpu.sockets) || 1
+  out.cpu.mhz = intOrZero(cpu.mhz)
+  out.cpu.maxMhz = intOrZero(cpu.maxMhz)
+  out.cpu.caches = cleanText(cpu.caches, 200)
+  out.cpu.flags = asArray(cpu.flags).map(function(f) { return cleanText(f, 32) }).filter(function(f) { return !!f })
+  out.cpu.virtualization = cleanText(cpu.virtualization, 40)
+  out.cpu.hypervisor = cleanText(cpu.hypervisor, 40)
+
+  var memory = asObject(data.memory)
+  out.memory.total = intOrZero(memory.total)
+  out.memory.used = intOrZero(memory.used)
+  out.memory.available = intOrZero(memory.available)
+  out.memory.swapTotal = intOrZero(memory.swapTotal)
+  out.memory.swapUsed = intOrZero(memory.swapUsed)
+  out.memory.modules = asArray(memory.modules).map(normalizeModule).filter(function(m) { return m.size > 0 || m.locator })
+
+  out.gpus = asArray(data.gpus).map(normalizeGpu).filter(function(g) { return g.name || g.pciId })
+  out.nics = asArray(data.nics).map(normalizeNic).filter(function(n) { return n.iface || n.name })
+  out.audio = asArray(data.audio).map(normalizeAudio).filter(function(a) { return a.name })
+  out.usb = asArray(data.usb).map(normalizeUsb).filter(function(u) { return u.name || u.product })
+  out.batteries = asArray(data.batteries).map(normalizeBattery).filter(function(b) { return b.name || b.capacity })
+  out.thermals = asArray(data.thermals).map(normalizeThermal).filter(function(t) {
+    return t.name && isFinite(t.temp)
+  })
+
+  var tpm = asObject(data.tpm)
+  out.tpm.present = tpm.present === true
+  out.tpm.version = cleanText(tpm.version, 12)
+
+  var sb = asObject(data.secureBoot)
+  out.secureBoot.available = sb.available === true
+  out.secureBoot.enabled = sb.enabled === true
+
+  var virt = asObject(data.virtualization)
+  out.virtualization.hypervisor = cleanText(virt.hypervisor, 40)
+  out.virtualization.guest = virt.guest === true || !!out.virtualization.hypervisor
+  out.virtualization.kvm = virt.kvm === true
+
+  out.pci = asArray(data.pci).map(normalizePci).filter(function(p) { return p.name || p.className })
+  return out
+}
+
+function notableFlags(flags) {
+  var want = {
+    vmx: "VT-x", svm: "AMD-V", hypervisor: "hypervisor",
+    aes: "AES", avx: "AVX", avx2: "AVX2", avx512f: "AVX-512",
+    nx: "NX", lm: "64-bit", sse4_2: "SSE4.2"
+  }
+  var list = asArray(flags)
+  var out = []
+  var seen = {}
+  for (var i = 0; i < list.length; i++) {
+    var key = String(list[i] || "").toLowerCase()
+    var label = want[key]
+    if (!label || seen[label]) continue
+    seen[label] = true
+    out.push(label)
+  }
+  return out
+}
+
+function cpuSummary(cpu) {
+  var row = asObject(cpu)
+  var bits = []
+  if (row.model) bits.push(row.model)
+  var topo = []
+  if (row.cores) topo.push(row.cores + (row.cores === 1 ? " core" : " cores"))
+  if (row.threads && row.threads !== row.cores)
+    topo.push(row.threads + " threads")
+  if (row.sockets > 1) topo.push(row.sockets + " sockets")
+  if (row.arch) topo.push(row.arch)
+  if (topo.length) bits.push(topo.join(", "))
+  var clock = ""
+  if (row.maxMhz) clock = Math.round(row.maxMhz) + " MHz max"
+  else if (row.mhz) clock = Math.round(row.mhz) + " MHz"
+  if (clock) bits.push(clock)
+  if (row.caches) bits.push(row.caches)
+  var feats = notableFlags(row.flags)
+  if (row.virtualization) feats.unshift(row.virtualization)
+  if (feats.length) bits.push(feats.join(", "))
+  return sentence(bits)
+}
+
+function machineSummary(machine) {
+  var row = asObject(machine)
+  return sentence([
+    joinParts([row.vendor, row.name], " "),
+    row.family && row.family !== row.name ? row.family : "",
+    row.chassis,
+    row.version ? "Version " + row.version : ""
+  ])
+}
+
+function boardSummary(board) {
+  var row = asObject(board)
+  return sentence([
+    joinParts([row.vendor, row.name], " "),
+    row.version ? "Version " + row.version : ""
+  ])
+}
+
+function chipsetSummary(chipset) {
+  var row = asObject(chipset)
+  return sentence([
+    joinParts([row.vendor, row.name], " "),
+    row.role,
+    row.southbridge ? "Southbridge " + row.southbridge : "",
+    row.pciId
+  ])
+}
+
+function biosSummary(bios) {
+  var row = asObject(bios)
+  return sentence([
+    joinParts([row.vendor, row.version], " "),
+    row.date,
+    row.uefi ? "UEFI" : ""
+  ])
+}
+
+function formatModuleSize(bytes) {
+  var n = Number(bytes)
+  if (!isFinite(n) || n <= 0) return ""
+  var gb = n / (1024 * 1024 * 1024)
+  if (gb >= 1) {
+    if (Math.abs(gb - Math.round(gb)) < 0.05) return Math.round(gb) + " GB"
+    return gb.toFixed(1) + " GB"
+  }
+  return Math.round(n / (1024 * 1024)) + " MB"
+}
+
+function moduleSummary(item) {
+  var row = normalizeModule(item)
+  var bits = []
+  if (row.size) bits.push(formatModuleSize(row.size))
+  if (row.type) bits.push(row.type)
+  if (row.form) bits.push(row.form)
+  if (row.speed) bits.push(row.speed + " MT/s")
+  if (row.manufacturer) bits.push(row.manufacturer)
+  if (row.part) bits.push(row.part)
+  if (row.rank) bits.push("rank " + row.rank)
+  return bits.join(" · ")
+}
+
+function gpuSummary(item) {
+  var row = normalizeGpu(item)
+  return sentence([
+    joinParts([row.vendor, row.name], " "),
+    row.driver ? "Driver " + row.driver : "",
+    row.pciId
+  ])
+}
+
+function nicSummary(item) {
+  var row = normalizeNic(item)
+  var bits = []
+  if (row.name && row.name !== row.iface) bits.push(row.name)
+  if (row.wireless) bits.push("Wireless")
+  if (row.driver) bits.push("Driver " + row.driver)
+  if (row.speed > 0) bits.push(row.speed + " Mb/s")
+  if (row.mac) bits.push(row.mac)
+  return sentence(bits)
+}
+
+function batterySummary(item) {
+  var row = normalizeBattery(item)
+  var bits = []
+  if (row.status) bits.push(row.status)
+  if (row.capacity) bits.push(row.capacity + "%")
+  if (row.technology) bits.push(row.technology)
+  return sentence(bits)
+}
+
+function thermalSummary(item) {
+  var row = normalizeThermal(item)
+  if (!isFinite(row.temp)) return ""
+  return (Math.round(row.temp * 10) / 10) + " °C"
+}
+
+function tpmSummary(tpm) {
+  var row = asObject(tpm)
+  if (!row.present) return ""
+  return sentence([row.version ? "TPM " + row.version : "TPM is present"])
+}
+
+function virtSummary(virt) {
+  var row = asObject(virt)
+  var bits = []
+  if (row.hypervisor) bits.push("Running on " + row.hypervisor)
+  else if (row.guest) bits.push("This machine is a guest")
+  if (row.kvm) bits.push("KVM is available for guests")
+  return sentence(bits)
+}

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -2,6 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import "Hardware.js" as HardwareJs
 
 QtObject {
   id: root
@@ -157,6 +158,7 @@ QtObject {
   property string audioSink: ""
   property string audioSource: ""
   property var disks: []
+  property var hardware: ({})
   property var luksDevices: []
   property var swapDevices: []
   property bool snapperPresent: false
@@ -418,6 +420,7 @@ QtObject {
     audioTuningMatch = data.audioTuningMatch === true
     audioTuningOn = data.audioTuningOn === true
     disks = adoptArray(disks, data.disks)
+    hardware = HardwareJs.normalize(data.hardware)
     luksDevices = adoptArray(luksDevices, data.luksDevices)
     swapDevices = adoptArray(swapDevices, data.swapDevices)
     snapperPresent = data.snapperPresent === true

--- a/shell.qml
+++ b/shell.qml
@@ -22,6 +22,7 @@ ShellRoot {
     { id: "sound", title: "Sound", keywords: "audio volume mute speaker headphone sink source microphone mic input output pipewire pactl wpctl tuning dsp restart voxtype dictation speech" },
     { id: "capture", title: "Capture", keywords: "screenshot record recording screen video ocr qr webcam grim slurp pictures videos" },
     { id: "disks", title: "Disks", keywords: "drive nvme ssd lsblk luks encryption snapper snapshot btrfs hibernation zram swap speedtest df usage trim fstrim timeline retention" },
+    { id: "hardware", title: "Hardware", keywords: "cpu processor memory ram dimm ddr chipset northbridge southbridge motherboard board bios uefi firmware tpm secure boot gpu graphics nic ethernet usb battery thermal sensor kvm hypervisor virtual machine dmi smbios lscpu lspci" },
     { id: "bar", title: "Bar", keywords: "position transparent menu bar top bottom left right show hide visible clock format time alternate date week start calendar sunday monday birth year age life expectancy indicators always show status icons dictation recording reminder night light dnd stay awake agents usage refresh sync snapshot file hostname device id spacer gap padding tray hidden icons unhide pin unpin plugin widget" },
     { id: "notifications", title: "Notifications", keywords: "do not disturb dnd silent mute quiet toast reminder timer notify later test time battery weather" },
     { id: "defaults", title: "Defaults", keywords: "browser terminal editor agent chrome firefox nvim pdf mime image video" },
@@ -128,6 +129,7 @@ ShellRoot {
   Component { id: soundPage; SoundPage { query: root.query } }
   Component { id: capturePage; CapturePage { query: root.query } }
   Component { id: disksPage; DisksPage { query: root.query } }
+  Component { id: hardwarePage; HardwarePage { query: root.query } }
   Component { id: barPage; BarPage { query: root.query } }
   Component { id: notificationsPage; NotificationsPage { query: root.query } }
   Component { id: defaultsPage; DefaultsPage { query: root.query } }
@@ -150,6 +152,7 @@ ShellRoot {
     sound: soundPage,
     capture: capturePage,
     disks: disksPage,
+    hardware: hardwarePage,
     bar: barPage,
     notifications: notificationsPage,
     defaults: defaultsPage,

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -517,3 +517,88 @@ assert(required.indexOf('require("hypr.atmos")\nrequire("default.hypr.toggles")'
 assertEqual(rules.ensureRequire(''), '', 'ensureRequire leaves an empty hyprland.lua alone')
 assertEqual(rules.describe({ placement: 'float', center: true }).indexOf('float') !== -1, true, 'describe names float')
 
+const hw = load('services/Hardware.js')
+const mem = hw.parseMeminfo(`MemTotal:       16398384 kB
+MemAvailable:   15443444 kB
+MemFree:         5808696 kB
+SwapTotal:       2097152 kB
+SwapFree:        1048576 kB
+`)
+assertEqual(mem.total, 16398384 * 1024, 'parseMeminfo reads MemTotal')
+assert(mem.used > 0, 'parseMeminfo computes used from available')
+assertEqual(mem.swapUsed, (2097152 - 1048576) * 1024, 'parseMeminfo computes swap used')
+
+const cpuinfo = hw.parseCpuinfo(`processor	: 0
+vendor_id	: GenuineIntel
+model name	: Intel(R) Xeon(R) Processor
+cpu cores	: 4
+physical id	: 0
+cpu MHz		: 2400.000
+flags		: fpu vmx avx2 hypervisor
+
+processor	: 1
+vendor_id	: GenuineIntel
+model name	: Intel(R) Xeon(R) Processor
+cpu cores	: 4
+physical id	: 0
+`)
+assertEqual(cpuinfo.model, 'Intel(R) Xeon(R) Processor', 'parseCpuinfo reads the model')
+assertEqual(cpuinfo.cores, 4, 'parseCpuinfo uses cpu cores per socket')
+assertEqual(cpuinfo.threads, 2, 'parseCpuinfo counts processors as threads')
+assert(cpuinfo.flags.indexOf('vmx') !== -1, 'parseCpuinfo reads flags')
+
+const lscpu = hw.parseLscpu(`Architecture:                            x86_64
+Model name:                              Intel(R) Xeon(R) Processor
+Vendor ID:                               GenuineIntel
+CPU(s):                                  4
+Socket(s):                               1
+Core(s) per socket:                      4
+CPU max MHz:                             3600.000
+L3 cache:                                16 MiB
+Hypervisor vendor:                       KVM
+Virtualization:                          VT-x
+Flags:                                   vmx avx2
+`)
+assertEqual(lscpu.arch, 'x86_64', 'parseLscpu reads architecture')
+assertEqual(lscpu.cores, 4, 'parseLscpu multiplies cores per socket')
+assertEqual(lscpu.hypervisor, 'KVM', 'parseLscpu reads the hypervisor')
+assert(lscpu.caches.indexOf('L3') !== -1, 'parseLscpu reads caches')
+
+const pci = hw.parseLspci(`00:00.0 "Host bridge [0600]" "Intel Corporation [8086]" "4th Gen Core Processor DRAM Controller [0c00]"
+00:02.0 "VGA compatible controller [0300]" "Intel Corporation [8086]" "Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics [0412]"
+00:1f.0 "ISA bridge [0601]" "Intel Corporation [8086]" "C220 Series Chipset Family LPC Controller [8c54]"
+`)
+assertEqual(pci.length, 3, 'parseLspci reads mm-style rows')
+const chip = hw.pickChipset(pci)
+assertEqual(chip.name, '4th Gen Core Processor DRAM Controller', 'pickChipset prefers the host bridge')
+assertEqual(chip.southbridge, 'C220 Series Chipset Family LPC Controller', 'pickChipset keeps the LPC bridge')
+assertEqual(chip.pciId, '8086:0c00', 'pickChipset reads the PCI id')
+assertEqual(hw.pickGpus(pci).length, 1, 'pickGpus finds the VGA device')
+assertEqual(hw.pickGpus(pci)[0].name.indexOf('Integrated Graphics') !== -1, true, 'pickGpus keeps the GPU name')
+
+assertEqual(hw.decodeMemorySize(0, 0), 0, 'decodeMemorySize treats an empty slot as zero')
+assertEqual(hw.decodeMemorySize(0xFFFF, 0), 0, 'decodeMemorySize treats unknown as zero')
+assertEqual(hw.decodeMemorySize(8192, 0), 8192 * 1024 * 1024, 'decodeMemorySize reads megabytes')
+assertEqual(hw.decodeMemorySize(0x8000 | 16, 0), 16 * 1024, 'decodeMemorySize reads the kilobyte bit')
+assertEqual(hw.decodeMemorySize(0x7FFF, 32768), 32768 * 1024 * 1024, 'decodeMemorySize uses extended size')
+assertEqual(hw.memoryTypeName(26), 'DDR4', 'memoryTypeName maps DDR4')
+assertEqual(hw.memoryTypeName(34), 'DDR5', 'memoryTypeName maps DDR5')
+assertEqual(hw.chassisTypeName(9), 'Laptop', 'chassisTypeName maps laptop')
+assertEqual(hw.chassisTypeName('Notebook'), 'Notebook', 'chassisTypeName keeps a name')
+
+const normalized = hw.normalize({
+  machine: { vendor: 'Framework', name: 'Laptop 13', chassis: 9 },
+  chipset: { vendor: 'Intel', name: 'Raptor Lake-P', pciId: '8086:a706', role: 'Host bridge' },
+  cpu: { model: 'Intel Core Ultra 7', cores: 16, threads: 22, flags: ['vmx', 'avx2'] },
+  memory: { total: 32 * 1024 * 1024 * 1024, used: 8 * 1024 * 1024 * 1024, available: 24 * 1024 * 1024 * 1024, modules: [{ locator: 'DIMM0', size: 16 * 1024 * 1024 * 1024, type: 'DDR5', speed: 5600 }] },
+  gpus: [{ name: 'Arc Graphics', vendor: 'Intel' }]
+})
+assertEqual(normalized.machine.chassis, 'Laptop', 'normalize maps a chassis code')
+assert(normalized.chipset.name.indexOf('Raptor') !== -1, 'normalize keeps the chipset')
+assert(hw.cpuSummary(normalized.cpu).indexOf('16 cores') !== -1, 'cpuSummary names cores')
+assert(hw.chipsetSummary(normalized.chipset).indexOf('Raptor') !== -1, 'chipsetSummary names the chipset')
+assertEqual(hw.formatModuleSize(16 * 1024 * 1024 * 1024), '16 GB', 'formatModuleSize uses whole gigabytes')
+assert(hw.moduleSummary(normalized.memory.modules[0]).indexOf('DDR5') !== -1, 'moduleSummary names the type')
+assertEqual(hw.cleanText('To Be Filled By O.E.M.'), '', 'cleanText drops OEM filler')
+assertEqual(hw.cleanText('Not Specified'), '', 'cleanText drops Not Specified')
+

--- a/tests/run
+++ b/tests/run
@@ -8,7 +8,7 @@ node tests/parse.test.js
 
 if [[ -x scripts/snapshot.sh ]] && command -v omarchy >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
   json=$(bash scripts/snapshot.sh)
-  echo "$json" | jq -e '.theme and .themes and has("extraThemes") and (.extraThemes | type == "array") and has("desktopApps") and (.desktopApps | type == "array") and has("tuiApps") and (.tuiApps | type == "array") and has("webApps") and (.webApps | type == "array") and .barPosition and .idleScreensaver and has("stayAwake") and has("nightlight") and has("nightlightTemperature") and has("screensaverEnabled") and has("barVisible") and has("dns") and has("bluetooth") and has("suspendEnabled") and has("powerProfile") and has("powerProfileAc") and has("powerProfileBattery") and (.powerProfiles | type == "array") and has("crashCapture") and has("plymouth") and (.plymouthThemes | type == "array") and has("doNotDisturb") and has("weatherLocation") and has("weatherCoords") and has("weatherAuto") and has("weatherPresent") and has("weatherUnit") and has("weatherRefreshMinutes") and has("reminderCount") and has("reminderActive") and has("reminders") and (.reminders | type == "array") and has("clockFormat") and has("clockFormatAlt") and has("clockWeekStart") and has("clockPresent") and has("clockBirthYear") and has("clockLifeExpectancy") and has("indicatorsPresent") and has("indicatorsAlwaysShow") and has("indicatorsItems") and (.indicatorsItems | type == "array") and has("agentsPresent") and has("agentsRefreshIntervalSec") and has("agentsSync") and has("agentsSyncDir") and has("agentsSyncFileName") and has("agentsSyncDeviceId") and has("spacerPresent") and has("spacerSize") and has("trayPresent") and has("trayHidden") and (.trayHidden | type == "array") and has("trayPinned") and (.trayPinned | type == "array") and has("powerPresent") and has("powerShowPercentage") and has("isLaptop") and has("batteryPresent") and has("monitors") and (.monitors | type == "array") and has("internalPresent") and has("internalEnabled") and has("externalPresent") and has("mirroring") and has("touchpadPresent") and has("touchpadEnabled") and has("touchscreenPresent") and has("touchscreenEnabled") and has("keyboardBacklightPresent") and has("keyboardBrightness") and has("wifiConnected") and has("wifiBandSelected") and (.wifiBands | type == "array") and has("wifiIface") and has("netKind") and has("netIface") and has("netIp") and has("wifiHw") and has("wifiRadio") and has("wifiConnections") and (.wifiConnections | type == "array") and has("bluetoothDevices") and (.bluetoothDevices | type == "array") and has("audioSinks") and (.audioSinks | type == "array") and has("audioSources") and (.audioSources | type == "array") and has("audioOutputVolume") and has("audioOutputMuted") and has("audioInputVolume") and has("audioInputMuted") and has("audioTuningMatch") and has("audioTuningOn") and has("disks") and (.disks | type == "array") and has("luksDevices") and (.luksDevices | type == "array") and has("swapDevices") and (.swapDevices | type == "array") and has("snapperPresent") and has("snapperConfigs") and (.snapperConfigs | type == "array") and has("snapshots") and (.snapshots | type == "array") and has("hibernationAvailable") and has("hibernationSupported") and has("hibernationConfigured") and has("screensaverBranded") and has("aboutBranded") and has("timezone") and has("timezones") and (.timezones | type == "array") and has("hostname") and has("keyboardLayout") and has("keyboardLayouts") and (.keyboardLayouts | type == "array") and has("ntp") and has("ntpAvailable") and has("ntpSynchronized") and has("locale") and has("locales") and (.locales | type == "array") and has("parallelDownloads") and has("fullName") and has("hyprLook") and has("hyprInput") and has("hyprLookManaged") and has("hyprNoGaps") and has("fingerprintAvailable") and has("sshdEnabled") and has("omarchyChannel") and has("updateAvailable") and has("plugins") and (.plugins | type == "array") and has("voxtypeInstalled") and has("fstrimEnabled") and has("directBootAvailable") and has("mimePdf") and has("picturesDir") and has("videosDir") and has("recordingActive") and has("webcamOverlay") and has("services") and has("gaming") and has("extras") and has("hooks") and (.hooks | type == "array") and has("autostart") and (.autostart | type == "array") and has("autostartManaged") and has("nightlightDay") and has("nightlightNight") and has("nightlightNightOn") and has("tailscalePeers") and (.tailscalePeers | type == "array") and (.hyprLook | has("cursorSize")) and (.hyprLook | has("activeOpacity")) and has("bindings") and (.bindings | type == "array") and has("bindingsManaged") and has("windowRules") and (.windowRules | type == "array") and has("windowRulesManaged") and has("keybindings") and (.keybindings | type == "array") and has("focusedClass") and has("cupsActive") and has("printerSetup")' >/dev/null
+  echo "$json" | jq -e '.theme and .themes and has("extraThemes") and (.extraThemes | type == "array") and has("desktopApps") and (.desktopApps | type == "array") and has("tuiApps") and (.tuiApps | type == "array") and has("webApps") and (.webApps | type == "array") and .barPosition and .idleScreensaver and has("stayAwake") and has("nightlight") and has("nightlightTemperature") and has("screensaverEnabled") and has("barVisible") and has("dns") and has("bluetooth") and has("suspendEnabled") and has("powerProfile") and has("powerProfileAc") and has("powerProfileBattery") and (.powerProfiles | type == "array") and has("crashCapture") and has("plymouth") and (.plymouthThemes | type == "array") and has("doNotDisturb") and has("weatherLocation") and has("weatherCoords") and has("weatherAuto") and has("weatherPresent") and has("weatherUnit") and has("weatherRefreshMinutes") and has("reminderCount") and has("reminderActive") and has("reminders") and (.reminders | type == "array") and has("clockFormat") and has("clockFormatAlt") and has("clockWeekStart") and has("clockPresent") and has("clockBirthYear") and has("clockLifeExpectancy") and has("indicatorsPresent") and has("indicatorsAlwaysShow") and has("indicatorsItems") and (.indicatorsItems | type == "array") and has("agentsPresent") and has("agentsRefreshIntervalSec") and has("agentsSync") and has("agentsSyncDir") and has("agentsSyncFileName") and has("agentsSyncDeviceId") and has("spacerPresent") and has("spacerSize") and has("trayPresent") and has("trayHidden") and (.trayHidden | type == "array") and has("trayPinned") and (.trayPinned | type == "array") and has("powerPresent") and has("powerShowPercentage") and has("isLaptop") and has("batteryPresent") and has("monitors") and (.monitors | type == "array") and has("internalPresent") and has("internalEnabled") and has("externalPresent") and has("mirroring") and has("touchpadPresent") and has("touchpadEnabled") and has("touchscreenPresent") and has("touchscreenEnabled") and has("keyboardBacklightPresent") and has("keyboardBrightness") and has("wifiConnected") and has("wifiBandSelected") and (.wifiBands | type == "array") and has("wifiIface") and has("netKind") and has("netIface") and has("netIp") and has("wifiHw") and has("wifiRadio") and has("wifiConnections") and (.wifiConnections | type == "array") and has("bluetoothDevices") and (.bluetoothDevices | type == "array") and has("audioSinks") and (.audioSinks | type == "array") and has("audioSources") and (.audioSources | type == "array") and has("audioOutputVolume") and has("audioOutputMuted") and has("audioInputVolume") and has("audioInputMuted") and has("audioTuningMatch") and has("audioTuningOn") and has("disks") and (.disks | type == "array") and has("hardware") and (.hardware | type == "object") and (.hardware.cpu | type == "object") and (.hardware.memory | type == "object") and (.hardware.chipset | type == "object") and has("luksDevices") and (.luksDevices | type == "array") and has("swapDevices") and (.swapDevices | type == "array") and has("snapperPresent") and has("snapperConfigs") and (.snapperConfigs | type == "array") and has("snapshots") and (.snapshots | type == "array") and has("hibernationAvailable") and has("hibernationSupported") and has("hibernationConfigured") and has("screensaverBranded") and has("aboutBranded") and has("timezone") and has("timezones") and (.timezones | type == "array") and has("hostname") and has("keyboardLayout") and has("keyboardLayouts") and (.keyboardLayouts | type == "array") and has("ntp") and has("ntpAvailable") and has("ntpSynchronized") and has("locale") and has("locales") and (.locales | type == "array") and has("parallelDownloads") and has("fullName") and has("hyprLook") and has("hyprInput") and has("hyprLookManaged") and has("hyprNoGaps") and has("fingerprintAvailable") and has("sshdEnabled") and has("omarchyChannel") and has("updateAvailable") and has("plugins") and (.plugins | type == "array") and has("voxtypeInstalled") and has("fstrimEnabled") and has("directBootAvailable") and has("mimePdf") and has("picturesDir") and has("videosDir") and has("recordingActive") and has("webcamOverlay") and has("services") and has("gaming") and has("extras") and has("hooks") and (.hooks | type == "array") and has("autostart") and (.autostart | type == "array") and has("autostartManaged") and has("nightlightDay") and has("nightlightNight") and has("nightlightNightOn") and has("tailscalePeers") and (.tailscalePeers | type == "array") and (.hyprLook | has("cursorSize")) and (.hyprLook | has("activeOpacity")) and has("bindings") and (.bindings | type == "array") and has("bindingsManaged") and has("windowRules") and (.windowRules | type == "array") and has("windowRulesManaged") and has("keybindings") and (.keybindings | type == "array") and has("focusedClass") and has("cupsActive") and has("printerSetup")' >/dev/null
   echo "ok - snapshot.sh emits a usable JSON object"
 else
   echo "ok - skipping live snapshot (omarchy/jq not available)"
@@ -121,6 +121,111 @@ if [[ -x scripts/disk-inventory.py ]] && command -v python3 >/dev/null 2>&1 && c
   echo "ok - disk-inventory.py emits disks, luksDevices, swapDevices, and snapshots"
 else
   echo "ok - skipping disk-inventory.py"
+fi
+
+if [[ -x scripts/hw-inventory.py ]] && command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  python3 scripts/hw-inventory.py | jq -e '
+    (.cpu | type == "object") and (.memory | type == "object") and
+    (.chipset | type == "object") and (.machine | type == "object") and
+    (.board | type == "object") and (.bios | type == "object") and
+    (.gpus | type == "array") and (.nics | type == "array") and
+    (.audio | type == "array") and (.usb | type == "array") and
+    (.batteries | type == "array") and (.thermals | type == "array") and
+    (.memory.modules | type == "array") and has("tpm") and has("secureBoot") and has("virtualization")
+  ' >/dev/null
+  echo "ok - hw-inventory.py emits cpu, memory, chipset, and the other units"
+
+  hw_home=$(mktemp -d)
+  mkdir -p "$hw_home/proc" \
+    "$hw_home/sys/class/dmi/id" \
+    "$hw_home/sys/class/net/eth0" \
+    "$hw_home/sys/class/net/lo" \
+    "$hw_home/sys/bus/pci/devices/0000:00:00.0" \
+    "$hw_home/usr/share/hwdata"
+  cat >"$hw_home/proc/meminfo" <<'EOF'
+MemTotal:        8388608 kB
+MemAvailable:    6291456 kB
+MemFree:         1048576 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+EOF
+  cat >"$hw_home/proc/cpuinfo" <<'EOF'
+processor	: 0
+vendor_id	: GenuineIntel
+model name	: Intel(R) Core(TM) i7-12700H
+cpu cores	: 6
+physical id	: 0
+cpu MHz		: 2700.000
+flags		: vmx avx2
+
+processor	: 1
+vendor_id	: GenuineIntel
+model name	: Intel(R) Core(TM) i7-12700H
+cpu cores	: 6
+physical id	: 0
+EOF
+  printf 'Framework\n' >"$hw_home/sys/class/dmi/id/sys_vendor"
+  printf 'Laptop 13\n' >"$hw_home/sys/class/dmi/id/product_name"
+  printf 'Framework\n' >"$hw_home/sys/class/dmi/id/board_vendor"
+  printf 'FRANMACP07\n' >"$hw_home/sys/class/dmi/id/board_name"
+  printf 'INSYDE Corp.\n' >"$hw_home/sys/class/dmi/id/bios_vendor"
+  printf '03.05\n' >"$hw_home/sys/class/dmi/id/bios_version"
+  printf '9\n' >"$hw_home/sys/class/dmi/id/chassis_type"
+  printf '82:2b:38:3d:bc:d0\n' >"$hw_home/sys/class/net/eth0/address"
+  printf '1\n' >"$hw_home/sys/class/net/eth0/type"
+  printf '1000\n' >"$hw_home/sys/class/net/eth0/speed"
+  printf '772\n' >"$hw_home/sys/class/net/lo/type"
+  printf '0x8086\n' >"$hw_home/sys/bus/pci/devices/0000:00:00.0/vendor"
+  printf '0x0c00\n' >"$hw_home/sys/bus/pci/devices/0000:00:00.0/device"
+  printf '0x060000\n' >"$hw_home/sys/bus/pci/devices/0000:00:00.0/class"
+  cat >"$hw_home/usr/share/hwdata/pci.ids" <<'EOF'
+8086  Intel Corporation
+	0c00  4th Gen Core Processor DRAM Controller
+EOF
+  mkdir -p "$hw_home/sys/firmware/dmi/tables"
+  python3 - "$hw_home/sys/firmware/dmi/tables/DMI" <<'PY'
+import pathlib, struct, sys
+strings = b"DIMM_A1\0BANK 0\0Samsung\0M378A1K43\0\0"
+body = bytearray(28)
+body[0] = 17
+body[1] = 28
+struct.pack_into("<H", body, 2, 0x1100)
+struct.pack_into("<H", body, 0x0C, 8192)
+body[0x0E] = 8
+body[0x10] = 1
+body[0x11] = 2
+body[0x12] = 26
+struct.pack_into("<H", body, 0x15, 3200)
+body[0x17] = 3
+body[0x1A] = 4
+body[0x1B] = 2
+pathlib.Path(sys.argv[1]).write_bytes(bytes(body) + strings)
+PY
+  ATMOS_SYS_ROOT="$hw_home" ATMOS_HW_SKIP_CMDS=1 python3 scripts/hw-inventory.py | jq -e '
+    .machine.vendor == "Framework" and
+    .machine.name == "Laptop 13" and
+    .machine.chassis == "Laptop" and
+    .board.name == "FRANMACP07" and
+    .bios.version == "03.05" and
+    .cpu.model == "Intel(R) Core(TM) i7-12700H" and
+    .cpu.cores == 6 and
+    .memory.total == 8589934592 and
+    .chipset.name == "4th Gen Core Processor DRAM Controller" and
+    .chipset.role == "Host bridge" and
+    .chipset.pciId == "8086:0c00" and
+    (.memory.modules | length == 1) and
+    .memory.modules[0].locator == "DIMM_A1" and
+    .memory.modules[0].type == "DDR4" and
+    .memory.modules[0].form == "DIMM" and
+    .memory.modules[0].speed == 3200 and
+    .memory.modules[0].manufacturer == "Samsung" and
+    (.nics | map(.iface) | index("eth0") != null) and
+    (.nics | map(.iface) | index("lo") == null)
+  ' >/dev/null
+  rm -rf "$hw_home"
+  echo "ok - hw-inventory.py reads a fixture tree for machine, memory, and chipset"
+else
+  echo "ok - skipping hw-inventory.py"
 fi
 
 if [[ -x scripts/set-keyboard-layout.sh ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Hardware hub that inventories the machine without writing a private prefs store.

`scripts/hw-inventory.py` reads `/proc`, DMI, PCI, and sysfs (no sudo) and folds the result into the existing snapshot. The new page shows a card for each unit that was readable:

- Machine, motherboard, chipset (host bridge + LPC/southbridge)
- Firmware, Secure Boot, TPM
- Processor, memory use, SMBIOS DIMM modules
- Graphics, network adapters, audio, USB, battery, thermal, virtualization

Empty units stay hidden. Search and `atmos hardware` both land here. Parsers live in `services/Hardware.js` so Node can test chipset, meminfo, and DIMM size decoding without Quickshell.

## CLA

- [ ] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06577-1686-76bb-af4d-19f766771e8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06577-1686-76bb-af4d-19f766771e8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

