### PR TITLE
fix: scroll prefs panes from the Flickable viewport

### DIFF
--- a/components/PrefsFlickable.qml
+++ b/components/PrefsFlickable.qml
@@ -3,23 +3,29 @@ import "../services"
 
 // One scrolling behaviour for every scrolling surface in Atmos.
 //
-// A bare Flickable turns each mouse-wheel notch into its own decelerating
-// flick. Roll the wheel a few notches and those animations stack and fight
-// each other, which is the sticky, rubbery feel. A notch should move the
-// view a fixed distance and stop, so the wheel is handled here and any
-// flick still running is cancelled first.
+// Flickable invents momentum. Every scroll event it receives becomes a
+// flick with deceleration, so the view keeps sliding after the input has
+// stopped. On a touchpad that is the whole problem: the pixel deltas from
+// a two-finger drag each start their own flick, the invented momentum from
+// one runs into the next, and the result is a view that lags the fingers
+// and slides on after they lift. That is the stickiness.
 //
-// Touchpads are deliberately left alone. They send pixel deltas and want
-// the kinetic handling Flickable already does well; taking that over would
-// make them worse rather than better.
+// So the wheel is handled here and the flick is cancelled first, which
+// leaves the view following the input exactly and stopping when it stops.
+//
+//   Touchpads report pixelDelta. Those are real distances, so they move
+//   the view one to one and the content tracks the fingers.
+//
+//   Mouse wheels report angleDelta in 120ths of a notch and no pixelDelta,
+//   so a notch moves a fixed three rows.
 //
 // The nav list already pinned the flick direction and the content pane did
-// not, so the two panes of the same window scrolled differently. Pinning it
-// here is what makes that consistent.
+// not, so the two panes of one window scrolled differently. Pinning it here
+// is what makes that consistent.
 Flickable {
   id: root
 
-  // How far one wheel notch travels. Three rows is the usual desktop step.
+  // How far one mouse-wheel notch travels.
   property real wheelStep: Theme.rowHeight * 3
 
   contentWidth: width
@@ -33,15 +39,21 @@ Flickable {
     // An embedded page is not the scroller; without this it would eat the
     // wheel on its way to the pane that actually scrolls.
     enabled: root.interactive
-    acceptedDevices: PointerDevice.Mouse
 
     onWheel: function(event) {
-      var notches = event.angleDelta.y / 120
-      if (notches === 0) return
       var max = Math.max(0, root.contentHeight - root.height)
       if (max <= 0) return
+
+      // A touchpad sends a distance. A wheel sends notches.
+      var dy = event.pixelDelta.y
+      if (dy === 0) dy = (event.angleDelta.y / 120) * root.wheelStep
+      if (dy === 0) return
+
       root.cancelFlick()
-      root.contentY = Math.max(0, Math.min(max, root.contentY - notches * root.wheelStep))
+      root.contentY = Math.max(0, Math.min(max, root.contentY - dy))
+      // Without this the Flickable handles the same event again and starts
+      // the flick this handler exists to avoid.
+      event.accepted = true
     }
   }
 }

