### PR TITLE
Shift the stub directory off before runGumJob execs

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -1198,7 +1198,9 @@ QtObject {
 
   function runGumJob(argv, kind, opts) {
     if (!(argv instanceof Array) || argv.length === 0) return
-    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\" exec \"$@\"", "prefs-job", gumStubDir]
+    // shift, or "$@" still carries $1 and exec is handed the stub directory
+    // itself: prefs-job: .../scripts/stubs: Is a directory
+    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\"; shift; exec \"$@\"", "prefs-job", gumStubDir]
     for (var i = 0; i < argv.length; i++) cmd.push(argv[i])
     runJob(cmd, "", kind, opts)
   }

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -91,3 +91,11 @@ assert(
   envSh.indexOf("hyprctl reload >/dev/null || true") !== -1,
   "atmos_hypr_reload does not fail the write when reload fails",
 );
+
+// runGumJob passes the stub dir as $1 and the command after it. Without the
+// shift, "$@" still carries $1 and exec is handed the directory itself:
+//   prefs-job: .../scripts/stubs: Is a directory
+assert(
+  omarchySrc.indexOf('PATH=\\"$1:$PATH\\"; shift; exec \\"$@\\"') !== -1,
+  "runGumJob shifts the stub dir off before exec",
+);


### PR DESCRIPTION
Every job through `runGumJob` fails on a real machine:

```
prefs-job: line 1: /home/pi/.local/share/atmos/scripts/stubs: Is a directory
```

## Cause

The wrapper passes the gum stub dir as `$1` so it can go on `PATH`, then the command after it:

```bash
bash -c 'PATH="$1:$PATH" exec "$@"' prefs-job <stubDir> omarchy update
```

In `bash -c SCRIPT NAME ARGS`, `"$@"` starts at **`$1`**, so it still carries the stub directory and `exec` is handed a directory as the command.

```console
$ bash -c 'PATH="$1:$PATH" exec "$@"' prefs-job ~/.local/share/atmos/scripts/stubs echo hello
prefs-job: line 1: /home/pi/.local/share/atmos/scripts/stubs: Is a directory

$ bash -c 'PATH="$1:$PATH"; shift; exec "$@"' prefs-job ~/.local/share/atmos/scripts/stubs echo hello
hello
```

And the stub still wins on `PATH` afterwards, which is the point of the wrapper:

```console
$ bash -c 'PATH="$1:$PATH"; shift; exec "$@"' prefs-job <stubDir> bash -c 'command -v gum'
/home/pi/.local/share/atmos/scripts/stubs/gum
```

## Scope

Every caller: fingerprint and FIDO2 setup/removal, sshd setup, sudoless docker setup/removal, update channel, `omarchy update`, firmware, orphan packages, package prune. Present since the initial commit as far as `git log -S` can see.

The other two `bash -c` wrappers are fine — `prefs-open` takes no leading argument, and the hibernation job names its command rather than expanding `"$@"`.

## Checks

`tests/run` 1106 ok, `oxlint` and `oxfmt --check` clean. Added a static assertion in `repo.test.js` since the suite cannot exercise QML.