### PR TITLE
Fix five settings-import bugs (two break import outright)

### DIFF
--- a/pages/ExportPage.qml
+++ b/pages/ExportPage.qml
@@ -156,6 +156,10 @@ PrefsPage {
       hardware: Omarchy.dmiProduct
     })
     root.forgetExport()
+    // Re-armed every time: onStarted clears it to give cat its EOF, and that
+    // assignment does not restore itself, so a second export would write
+    // nothing and still report success.
+    writeProc.stdinEnabled = true
     writeProc.target = root.realPath(root.exportPath)
     writeProc.text = text
     writeProc.command = ["sh", "-c", "cat > \"$1\"", "sh", writeProc.target]

--- a/scripts/apply-settings.sh
+++ b/scripts/apply-settings.sh
@@ -152,6 +152,18 @@ queue_stdin() {
 
 bool_arg() { [[ $1 == true ]] && printf 'true\n' || printf 'false\n'; }
 
+# format / formatAlt on a horizontal bar, verticalFormat / verticalFormatAlt
+# on one down the side.
+clock_key() {
+  local base=$1 position
+  position=$(plan_or_snapshot barPosition)
+  if [[ $position == left || $position == right ]]; then
+    printf 'vertical%s%s\n' "$(tr '[:lower:]' '[:upper:]' <<<"${base:0:1}")" "${base:1}"
+  else
+    printf '%s\n' "$base"
+  fi
+}
+
 # A toggle has no "set" verb, so it only runs when the plan actually flips it.
 toggle_needed() {
   local key=$1
@@ -188,11 +200,16 @@ while IFS= read -r key; do
 
     barPosition) queue "$key" "" omarchy bar position "$value" ;;
     barTransparent) queue "$key" "" omarchy bar transparent "$(bool_arg "$value")" ;;
+    # The toggle is named bar-off, so the argument is the state being turned
+    # off. Passing the visibility straight through showed the bar when the
+    # plan asked to hide it.
     barVisible)
-      toggle_needed "$key" && queue "$key" "" omarchy toggle bar "$([[ $value == true ]] && echo on || echo off)"
+      toggle_needed "$key" && queue "$key" "" omarchy toggle bar "$([[ $value == true ]] && echo off || echo on)"
       ;;
-    clockFormat) queue "$key" clock omarchy bar set omarchy.clock format "$value" ;;
-    clockFormatAlt) queue "$key" clock omarchy bar set omarchy.clock formatAlt "$value" ;;
+    # A bar on the left or right draws the clock from verticalFormat, so
+    # writing format there changes a setting nobody can see.
+    clockFormat) queue "$key" clock omarchy bar set omarchy.clock "$(clock_key format)" "$value" ;;
+    clockFormatAlt) queue "$key" clock omarchy bar set omarchy.clock "$(clock_key formatAlt)" "$value" ;;
     clockWeekStart) queue "$key" clock omarchy bar set omarchy.clock weekStartDay "$value" ;;
 
     browser | terminal | editor | agent) queue "$key" "" omarchy default "$key" "$value" ;;
@@ -253,12 +270,12 @@ while IFS= read -r key; do
 
     audioOutputVolume) queue "$key" "" bash "$ROOT/set-audio.sh" output-volume "$value" ;;
     audioInputVolume) queue "$key" "" bash "$ROOT/set-audio.sh" input-volume "$value" ;;
-    audioOutputMuted)
-      toggle_needed "$key" && queue "$key" "" omarchy audio output volume mute-toggle
-      ;;
-    audioInputMuted)
-      toggle_needed "$key" && queue "$key" "" omarchy audio input mute
-      ;;
+    # Deferred to the end of the run. set-audio.sh unmutes the device before
+    # it sets a volume, and the keys sort mute before volume, so muting first
+    # and then setting a volume left the device unmuted. There is only a
+    # toggle, no set, so the desired state is compared against what the
+    # volume write will have left behind.
+    audioOutputMuted | audioInputMuted) ;;
     audioTuningOn) queue "$key" "" omarchy audio tuning "$([[ $value == true ]] && echo on || echo off)" ;;
 
     powerProfileAc) queue "$key" "" omarchy powerprofiles set ac "$value" ;;
@@ -327,6 +344,21 @@ while IFS= read -r key; do
       ;;
   esac
 done < <(jq -r '.changes[].key' <<<"$PLAN")
