### PR TITLE
Fix five settings-import bugs (two break import outright)

### DIFF
--- a/pages/ExportPage.qml
+++ b/pages/ExportPage.qml
@@ -156,6 +156,10 @@ PrefsPage {
       hardware: Omarchy.dmiProduct
     })
     root.forgetExport()
+    // Re-armed every time: onStarted clears it to give cat its EOF, and that
+    // assignment does not restore itself, so a second export would write
+    // nothing and still report success.
+    writeProc.stdinEnabled = true
     writeProc.target = root.realPath(root.exportPath)
     writeProc.text = text
     writeProc.command = ["sh", "-c", "cat > \"$1\"", "sh", writeProc.target]

--- a/scripts/apply-settings.sh
+++ b/scripts/apply-settings.sh
@@ -152,6 +152,18 @@ queue_stdin() {
 
 bool_arg() { [[ $1 == true ]] && printf 'true\n' || printf 'false\n'; }
 
+# format / formatAlt on a horizontal bar, verticalFormat / verticalFormatAlt
+# on one down the side.
+clock_key() {
+  local base=$1 position
+  position=$(plan_or_snapshot barPosition)
+  if [[ $position == left || $position == right ]]; then
+    printf 'vertical%s%s\n' "$(tr '[:lower:]' '[:upper:]' <<<"${base:0:1}")" "${base:1}"
+  else
+    printf '%s\n' "$base"
+  fi
+}
+
 # A toggle has no "set" verb, so it only runs when the plan actually flips it.
 toggle_needed() {
   local key=$1
@@ -188,23 +200,16 @@ while IFS= read -r key; do
 
     barPosition) queue "$key" "" omarchy bar position "$value" ;;
     barTransparent) queue "$key" "" omarchy bar transparent "$(bool_arg "$value")" ;;
+    # The toggle is named bar-off, so the argument is the state being turned
+    # off. Passing the visibility straight through showed the bar when the
+    # plan asked to hide it.
     barVisible)
-      toggle_needed "$key" && queue "$key" "" omarchy toggle bar "$([[ $value == true ]] && echo on || echo off)"
+      toggle_needed "$key" && queue "$key" "" omarchy toggle bar "$([[ $value == true ]] && echo off || echo on)"
       ;;
-    # Omarchy.setClockFormat writes verticalFormat when the bar is on a
-    # side. Importing onto format there would leave the live clock unchanged.
-    clockFormat)
-      fmt_key=format
-      pos=$(plan_or_snapshot barPosition)
-      [[ $pos == left || $pos == right ]] && fmt_key=verticalFormat
-      queue "$key" clock omarchy bar set omarchy.clock "$fmt_key" "$value"
-      ;;
-    clockFormatAlt)
-      fmt_key=formatAlt
-      pos=$(plan_or_snapshot barPosition)
-      [[ $pos == left || $pos == right ]] && fmt_key=verticalFormatAlt
-      queue "$key" clock omarchy bar set omarchy.clock "$fmt_key" "$value"
-      ;;
+    # A bar on the left or right draws the clock from verticalFormat, so
+    # writing format there changes a setting nobody can see.
+    clockFormat) queue "$key" clock omarchy bar set omarchy.clock "$(clock_key format)" "$value" ;;
+    clockFormatAlt) queue "$key" clock omarchy bar set omarchy.clock "$(clock_key formatAlt)" "$value" ;;
     clockWeekStart) queue "$key" clock omarchy bar set omarchy.clock weekStartDay "$value" ;;
 
     browser | terminal | editor | agent) queue "$key" "" omarchy default "$key" "$value" ;;
@@ -268,12 +273,12 @@ while IFS= read -r key; do
 
     audioOutputVolume) queue "$key" "" bash "$ROOT/set-audio.sh" output-volume "$value" ;;
     audioInputVolume) queue "$key" "" bash "$ROOT/set-audio.sh" input-volume "$value" ;;
-    audioOutputMuted)
-      toggle_needed "$key" && queue "$key" "" omarchy audio output volume mute-toggle
-      ;;
-    audioInputMuted)
-      toggle_needed "$key" && queue "$key" "" omarchy audio input mute
-      ;;
+    # Deferred to the end of the run. set-audio.sh unmutes the device before
+    # it sets a volume, and the keys sort mute before volume, so muting first
+    # and then setting a volume left the device unmuted. There is only a
+    # toggle, no set, so the desired state is compared against what the
+    # volume write will have left behind.
+    audioOutputMuted | audioInputMuted) ;;
     audioTuningOn) queue "$key" "" omarchy audio tuning "$([[ $value == true ]] && echo on || echo off)" ;;
 
     powerProfileAc) queue "$key" "" omarchy powerprofiles set ac "$value" ;;
