### PR TITLE
fix: snapshot.sh bluetooth jq abort and unguarded probes

### DIFF
--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -44,7 +44,7 @@ emit_look_snapshot() {
   background=${background%$'\n'}
   font=$(omarchy_out font current)
   font=${font%$'\n'}
-  text_size=$(omarchy display text size 2>/dev/null | awk '/text size:/{print $3; exit}')
+  text_size=$(omarchy display text size 2>/dev/null | awk '/text size:/{print $3; exit}' || true)
   [[ $text_size =~ ^[0-9]+$ ]] || text_size=12
   stay_awake=$(omarchy_out toggle idle status | jq -r '.enabled // false' 2>/dev/null || true)
   [[ $stay_awake == true ]] || stay_awake=false
@@ -182,7 +182,7 @@ case $dns in
   *) dns="" ;;
 esac
 
-text_size=$(omarchy display text size 2>/dev/null | awk '/text size:/{print $3; exit}')
+text_size=$(omarchy display text size 2>/dev/null | awk '/text size:/{print $3; exit}' || true)
 [[ $text_size =~ ^[0-9]+$ ]] || text_size=12
 
 stay_awake=$(omarchy_out toggle idle status | jq -r '.enabled // false' 2>/dev/null || true)
@@ -252,7 +252,7 @@ fi
 
 wifi_iface=""
 if [[ $wifi_connected == true ]]; then
-  wifi_iface=$(LC_ALL=C nmcli -e no -g DEVICE,TYPE,STATE device status 2>/dev/null | awk -F: '$2 == "wifi" && $3 == "connected" { print $1; exit }')
+  wifi_iface=$(LC_ALL=C nmcli -e no -g DEVICE,TYPE,STATE device status 2>/dev/null | awk -F: '$2 == "wifi" && $3 == "connected" { print $1; exit }' || true)
   [[ $wifi_iface =~ ^[a-zA-Z0-9._-]+$ ]] || wifi_iface=""
 fi
 