--- a/components/PrefsFlickable.qml
+++ b/components/PrefsFlickable.qml
@@ -1,0 +1,47 @@
+import QtQuick
+import "../services"
+
+// One scrolling behaviour for every scrolling surface in Atmos.
+//
+// A bare Flickable turns each mouse-wheel notch into its own decelerating
+// flick. Roll the wheel a few notches and those animations stack and fight
+// each other, which is the sticky, rubbery feel. A notch should move the
+// view a fixed distance and stop, so the wheel is handled here and any
+// flick still running is cancelled first.
+//
+// Touchpads are deliberately left alone. They send pixel deltas and want
+// the kinetic handling Flickable already does well; taking that over would
+// make them worse rather than better.
+//
+// The nav list already pinned the flick direction and the content pane did
+// not, so the two panes of the same window scrolled differently. Pinning it
+// here is what makes that consistent.
+Flickable {
+  id: root
+
+  // How far one wheel notch travels. Three rows is the usual desktop step.
+  property real wheelStep: Theme.rowHeight * 3
+
+  contentWidth: width
+  flickableDirection: Flickable.VerticalFlick
+  boundsBehavior: Flickable.StopAtBounds
+  // A pane that already fits should not swallow a drag and rubber-band
+  // against its own bounds.
+  interactive: contentHeight > height
+
+  WheelHandler {
+    // An embedded page is not the scroller; without this it would eat the
+    // wheel on its way to the pane that actually scrolls.
+    enabled: root.interactive
+    acceptedDevices: PointerDevice.Mouse
+
+    onWheel: function(event) {
+      var notches = event.angleDelta.y / 120
+      if (notches === 0) return
+      var max = Math.max(0, root.contentHeight - root.height)
+      if (max <= 0) return
+      root.cancelFlick()
+      root.contentY = Math.max(0, Math.min(max, root.contentY - notches * root.wheelStep))
+    }
+  }
+}

--- a/components/PrefsFlickable.qml
+++ b/components/PrefsFlickable.qml
@@ -3,21 +3,19 @@ import "../services"
 
 // One scrolling behaviour for every scrolling surface in Atmos.
 //
-// Flickable invents momentum. Every scroll event it receives becomes a
-// flick with deceleration, so the view keeps sliding after the input has
-// stopped. On a touchpad that is the whole problem: the pixel deltas from
-// a two-finger drag each start their own flick, the invented momentum from
-// one runs into the next, and the result is a view that lags the fingers
-// and slides on after they lift. That is the stickiness.
+// Left to itself a Flickable scrolls a touchpad about a pixel per event,
+// which reads as the view being stuck rather than slow. Measuring it on a
+// laptop showed the events arriving with a pixel delta of five to eleven,
+// so the view was moving a fraction of what the fingers asked for.
 //
-// So the wheel is handled here and the flick is cancelled first, which
-// leaves the view following the input exactly and stopping when it stops.
+// The wheel is handled here instead. Note that this is a MouseArea and not
+// a WheelHandler: a WheelHandler placed on this Flickable never received a
+// single event, while a MouseArea receives all of them.
 //
-//   Touchpads report pixelDelta. Those are real distances, so they move
-//   the view one to one and the content tracks the fingers.
-//
-//   Mouse wheels report angleDelta in 120ths of a notch and no pixelDelta,
-//   so a notch moves a fixed three rows.
+// scrollFactor compensates for Omarchy shipping input.lua with
+// scroll_factor = 0.4, which damps the deltas before they ever reach an
+// application. Three restores roughly what the fingers moved. It is the
+// one number here that is a matter of taste rather than correctness.
 //
 // The nav list already pinned the flick direction and the content pane did
 // not, so the two panes of one window scrolled differently. Pinning it here
