### PR TITLE
fix: break errorBanner height binding loop

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -427,8 +427,13 @@ ShellRoot {
 
         Text {
           id: errorText
-          anchors.fill: parent
-          anchors.margins: 8
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.top: parent.top
+          anchors.leftMargin: 8
+          anchors.rightMargin: 8
+          anchors.topMargin: 8
+          anchors.bottomMargin: 8
           text: Omarchy.lastError
           color: Theme.urgent
           wrapMode: Text.WordWrap


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the QML height binding loop on launch (`Binding loop detected for property "height"` at `errorBanner` in `shell.qml`).

`errorBanner.height` is derived from `errorText.implicitHeight`, but `errorText` used `anchors.fill: parent` with `Text.WordWrap`. That made the parent height depend on the child while the child was sized by the parent.

The text now anchors to left/right/top (with the existing 8px margins) instead of filling the parent. Width still drives wrapping; height stays implicit so the banner can size from `implicitHeight + Theme.pad` without a cycle.

Closes #3.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3091353-fe28-4e0a-b45d-c4017b86f9e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3091353-fe28-4e0a-b45d-c4017b86f9e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

