### PR TITLE
feat: mouse back pops the page stack

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -845,5 +845,11 @@ ShellRoot {
         else if (searchField.text.length > 0) searchField.text = ""
       }
     }
+
+    TapHandler {
+      acceptedButtons: Qt.BackButton
+      enabled: pageStack.depth > 1 && !errorDialog.visible && !sudoModeDialog.visible
+      onTapped: pageStack.pop()
+    }
   }
 }


### PR DESCRIPTION
## Summary

Mouse button 8 (`Qt.BackButton`) pops the page stack when the header back chevron would, the same as Escape on a nested page. Error and sudo dialogs keep the button.

Implemented with x-ai/grok-4.6.