@@ -27,6 +25,8 @@ Flickable {
 
   // How far one mouse-wheel notch travels.
   property real wheelStep: Theme.rowHeight * 3
+  // How much of the reported distance a touchpad drag actually moves.
+  property real scrollFactor: 3
 
   contentWidth: width
   flickableDirection: Flickable.VerticalFlick
@@ -35,25 +35,36 @@ Flickable {
   // against its own bounds.
   interactive: contentHeight > height
 
-  WheelHandler {
-    // An embedded page is not the scroller; without this it would eat the
+  // Fills the content item, so it lies under the pointer wherever the view
+  // is scrolled to. NoButton means it never takes a press, so every control
+  // on the page still works; it is here only for the wheel, which nothing
+  // in a settings row consumes.
+  MouseArea {
+    anchors.fill: parent
+    z: -1
+    acceptedButtons: Qt.NoButton
+    propagateComposedEvents: true
+    // An embedded page is not the scroller. Without this it would take the
     // wheel on its way to the pane that actually scrolls.
     enabled: root.interactive
 
-    onWheel: function(event) {
+    onWheel: function(wheel) {
       var max = Math.max(0, root.contentHeight - root.height)
-      if (max <= 0) return
-
-      // A touchpad sends a distance. A wheel sends notches.
-      var dy = event.pixelDelta.y
-      if (dy === 0) dy = (event.angleDelta.y / 120) * root.wheelStep
-      if (dy === 0) return
-
+      if (max <= 0) {
+        wheel.accepted = false
+        return
+      }
+      // A touchpad reports a distance. A wheel reports notches and no
+      // distance at all.
+      var dy = wheel.pixelDelta.y * root.scrollFactor
+      if (wheel.pixelDelta.y === 0) dy = (wheel.angleDelta.y / 120) * root.wheelStep
+      if (dy === 0) {
+        wheel.accepted = false
+        return
+      }
       root.cancelFlick()
       root.contentY = Math.max(0, Math.min(max, root.contentY - dy))
-      // Without this the Flickable handles the same event again and starts
-      // the flick this handler exists to avoid.
-      event.accepted = true
+      wheel.accepted = true
     }
   }
 }

--- a/components/PrefsFlickable.qml
+++ b/components/PrefsFlickable.qml
@@ -8,14 +8,18 @@ import "../services"
 // laptop showed the events arriving with a pixel delta of five to eleven,
 // so the view was moving a fraction of what the fingers asked for.
 //
-// The wheel is handled here instead. Note that this is a MouseArea and not
-// a WheelHandler: a WheelHandler placed on this Flickable never received a
-// single event, while a MouseArea receives all of them.
+// The wheel is handled here instead. Note that this is a MouseArea on the
+// Flickable viewport and not a WheelHandler: a WheelHandler placed as a
+// child of this Flickable never received a single event, while a MouseArea
+// receives them.
 //
-// scrollFactor compensates for Omarchy shipping input.lua with
-// scroll_factor = 0.4, which damps the deltas before they ever reach an
-// application. Three restores roughly what the fingers moved. It is the
-// one number here that is a matter of taste rather than correctness.
+// The handler sits on the viewport (parent: root), not contentItem. Flickable
+// reparents children onto contentItem, so a z: -1 MouseArea there only gets
+// the wheel where nothing else wants it. Nav rows, search hits, toggles,
+// and sliders all have their own MouseAreas that would swallow the event.
+//
+// scrollFactor defaults to 1 so Input → Scroll speed remains the only
+// speed control. pixelDelta already includes compositor scroll_factor.
 //
 // The nav list already pinned the flick direction and the content pane did
 // not, so the two panes of one window scrolled differently. Pinning it here
@@ -26,7 +30,9 @@ Flickable {
   // How far one mouse-wheel notch travels.
   property real wheelStep: Theme.rowHeight * 3
   // How much of the reported distance a touchpad drag actually moves.
-  property real scrollFactor: 3
+  // 1 keeps Input → Scroll speed as the only speed control; pixelDelta
+  // already includes compositor scroll_factor.
+  property real scrollFactor: 1
 
   contentWidth: width
   flickableDirection: Flickable.VerticalFlick
@@ -35,17 +41,14 @@ Flickable {
   // against its own bounds.
   interactive: contentHeight > height
 
-  // Fills the content item, so it lies under the pointer wherever the view
-  // is scrolled to. NoButton means it never takes a press, so every control
-  // on the page still works; it is here only for the wheel, which nothing
-  // in a settings row consumes.
+  // On the viewport, not contentItem. NoButton means it never takes a
+  // press, so every control on the page still works. Disabled when the
+  // Flickable is not the scroller so an embedded page does not take the
+  // wheel on its way to the pane that does.
   MouseArea {
-    anchors.fill: parent
-    z: -1
+    parent: root
+    anchors.fill: root
     acceptedButtons: Qt.NoButton
-    propagateComposedEvents: true
-    // An embedded page is not the scroller. Without this it would take the
-    // wheel on its way to the pane that actually scrolls.
     enabled: root.interactive
 
     onWheel: function(wheel) {

--- a/components/PrefsHelp.qml
+++ b/components/PrefsHelp.qml
@@ -107,14 +107,12 @@ Item {
         font.bold: true
       }
 
-      Flickable {
+      PrefsFlickable {
         width: parent.width
         visible: helpColumn.implicitHeight > 0
         height: visible ? Math.min(helpColumn.implicitHeight, 360) : 0
-        contentWidth: width
         contentHeight: helpColumn.implicitHeight
         clip: true
-        boundsBehavior: Flickable.StopAtBounds
 
         Column {
           id: helpColumn

--- a/components/PrefsPage.qml
+++ b/components/PrefsPage.qml
@@ -20,13 +20,11 @@ Item {
   height: root.embed ? implicitHeight : (parent ? parent.height : 400)
   visible: !root.embed || root.hasSections
 
-  Flickable {
+  PrefsFlickable {
     id: flick
     anchors.fill: parent
     clip: !root.embed
-    interactive: !root.embed
-    boundsBehavior: Flickable.StopAtBounds
-    contentWidth: width
+    interactive: !root.embed && contentHeight > height
     contentHeight: pageColumn.implicitHeight + (root.embed ? 0 : Theme.spaceLg * 2)
 
     Column {

--- a/pages/SearchPage.qml
+++ b/pages/SearchPage.qml
@@ -63,12 +63,10 @@ Item {
     }
   }
 
-  Flickable {
+  PrefsFlickable {
     id: flick
     anchors.fill: parent
     clip: true
-    boundsBehavior: Flickable.StopAtBounds
-    contentWidth: width
     contentHeight: pageColumn.implicitHeight + Theme.spaceLg * 2
 
     Column {

--- a/shell.qml
+++ b/shell.qml
@@ -457,7 +457,7 @@ ShellRoot {
           }
         }
 
-        Flickable {
+        PrefsFlickable {
           id: navFlick
           anchors.left: parent.left
           anchors.right: parent.right
@@ -465,10 +465,7 @@ ShellRoot {
           anchors.topMargin: Theme.space
           anchors.bottom: parent.bottom
           clip: true
-          contentWidth: width
           contentHeight: navColumn.implicitHeight
-          boundsBehavior: Flickable.StopAtBounds
-          flickableDirection: Flickable.VerticalFlick
 
           Column {
             id: navColumn


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lands [Fred Nix](https://github.com/nixfred)'s PrefsFlickable scrolling work from [`nixfred/atmos:scroll-wheel`](https://github.com/nixfred/atmos/tree/scroll-wheel) on current `main`, with the two review blockers from #6 addressed.

Touchpad and mouse-wheel scrolling in the prefs panes was unusable: Flickable turned each event into a ~1px decelerating flick, and a child `WheelHandler` received zero events. One shared `PrefsFlickable` now handles the wheel for the content pane, search results, nav list, and help modal.

**Kept from Fred's branch**
- Shared `PrefsFlickable` used by content, search, nav, and help
- `cancelFlick()` then `contentY` from `pixelDelta` / `angleDelta`
- `flickableDirection: VerticalFlick`
- `interactive: contentHeight > height`

**Review fixes vs the fork branch**
1. Rebased the three scroll commits onto current `origin/main` (clean, no conflicts).
2. Moved the `MouseArea` onto the Flickable viewport (`parent: root`, `anchors.fill: root`) instead of `contentItem` at `z: -1`, so wheel events still arrive over nav rows, search hits, and controls.
3. Defaulted `scrollFactor` to `1` instead of `3`, so Input → Scroll speed remains the only speed control. `pixelDelta` already includes compositor `scroll_factor`.

Fixes #6.

Based on work by Fred Nix (@nixfred).

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8816d1a-7e0b-4c5d-ad74-5b4d52dd2da0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8816d1a-7e0b-4c5d-ad74-5b4d52dd2da0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

