### PR TITLE
fix: support avatars from user-only FUSE mounts

### DIFF
--- a/scripts/set-avatar.sh
+++ b/scripts/set-avatar.sh
@@ -90,12 +90,20 @@ case $action in
       echo "set-avatar.sh: not a file: $src" >&2
       exit 1
     }
-    size=$(wc -c <"$src")
+
+    # Privileged processes cannot read user-only FUSE mounts such as rclone
+    # mounts without allow_other. Stage the selected file while we still have
+    # the desktop user's access, then use that local copy for every write.
+    staged=$(mktemp -p /tmp atmos-avatar.XXXXXX)
+    trap 'rm -f -- "$staged"' EXIT
+    cp -f -- "$src" "$staged"
+
+    size=$(wc -c <"$staged")
     (( size > 0 && size <= 5000000 )) || {
       echo "set-avatar.sh: image must be 1 byte to 5 MB" >&2
       exit 1
     }
-    mime=$(file -b --mime-type "$src" 2>/dev/null || true)
+    mime=$(file -b --mime-type "$staged" 2>/dev/null || true)
     case $mime in
       image/png | image/jpeg | image/jpg) ;;
       *)
@@ -104,7 +112,7 @@ case $action in
         ;;
     esac
     if [[ $user == "$(id -un)" ]]; then
-      install_face "$src"
+      install_face "$staged"
     else
       "$ROOT/as-root.sh" /bin/bash -c '
         set -euo pipefail
@@ -118,9 +126,9 @@ case $action in
           setfacl -m u:sddm:x "$home" 2>/dev/null || true
           setfacl -m u:sddm:r "$home/.face.icon" 2>/dev/null || true
         fi
-      ' bash "$home" "$src"
+      ' bash "$home" "$staged"
     fi
-    install_accounts "$src"
+    install_accounts "$staged"
     ;;
   clear)
     if [[ $user == "$(id -un)" ]]; then

--- a/tests/run
+++ b/tests/run
@@ -382,6 +382,60 @@ if [[ -x scripts/set-avatar.sh ]]; then
     exit 1
   fi
   echo "ok - set-avatar.sh rejects root, a trailing hyphen, a relative path, and a non-image"
+
+  avatar_case=$(mktemp -d)
+  trap 'rm -rf -- "$avatar_case"' EXIT
+  mkdir -p "$avatar_case/bin" "$avatar_case/home" "$avatar_case/scripts" "$avatar_case/source"
+  cp scripts/set-avatar.sh "$avatar_case/scripts/set-avatar.sh"
+  chmod +x "$avatar_case/scripts/set-avatar.sh"
+
+  cat >"$avatar_case/bin/getent" <<'SH'
+#!/bin/bash
+set -euo pipefail
+if [[ ${1:-} == passwd && ${2:-} == atmostest ]]; then
+  printf 'atmostest:x:1001:1001:Atmos Test:%s:/bin/bash\n' "$ATMOS_TEST_HOME"
+  exit 0
+fi
+exec /usr/bin/getent "$@"
+SH
+  chmod +x "$avatar_case/bin/getent"
+
+  cat >"$avatar_case/scripts/as-root.sh" <<'SH'
+#!/bin/bash
+set -euo pipefail
+last=${!#}
+if [[ " $* " == *"/var/lib/AccountsService/"* ]]; then
+  [[ $last != "$ATMOS_TEST_SOURCE" ]]
+  [[ $last == /tmp/atmos-avatar.* ]]
+  printf '%s\n' "$last" >"$ATMOS_TEST_STAGE_PATH"
+  cp -- "$last" "$ATMOS_TEST_ACCOUNTS_ICON"
+  exit 0
+fi
+exec "$@"
+SH
+  chmod +x "$avatar_case/scripts/as-root.sh"
+
+  base64 -d >"$avatar_case/source/avatar.jpg" <<'JPEG'
+/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/Aaf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/Aaf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/IV//2gAMAwEAAgADAAAAEP/EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EABQQAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z
+JPEG
+  chmod 700 "$avatar_case/source"
+  chmod 600 "$avatar_case/source/avatar.jpg"
+
+  PATH="$avatar_case/bin:$PATH" \
+    ATMOS_TEST_HOME="$avatar_case/home" \
+    ATMOS_TEST_SOURCE="$avatar_case/source/avatar.jpg" \
+    ATMOS_TEST_STAGE_PATH="$avatar_case/staged-path" \
+    ATMOS_TEST_ACCOUNTS_ICON="$avatar_case/accounts-icon" \
+    bash "$avatar_case/scripts/set-avatar.sh" set atmostest "$avatar_case/source/avatar.jpg"
+
+  staged_path=$(<"$avatar_case/staged-path")
+  cmp "$avatar_case/source/avatar.jpg" "$avatar_case/home/.face"
+  cmp "$avatar_case/source/avatar.jpg" "$avatar_case/home/.face.icon"
+  cmp "$avatar_case/source/avatar.jpg" "$avatar_case/accounts-icon"
+  [[ ! -e $staged_path ]]
+  rm -rf -- "$avatar_case"
+  trap - EXIT
+  echo "ok - set-avatar.sh stages a private source before privileged copies and cleans up"
 else
   echo "ok - skipping set-avatar.sh"
 fi


### PR DESCRIPTION
## What was wrong

Choosing an avatar from a user-only FUSE mount could fail after partially applying it. The unprivileged `.face` copies succeeded, but the AccountsService step reopened the original path as root. FUSE mounts without `allow_other`, including the default rclone setup, reject that privileged read.

## Fix

- stage the selected image in a private local temporary file while it is readable as the desktop user
- validate and install the exact staged bytes for both the home and AccountsService copies
- remove the staged file on every exit path

## Verification

- `./tests/run`
- added an isolated end-to-end regression that exercises the real avatar script, verifies every output byte-for-byte, proves the privileged phase receives the staged path, and checks cleanup
- reproduced and verified live with a JPEG selected from a read-only rclone FUSE mount