@@ -335,7 +335,7 @@ if present bluetoothctl && present jq; then
         | map(capture("^Device (?<address>[0-9A-Fa-f:]{17})(?: (?<name>.*))?$")
           | {address: .address, name: ((.name // "") | if . == "" then .address else . end)});
       ([$connected | parse[] | .address] | unique) as $on
-      | [$paired | parse[] | . + {connected: ($on | index(.address) != null)}]
+      | [$paired | parse[] as $d | $d + {connected: ($on | index($d.address) != null)}]
     ' || true
   )
   [[ -n $bluetooth_devices_json ]] || bluetooth_devices_json='[]'
@@ -737,7 +737,7 @@ if present hyprctl && present jq; then
   [[ -n $monitors_json ]] || monitors_json='[]'
   while IFS= read -r name; do
     [[ $name =~ ^[A-Za-z0-9._-]+$ ]] || continue
-    bright=$(omarchy brightness display --no-osd --monitor "$name" 2>/dev/null | awk 'NR==1 && $1 ~ /^[0-9]+$/ { print $1; exit }')
+    bright=$(omarchy brightness display --no-osd --monitor "$name" 2>/dev/null | awk 'NR==1 && $1 ~ /^[0-9]+$/ { print $1; exit }' || true)
     if [[ $bright =~ ^[0-9]+$ ]]; then
       (( bright > 100 )) && bright=100
       monitors_json=$(jq -c --arg n "$name" --argjson b "$bright" \
@@ -868,7 +868,7 @@ if present timedatectl; then
   fi
   timezones_json=$(timedatectl list-timezones 2>/dev/null | awk '
     /^[A-Za-z0-9/_+-]+$/ && !/\.\./ { print }
-  ' | lines_json)
+  ' | lines_json || true)
 fi
 [[ -n $timezones_json ]] || timezones_json='[]'
 

--- a/tests/run
+++ b/tests/run
@@ -58,6 +58,75 @@ rm -f "$catalog" "$snapshot"
 echo "ok - SearchIndex.js query hits font and misses network"
 echo "ok - SearchIndex.js state reads snapshot-derived theme"
 
+if command -v jq >/dev/null 2>&1; then
+  paired_list=$'Device AA:BB:CC:DD:EE:FF Headphones\nDevice 11:22:33:44:55:66 Keyboard'
+  connected_list='Device AA:BB:CC:DD:EE:FF Headphones'
+  bt_jq='
+    def parse:
+      split("\n")
+      | map(select(test("^Device ")))
+      | map(capture("^Device (?<address>[0-9A-Fa-f:]{17})(?: (?<name>.*))?$")
+        | {address: .address, name: ((.name // "") | if . == "" then .address else . end)});
+    ([$connected | parse[] | .address] | unique) as $on
+    | [$paired | parse[] as $d | $d + {connected: ($on | index($d.address) != null)}]
+  '
+  bt_json=$(jq -n -c --arg paired "$paired_list" --arg connected "$connected_list" "$bt_jq")
+  echo "$bt_json" | jq -e '
+    length == 2
+    and ([.[] | select(.address == "AA:BB:CC:DD:EE:FF" and .name == "Headphones" and .connected == true)] | length == 1)
+    and ([.[] | select(.address == "11:22:33:44:55:66" and .name == "Keyboard" and .connected == false)] | length == 1)
+  ' >/dev/null
+  echo "ok - bluetooth jq marks connected paired devices without aborting"
+
+  if jq -n -c --arg paired "$paired_list" --arg connected "$connected_list" '
+    def parse:
+      split("\n")
+      | map(select(test("^Device ")))
+      | map(capture("^Device (?<address>[0-9A-Fa-f:]{17})(?: (?<name>.*))?$")
+        | {address: .address, name: ((.name // "") | if . == "" then .address else . end)});
+    ([$connected | parse[] | .address] | unique) as $on
+    | [$paired | parse[] | . + {connected: ($on | index(.address) != null)}]
+  ' >/dev/null 2>&1; then
+    echo "not ok - broken bluetooth jq unexpectedly succeeded"
+    exit 1
+  fi
+  echo "ok - broken bluetooth jq still aborts on paired devices"
+else
+  echo "ok - skipping bluetooth jq (jq not available)"
+fi
+
+if [[ -f scripts/snapshot.sh ]]; then
+  if ! grep -q 'parse\[\] as \$d | \$d + {connected: (\$on | index(\$d.address) != null)}' scripts/snapshot.sh; then
+    echo "not ok - snapshot.sh bluetooth jq still indexes .address against \$on"
+    exit 1
+  fi
+  echo "ok - snapshot.sh bluetooth jq binds each paired device before index()"
+
+  text_size_guards=$(grep -cE 'omarchy display text size .*\| awk .* \|\| true' scripts/snapshot.sh || true)
+  if [[ $text_size_guards -lt 2 ]]; then
+    echo "not ok - text_size probe missing a || true guard"
+    exit 1
+  fi
+  if ! grep -qE 'omarchy brightness display --no-osd --monitor .* \|\| true' scripts/snapshot.sh; then
+    echo "not ok - brightness probe is unguarded"
+    exit 1
+  fi
+  if ! grep -qE 'nmcli -e no -g DEVICE,TYPE,STATE device status .* \|\| true' scripts/snapshot.sh; then
+    echo "not ok - wifi_iface probe is unguarded"
+    exit 1
+  fi
+  if ! grep -A3 'timedatectl list-timezones' scripts/snapshot.sh | grep -q '|| true'; then
+    echo "not ok - timezones probe is unguarded"
+    exit 1
+  fi
+  echo "ok - snapshot.sh best-effort probes are guarded with || true"
+
+  set -euo pipefail
+  guarded=$(false | awk 'NR==1 { print $1; exit }' || true)
+  [[ -z $guarded ]]
+  echo "ok - guarded failing probe does not abort under set -euo pipefail"
+fi
+
 if [[ -x scripts/snapshot.sh ]] && command -v omarchy >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
   look_json=$(bash scripts/snapshot.sh look)
   echo "$look_json" | jq -e '.theme and (.themes | type == "array") and has("font") and has("nightlight")' >/dev/null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2. `scripts/snapshot.sh` was exiting non-zero, so Atmos showed `omarchy snapshot failed` and left the prefs empty.

**Bluetooth connected flags.** `index(.address)` evaluated `.address` against the connected-address array `$on`, so jq aborted with `Cannot index array with string ("address")` whenever any paired device was present. Bind each paired device first:

```jq
| [$paired | parse[] as $d | $d + {connected: ($on | index($d.address) != null)}]
```

**Best-effort probes.** The script runs under `set -euo pipefail`. A failed brightness, text size, wifi iface, or timezone pipeline aborted the whole snapshot (often with empty stderr because of `2>/dev/null`). Those probes already had fallbacks; they now use `|| true` inside the command substitution.

`tests/run` covers the jq filter (paired + connected devices, and the old expression still aborting) and checks that the four probes stay guarded.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cfa437d-7f4b-4bcc-984e-3d9cb36e739c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cfa437d-7f4b-4bcc-984e-3d9cb36e739c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