@@ -346,6 +351,21 @@ while IFS= read -r key; do
       ;;
   esac
 done < <(jq -r '.changes[].key' <<<"$PLAN")
+
+# Mute last, against the state the volume writes leave behind.
+queue_mute() {
+  local key=$1 volume_key=$2
+  shift 2
+  plan_has "$key" || return 0
+  local want current
+  want=$(plan_value "$key")
+  # A volume write unmutes, so that is the state this is really starting from.
+  if plan_has "$volume_key"; then current=false; else current=$(snap_value "$key"); fi
+  [[ $want == "$current" ]] && return 0
+  queue "$key" "" "$@"
+}
+queue_mute audioOutputMuted audioOutputVolume omarchy audio output volume mute-toggle
+queue_mute audioInputMuted audioInputVolume omarchy audio input mute
 
 # The undo plan is the same plan with from and value swapped, so reversing an
 # import is the ordinary path rather than a special one.

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -3616,6 +3616,10 @@ QtObject {
       if (root.jobStdin.length > 0) {
         write(root.jobStdin)
         root.jobStdin = ""
+        // Closed after writing, or a job that reads its input to EOF never
+        // gets one. enqueueIo re-arms this per job, so it stays correct for
+        // the next one.
+        stdinEnabled = false;
       }
     }
     onExited: function(exitCode) {

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -1201,7 +1201,9 @@ QtObject {
 
   function runGumJob(argv, kind, opts) {
     if (!(argv instanceof Array) || argv.length === 0) return
-    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\" exec \"$@\"", "prefs-job", gumStubDir]
+    // shift, or "$@" still carries $1 and exec is handed the stub directory
+    // itself: prefs-job: .../scripts/stubs: Is a directory
+    var cmd = ["bash", "-c", "PATH=\"$1:$PATH\"; shift; exec \"$@\"", "prefs-job", gumStubDir]
     for (var i = 0; i < argv.length; i++) cmd.push(argv[i])
     runJob(cmd, "", kind, opts)
   }

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1015,5 +1015,31 @@ assert(
 //   prefs-job: .../scripts/stubs: Is a directory
 assert(
   omarchySrc.indexOf('PATH=\"$1:$PATH\"; shift; exec \"$@\"') !== -1,
-  "runGumJob shifts the stub dir off before exec",
+  "runGumJob shifts the stub dir off before exec"
+);
+
+// A job whose input is read to EOF hangs unless stdin is closed after the
+// write. enqueueIo re-arms stdinEnabled per job, so closing is safe.
+assert(
+  /write\(root\.jobStdin\)[\s\S]{0,400}stdinEnabled = false/.test(omarchySrc),
+  "jobProc closes stdin after writing",
+);
+
+const applySh = fs.readFileSync(path.join(__dirname, "..", "scripts", "apply-settings.sh"), "utf8");
+// omarchy toggle bar maps to the bar-off flag, so the argument is inverted.
+assert(
+  applySh.indexOf('omarchy toggle bar "$([[ $value == true ]] && echo off || echo on)"') !== -1,
+  "barVisible passes the bar-off state, not the visibility",
+);
+// set-audio.sh unmutes before setting a volume, so mute has to come after.
+assert(
+  applySh.indexOf("queue_mute audioOutputMuted audioOutputVolume") !== -1,
+  "mute is applied after volume, against the state volume leaves behind",
+);
+assert(applySh.indexOf("clock_key format") !== -1, "a side bar writes verticalFormat");
+
+const exportPage = fs.readFileSync(path.join(__dirname, "..", "pages", "ExportPage.qml"), "utf8");
+assert(
+  exportPage.indexOf("writeProc.stdinEnabled = true") !== -1,
+  "export re-arms stdin, so a second export is not an empty file",
 );

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1007,5 +1007,13 @@ assert(
 );
 assert(
   omarchySrc.indexOf("if (!AccountsJs.isFullName(name)) return") !== -1,
-  "Omarchy validates full name with AccountsJs.isFullName",
+  "Omarchy validates full name with AccountsJs.isFullName"
+);
+
+// runGumJob passes the stub dir as $1 and the command after it. Without the
+// shift, "$@" still carries $1 and exec is handed the directory itself:
+//   prefs-job: .../scripts/stubs: Is a directory
+assert(
+  omarchySrc.indexOf('PATH=\"$1:$PATH\"; shift; exec \"$@\"') !== -1,
+  "runGumJob shifts the stub dir off before exec",
 );


### PR DESCRIPTION
Rebased [nixfred#18](https://github.com/csfh/atmos/pull/18) onto current `main` (including the rebased gum-job fix). Conflicts resolved in `scripts/apply-settings.sh` (kept `clock_key` helper) and `tests/repo.test.js` (kept main + gum + import asserts).

Original work by @nixfred. Closes #18 once merged (will close the fork PR manually if needed).