### PR TITLE
Shift the stub directory off before runGumJob execs

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -1201,7 +1201,9 @@ QtObject {
 
   function runGumJob(argv, kind, opts) {
     if (!(argv instanceof Array) || argv.length === 0) return
-    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\" exec \"$@\"", "prefs-job", gumStubDir]
+    // shift, or "$@" still carries $1 and exec is handed the stub directory
+    // itself: prefs-job: .../scripts/stubs: Is a directory
+    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\"; shift; exec \"$@\"", "prefs-job", gumStubDir]
     for (var i = 0; i < argv.length; i++) cmd.push(argv[i])
     runJob(cmd, "", kind, opts)
   }

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1007,5 +1007,13 @@ assert(
 );
 assert(
   omarchySrc.indexOf("if (!AccountsJs.isFullName(name)) return") !== -1,
-  "Omarchy validates full name with AccountsJs.isFullName",
+  "Omarchy validates full name with AccountsJs.isFullName"
+);
+
+// runGumJob passes the stub dir as $1 and the command after it. Without the
+// shift, "$@" still carries $1 and exec is handed the directory itself:
+//   prefs-job: .../scripts/stubs: Is a directory
+assert(
+  omarchySrc.indexOf('PATH=\"$1:$PATH\"; shift; exec \"$@\"') !== -1,
+  "runGumJob shifts the stub dir off before exec",
 );


### PR DESCRIPTION
Rebased [nixfred#17](https://github.com/csfh/atmos/pull/17) onto current `main` after #15 landed (conflict in `tests/repo.test.js` only — kept both assert sets).

Original work by @nixfred. Closes #17 once merged (will close the fork PR manually if needed).