+
+# Mute last, against the state the volume writes leave behind.
+queue_mute() {
+  local key=$1 volume_key=$2
+  shift 2
+  plan_has "$key" || return 0
+  local want current
+  want=$(plan_value "$key")
+  # A volume write unmutes, so that is the state this is really starting from.
+  if plan_has "$volume_key"; then current=false; else current=$(snap_value "$key"); fi
+  [[ $want == "$current" ]] && return 0
+  queue "$key" "" "$@"
+}
+queue_mute audioOutputMuted audioOutputVolume omarchy audio output volume mute-toggle
+queue_mute audioInputMuted audioInputVolume omarchy audio input mute
 
 # The undo plan is the same plan with from and value swapped, so reversing an
 # import is the ordinary path rather than a special one.

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -3598,6 +3598,10 @@ QtObject {
       if (root.jobStdin.length > 0) {
         write(root.jobStdin)
         root.jobStdin = ""
+        // Closed after writing, or a job that reads its input to EOF never
+        // gets one. enqueueIo re-arms this per job, so it stays correct for
+        // the next one.
+        stdinEnabled = false;
       }
     }
     onExited: function(exitCode) {

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -91,3 +91,29 @@ assert(
   envSh.indexOf("hyprctl reload >/dev/null || true") !== -1,
   "atmos_hypr_reload does not fail the write when reload fails",
 );
+
+// A job whose input is read to EOF hangs unless stdin is closed after the
+// write. enqueueIo re-arms stdinEnabled per job, so closing is safe.
+assert(
+  /write\(root\.jobStdin\)[\s\S]{0,400}stdinEnabled = false/.test(omarchySrc),
+  "jobProc closes stdin after writing",
+);
+
+const applySh = fs.readFileSync(path.join(__dirname, "..", "scripts", "apply-settings.sh"), "utf8");
+// omarchy toggle bar maps to the bar-off flag, so the argument is inverted.
+assert(
+  applySh.indexOf('omarchy toggle bar "$([[ $value == true ]] && echo off || echo on)"') !== -1,
+  "barVisible passes the bar-off state, not the visibility",
+);
+// set-audio.sh unmutes before setting a volume, so mute has to come after.
+assert(
+  applySh.indexOf("queue_mute audioOutputMuted audioOutputVolume") !== -1,
+  "mute is applied after volume, against the state volume leaves behind",
+);
+assert(applySh.indexOf("clock_key format") !== -1, "a side bar writes verticalFormat");
+
+const exportPage = fs.readFileSync(path.join(__dirname, "..", "pages", "ExportPage.qml"), "utf8");
+assert(
+  exportPage.indexOf("writeProc.stdinEnabled = true") !== -1,
+  "export re-arms stdin, so a second export is not an empty file",
+);


### PR DESCRIPTION
Five bugs from an audit of `main`. Each verified against the code that would run, not inferred. Two of them break import outright.

## 1. HIGH — a GUI import hangs and blocks the queue

`runJob` writes the plan to the job's stdin and never closes it. `apply-settings.sh` reads a plan with `PLAN=$(cat)`, which waits for EOF. Since the import is a queued job, everything behind it waits too.

```console
$ (echo '{"schema":1,"changes":[]}'; sleep 30) | bash scripts/apply-settings.sh
# exit 124 — hung

$ echo '{"schema":1,"changes":[]}' | bash scripts/apply-settings.sh
Nothing to apply.   # exit 0
```

Closing stdin after the write is safe: `enqueueIo` re-arms `stdinEnabled` per job, and the other stdin callers (account password, wifi join, luks) read lines and do not need it held open.

## 2. HIGH — a second export writes an empty file and says it worked

`writeProc` clears `stdinEnabled` in `onStarted` so `cat` gets its EOF. That assignment does not restore itself, so from the second export onward `write(text)` does nothing, `cat` sees an immediate EOF, and the file is truncated to zero — reported as success. Re-armed before each run.

## 3. Hiding the bar showed it

`omarchy toggle bar` dispatches to `omarchy-toggle bar-off`, so the argument is the state being **turned off** — which is why `setBarVisible` sends `on ? "off" : "on"`. The importer passed visibility straight through, so `barVisible = false` ran `omarchy toggle bar off`, cleared `bar-off`, and showed the bar.

## 4. Muting a device and setting its volume left it unmuted

`set-audio.sh` unmutes before setting a volume, deliberately. Keys sort `audioOutputMuted` before `audioOutputVolume`, so the mute was undone by the volume that followed.

Mute is applied at the end now. There is only `mute-toggle` and no set verb, so the desired state is compared against what the volume write leaves behind rather than against the snapshot:

```
audioOutputVolume   set-audio.sh output-volume 70
audioOutputMuted    omarchy audio output volume mute-toggle
```

## 5. Clock format on a side bar changed an invisible setting

A bar on the left or right reads `verticalFormat` / `verticalFormatAlt`, which `setClockFormat` already handles and the importer did not:

```
clockFormat   omarchy bar set omarchy.clock verticalFormat HH:mm
```

## Checks

`tests/run` 1110 ok, `oxlint` and `oxfmt --check` clean, `qmllint` clean, app loads. Guard assertions for all five in `repo.test.js`, since the suite cannot exercise QML or a live writer.

## Not in this PR

The audit also flagged things in your code that I have not touched, some of which look serious — `set-avatar.sh` following a `.face` symlink and overwriting the original photo, `hypr-sentinel` sentinel matching inside quoted strings, `inputState()` dropping existing `kb_options`, `set-hyprsunset.sh` rewriting the whole file, and timed passwordless sudo surviving a reboot. Happy to file those separately with reproductions if useful — I did not want to bury them in an import fix.