### PR TITLE
Defer to unmanaged workspace gestures instead of writing a duplicate

### DIFF
--- a/pages/ExportPage.qml
+++ b/pages/ExportPage.qml
@@ -302,7 +302,8 @@ PrefsPage {
       var doc = SettingsJs.parseSettingsMarkdown(String(readOut.text || ""))
       root.lastDoc = doc
       root.plan = SettingsJs.planImport(doc, Omarchy.snapshotData, null, {
-        hardware: Omarchy.dmiProduct
+        hardware: Omarchy.dmiProduct,
+        workspaceGestureUnmanaged: Omarchy.liveWorkspaceGestureUnmanaged(),
       })
       root.importStatus = root.plan.changes.length === 0
         ? "Nothing to change. " + root.plan.summary

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -413,7 +413,7 @@ PrefsPage {
     SettingRow {
       label: "Three-finger swipe"
       description: Omarchy.hyprWorkspaceGestureUnmanaged
-        ? "This gesture is already in ~/.config/hypr/input.lua outside the Atmos block, so the switch stays off. Comment that line out to let Atmos own it."
+        ? "This gesture is already in ~/.config/hypr/input.lua outside the Atmos block, so the switch stays on and Atmos will not change it. Comment that line out to let Atmos own it."
         : "Swipe sideways with three fingers to change workspace."
       hint: "~/.config/hypr/input.lua · hl.gesture"
       query: root.query

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -412,13 +412,16 @@ PrefsPage {
 
     SettingRow {
       label: "Three-finger swipe"
-      description: "Swipe sideways with three fingers to change workspace."
+      description: Omarchy.hyprWorkspaceGestureUnmanaged
+        ? "This gesture is already in ~/.config/hypr/input.lua outside the Atmos block, so the switch stays off. Comment that line out to let Atmos own it."
+        : "Swipe sideways with three fingers to change workspace."
       hint: "~/.config/hypr/input.lua · hl.gesture"
       query: root.query
       keywords: ["gesture", "swipe", "workspace", "three"]
 
       PrefsToggle {
         checked: Omarchy.hyprWorkspaceGesture
+        enabled: !Omarchy.hyprWorkspaceGestureUnmanaged
         onToggled: Omarchy.setHyprWorkspaceGesture(!Omarchy.hyprWorkspaceGesture)
       }
     }

--- a/scripts/apply-settings.sh
+++ b/scripts/apply-settings.sh
@@ -104,6 +104,7 @@ declare -a RUN_KEYS=()
 declare -a RUN_CMDS=()
 declare -a RUN_GROUPS=()
 declare -a RUN_STDIN=()
+declare -a SKIPPED_KEYS=()
 
 queue() {
   local key=$1 group=$2
@@ -167,6 +168,10 @@ for ((i = 0; i < cmd_count; i++)); do
       unset 'argv[-1]'
     fi
   fi
+  if jq -e --argjson i "$i" '.[$i].skip == true' <<<"$COMMANDS" >/dev/null; then
+    SKIPPED_KEYS+=("$key")
+    continue
+  fi
   # Prefer stdin when non-empty so a long list does not hit the 128 KiB argv cap.
   if [[ -n $stdin_payload && ${#argv[@]} -gt 0 && ${argv[-1]} == "$stdin_payload" ]]; then
     unset 'argv[-1]'
@@ -177,6 +182,7 @@ for ((i = 0; i < cmd_count; i++)); do
     queue "$key" "$backup" "${argv[@]}"
   fi
 done
+
 
 # The undo plan is the same plan with from and value swapped, so reversing an
 # import is the ordinary path rather than a special one.
@@ -214,6 +220,11 @@ fi
 
 status=0
 results=()
+if ((${#SKIPPED_KEYS[@]} > 0)); then
+  for key in "${SKIPPED_KEYS[@]}"; do
+    results+=("$(jq -nc --arg k "$key" '{key:$k, status:"skipped"}')")
+  done
+fi
 for i in "${!RUN_KEYS[@]}"; do
   key=${RUN_KEYS[$i]}
   mapfile -d '' -t argv < <(base64 -d <<<"${RUN_CMDS[$i]}")

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -367,6 +367,10 @@ def sentinel_has_workspace_gesture(src: str) -> bool:
             continue
         end = text.find(")", at)
         body = text[at : end + 1 if end >= 0 else len(text)]
+        # Any live workspace action means defer. Hyprland clashes on
+        # HORIZONTAL, so a vertical/left/right workspace line over-defers
+        # and blocks a non-shadowing Atmos swipe. That is the rule: do not
+        # emit a second workspace gesture when one already exists.
         if re.search(r"""action\s*=\s*["']workspace["']""", body):
             return True
         i = at + 11

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -213,7 +213,7 @@ def sanitize_variants(raw, layout_count: int) -> str:
     return ",".join(parts)
 
 
-def serialize_input(raw: dict) -> str:
+def serialize_input(raw: dict, existing: str = "") -> str:
     src = raw if isinstance(raw, dict) else {}
     accel = str(src.get("accelProfile") or "")
     if accel not in ("flat", "adaptive"):
@@ -281,7 +281,10 @@ def serialize_input(raw: dict) -> str:
         "  },",
         "})",
     ]
-    if s["workspaceGesture"]:
+    # A live unmanaged hl.gesture already owns HORIZONTAL. Writing ours
+    # would make Hyprland reject the second as "Previous HORIZONTAL shadows
+    # new HORIZONTAL". Option 2: Atmos defers and never comments the user line.
+    if s["workspaceGesture"] and not input_has_unmanaged_workspace_gesture(existing):
         lines.append('hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })')
     lines.append(INPUT_END)
     return "\n".join(lines)
@@ -379,6 +382,26 @@ def input_has_workspace_gesture(text: str) -> bool:
     if bounds:
         return sentinel_has_workspace_gesture(src[bounds[0] : bounds[1]])
     return False
+
+
+def input_outside_sentinels(text: str) -> str:
+    src = text or ""
+    src = strip_sentinel(src, INPUT_BEGIN, INPUT_END)
+    return strip_sentinel(src, LEGACY_INPUT_BEGIN, LEGACY_INPUT_END)
+
+
+def input_has_unmanaged_workspace_gesture(text: str) -> bool:
+    return sentinel_has_workspace_gesture(input_outside_sentinels(text))
+
+
+def input_workspace_gesture_state(text: str) -> dict:
+    managed = input_has_workspace_gesture(text)
+    unmanaged = input_has_unmanaged_workspace_gesture(text)
+    return {
+        "workspaceGesture": managed or unmanaged,
+        "workspaceGestureManaged": managed,
+        "workspaceGestureUnmanaged": unmanaged,
+    }
 
 
 def parse_launch_calls(text: str) -> list[str]:
@@ -950,6 +973,8 @@ def apply(kind: str, path: Path, payload: dict | None, reset: bool) -> str:
         begin, end, serialize = INPUT_BEGIN, INPUT_END, serialize_input
     if reset:
         return strip_sentinel(text, begin, end)
+    if kind == "input":
+        return replace_sentinel(text, begin, end, serialize_input(payload or {}, text))
     return replace_sentinel(text, begin, end, serialize(payload or {}))
 
 
@@ -991,7 +1016,7 @@ def main() -> int:
         elif kind == "autostart":
             print(json.dumps(parse_autostart(text)))
         elif kind == "input":
-            print(json.dumps(input_has_workspace_gesture(text)))
+            print(json.dumps(input_workspace_gesture_state(text)))
         else:
             print(
                 "hypr-sentinel.py: list is for autostart|bindings|windows|input",

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -2037,13 +2037,23 @@ hypr_input_managed=false
 if [[ -f $input_file ]] && grep -q -- '-- atmos:input begin' "$input_file"; then
   hypr_input_managed=true
 fi
-# Only a live hl.gesture in the managed input sentinel. A commented Omarchy
-# example or an unmanaged line elsewhere would stick the toggle on.
+# Managed vs unmanaged: a live hl.gesture outside the atmos/legacy input
+# sentinels is still on, but Atmos does not own it. A commented Omarchy
+# stock example is neither.
 hypr_workspace_gesture=false
+hypr_workspace_gesture_managed=false
+hypr_workspace_gesture_unmanaged=false
 if [[ -f $input_file ]] && present python3; then
   parsed=$(python3 "$SNAP_DIR/hypr-sentinel.py" input list "$input_file" 2>/dev/null || true)
-  [[ $parsed == true ]] && hypr_workspace_gesture=true
+  if [[ -n $parsed ]]; then
+    hypr_workspace_gesture=$(jq -r '.workspaceGesture // false' <<<"$parsed" 2>/dev/null || echo false)
+    hypr_workspace_gesture_managed=$(jq -r '.workspaceGestureManaged // false' <<<"$parsed" 2>/dev/null || echo false)
+    hypr_workspace_gesture_unmanaged=$(jq -r '.workspaceGestureUnmanaged // false' <<<"$parsed" 2>/dev/null || echo false)
+  fi
 fi
+[[ $hypr_workspace_gesture == true ]] || hypr_workspace_gesture=false
+[[ $hypr_workspace_gesture_managed == true ]] || hypr_workspace_gesture_managed=false
+[[ $hypr_workspace_gesture_unmanaged == true ]] || hypr_workspace_gesture_unmanaged=false
 # Writer field names live next to the hyprctl names applyHyprInput reads.
 # merged_group hands this object to set-hypr-input.sh; without kbLayoutOverride
 # and workspaceGesture, importing any other input key would drop them.
@@ -2624,6 +2634,8 @@ snapshot_json=$(jq -n \
   --argjson hyprLookManaged "$hypr_look_managed" \
   --argjson hyprInputManaged "$hypr_input_managed" \
   --argjson hyprWorkspaceGesture "$hypr_workspace_gesture" \
+  --argjson hyprWorkspaceGestureManaged "$hypr_workspace_gesture_managed" \
+  --argjson hyprWorkspaceGestureUnmanaged "$hypr_workspace_gesture_unmanaged" \
   --argjson hyprNoGaps "$hypr_no_gaps" \
   --argjson hyprSquareAspect "$hypr_square_aspect" \
   --arg hyprWorkspaceLayout "$hypr_workspace_layout" \
@@ -2864,6 +2876,8 @@ snapshot_json=$(jq -n \
     hyprLookManaged: $hyprLookManaged,
     hyprInputManaged: $hyprInputManaged,
     hyprWorkspaceGesture: $hyprWorkspaceGesture,
+    hyprWorkspaceGestureManaged: $hyprWorkspaceGestureManaged,
+    hyprWorkspaceGestureUnmanaged: $hyprWorkspaceGestureUnmanaged,
     hyprNoGaps: $hyprNoGaps,
     hyprSquareAspect: $hyprSquareAspect,
     hyprWorkspaceLayout: $hyprWorkspaceLayout,

--- a/services/HyprPrefs.js
+++ b/services/HyprPrefs.js
@@ -244,7 +244,7 @@ function serializeLook(raw) {
   return lines.join("\n");
 }
 
-function serializeInput(raw) {
+function serializeInput(raw, existing) {
   var s = clampInput(raw);
   var inputLines = [
     "    sensitivity = " + luaNumber(s.sensitivity) + ",",
@@ -283,7 +283,10 @@ function serializeInput(raw) {
     "  },",
     "})",
   ];
-  if (s.workspaceGesture)
+  // A live unmanaged hl.gesture already owns HORIZONTAL. Writing ours
+  // would make Hyprland reject the second as "Previous HORIZONTAL shadows
+  // new HORIZONTAL". Option 2: Atmos defers and never comments the user line.
+  if (s.workspaceGesture && !inputHasUnmanagedWorkspaceGesture(existing))
     lines.push('hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })');
   lines.push(INPUT_END);
   return lines.join("\n");
@@ -339,12 +342,8 @@ function applyLookFile(text, raw) {
 }
 
 function applyInputFile(text, raw) {
-  return replaceSentinel(
-    stripSentinel(text, LEGACY_INPUT_BEGIN, LEGACY_INPUT_END),
-    INPUT_BEGIN,
-    INPUT_END,
-    serializeInput(raw),
-  );
+  var cleaned = stripSentinel(text, LEGACY_INPUT_BEGIN, LEGACY_INPUT_END);
+  return replaceSentinel(cleaned, INPUT_BEGIN, INPUT_END, serializeInput(raw, cleaned));
 }
 
 function resetLookFile(text) {
@@ -477,4 +476,23 @@ function inputHasWorkspaceGesture(text) {
   src = extractSentinel(text, LEGACY_INPUT_BEGIN, LEGACY_INPUT_END);
   if (src) return sentinelHasWorkspaceGesture(src);
   return false;
+}
+
+function inputOutsideSentinels(text) {
+  var src = stripSentinel(String(text || ""), INPUT_BEGIN, INPUT_END);
+  return stripSentinel(src, LEGACY_INPUT_BEGIN, LEGACY_INPUT_END);
+}
+
+function inputHasUnmanagedWorkspaceGesture(text) {
+  return sentinelHasWorkspaceGesture(inputOutsideSentinels(text));
+}
+
+function inputWorkspaceGestureState(text) {
+  var managed = inputHasWorkspaceGesture(text);
+  var unmanaged = inputHasUnmanagedWorkspaceGesture(text);
+  return {
+    workspaceGesture: managed || unmanaged,
+    workspaceGestureManaged: managed,
+    workspaceGestureUnmanaged: unmanaged,
+  };
 }

--- a/services/HyprPrefs.js
+++ b/services/HyprPrefs.js
@@ -462,6 +462,10 @@ function sentinelHasWorkspaceGesture(src) {
     }
     var end = text.indexOf(")", at);
     var body = text.substring(at, end === -1 ? text.length : end + 1);
+    // Any live workspace action means defer. Hyprland clashes on
+    // HORIZONTAL, so a vertical/left/right workspace line over-defers
+    // and blocks a non-shadowing Atmos swipe. That is the rule: do not
+    // emit a second workspace gesture when one already exists.
     if (/action\s*=\s*["']workspace["']/.test(body)) return true;
     i = at + 11;
   }

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -296,6 +296,8 @@ QtObject {
   property string hyprKbOptions: ""
   property bool hyprKbGroupToggle: false
   property bool hyprWorkspaceGesture: false
+  property bool hyprWorkspaceGestureManaged: false
+  property bool hyprWorkspaceGestureUnmanaged: false
   property bool hyprInputManaged: false
   property bool hyprNoGaps: false
   property bool hyprSquareAspect: false
@@ -563,6 +565,8 @@ QtObject {
     hyprLookManaged = SnapshotJs.adoptValue(hyprLookManaged, next.hyprLookManaged)
     hyprInputManaged = SnapshotJs.adoptValue(hyprInputManaged, next.hyprInputManaged)
     hyprWorkspaceGesture = SnapshotJs.adoptValue(hyprWorkspaceGesture, next.hyprWorkspaceGesture !== undefined ? next.hyprWorkspaceGesture : (input ? input.workspaceGesture : undefined))
+    hyprWorkspaceGestureManaged = SnapshotJs.adoptValue(hyprWorkspaceGestureManaged, next.hyprWorkspaceGestureManaged)
+    hyprWorkspaceGestureUnmanaged = SnapshotJs.adoptValue(hyprWorkspaceGestureUnmanaged, next.hyprWorkspaceGestureUnmanaged)
     hyprNoGaps = SnapshotJs.adoptValue(hyprNoGaps, next.hyprNoGaps)
     hyprSquareAspect = SnapshotJs.adoptValue(hyprSquareAspect, next.hyprSquareAspect)
     hyprWorkspaceLayout = SnapshotJs.adoptValue(hyprWorkspaceLayout, next.hyprWorkspaceLayout)
@@ -789,9 +793,33 @@ QtObject {
     runSettingCommand(SettingsJs.commandFor(key, value, snapshotData, scriptOpts()), key)
   }
 
+  function inputLuaText() {
+    inputLuaView.reload()
+    if (typeof inputLuaView.waitForJob === "function")
+      inputLuaView.waitForJob()
+    var src = typeof inputLuaView.text === "function" ? inputLuaView.text() : inputLuaView.text
+    return String(src || "")
+  }
+
+  function applyHyprWorkspaceGestureFromFile() {
+    var state = HyprPrefs.inputWorkspaceGestureState(root.inputLuaText())
+    hyprWorkspaceGesture = state.workspaceGesture === true
+    hyprWorkspaceGestureManaged = state.workspaceGestureManaged === true
+    hyprWorkspaceGestureUnmanaged = state.workspaceGestureUnmanaged === true
+  }
+
+  function liveWorkspaceGestureUnmanaged() {
+    return HyprPrefs.inputHasUnmanagedWorkspaceGesture(root.inputLuaText())
+  }
+
   function applyWritePatch(job) {
     if (!job || !job.apply) return
     applySnapshot(JSON.stringify(job.apply))
+    // refresh: "none" leaves these flags stale. Commenting the stock line
+    // out and then touching Sensitivity would take ownership in the file
+    // while the row stayed disabled. Re-scan after every input write.
+    if (job.key === "hyprInput" || job.key === "hyprInputManaged")
+      root.applyHyprWorkspaceGestureFromFile()
   }
 
   function lookState(patch) {
@@ -1803,6 +1831,7 @@ QtObject {
     })
   }
   function setHyprWorkspaceGesture(on) {
+    if (hyprWorkspaceGestureUnmanaged) return
     if (on === hyprWorkspaceGesture) return
     writeHyprInput({ workspaceGesture: on })
   }
@@ -2947,6 +2976,13 @@ QtObject {
   onThemesChanged: {
     var mapped = ThemeJs.themeNameFromSlug(root.theme, root.themes)
     if (mapped && mapped !== root.theme) root.applySnapshot(JSON.stringify({ theme: mapped }))
+  }
+
+  FileView {
+    id: inputLuaView
+    path: root.inputLuaFile
+    watchChanges: false
+    printErrors: false
   }
 
   property Instantiator fileWatchers: Instantiator {

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -2978,13 +2978,6 @@ QtObject {
     if (mapped && mapped !== root.theme) root.applySnapshot(JSON.stringify({ theme: mapped }))
   }
 
-  FileView {
-    id: inputLuaView
-    path: root.inputLuaFile
-    watchChanges: false
-    printErrors: false
-  }
-
   property Instantiator fileWatchers: Instantiator {
     model: root.watchSpecs
     delegate: FileView {
@@ -3057,6 +3050,13 @@ QtObject {
       root.snapshotReady = true
       root.ioFinished()
     }
+  }
+
+  FileView {
+    id: inputLuaView
+    path: root.inputLuaFile
+    watchChanges: false
+    printErrors: false
   }
 
   property Process mutProc: Process {

--- a/services/Settings.js
+++ b/services/Settings.js
@@ -1081,7 +1081,7 @@ function planImport(doc, snapshot, keys, options) {
       // Workspace gesture is a boolean, so unmanagedCount never fires. A
       // live hl.gesture outside the Atmos block still owns HORIZONTAL;
       // writing this key would either no-op or duplicate it. Skip instead.
-      if (key === "hyprInput.workspaceGesture" && snap.hyprWorkspaceGestureUnmanaged === true) {
+      if (key === "hyprInput.workspaceGesture" && workspaceGestureUnmanaged(snap, opts)) {
         warnings.push({
           key: key,
           message:
@@ -1385,6 +1385,14 @@ function choiceReason(item, value) {
 // fall back to 07:00 is blocked instead of silently rewriting the schedule.
 function isClockTime(value) {
   return typeof value === "string" && /^([01]?\d|2[0-3]):([0-5]\d)$/.test(value);
+}
+
+// Snapshot flag, or a live re-scan the caller already did (same scan as
+// the writer). A stale in-memory snapshot can miss an uncommented stock line.
+function workspaceGestureUnmanaged(snap, options) {
+  var opts = options || {};
+  if (opts.workspaceGestureUnmanaged === true) return true;
+  return !!(snap && snap.hyprWorkspaceGestureUnmanaged === true);
 }
 
 // Rows the snapshot says live outside the block Atmos manages.
@@ -2212,8 +2220,9 @@ function clockBarKey(base, snapshot) {
   return base;
 }
 
-function skipRecord(key) {
-  return { skip: true, key: key };
+function skipRecord(key, extra) {
+  extra = extra || {};
+  return { skip: true, key: key, report: extra.report === true };
 }
 
 function tagApply(apply) {
@@ -2425,8 +2434,18 @@ function commandFor(key, value, snapshot, opts) {
 
   if (spec.kind === "hypr-group") {
     var field = String(key).slice(spec.group.length + 1);
+    // Same scan as the writer. A stale snapshot can omit the unmanaged
+    // flag; do not queue a gesture write or later claim it applied.
+    if (
+      spec.group === "hyprInput" &&
+      field === "workspaceGesture" &&
+      workspaceGestureUnmanaged(snapshot, opts)
+    )
+      return skipRecord(key, { report: true });
     var merged = copyObject(readValue(snapshot, spec.group));
     merged[field] = value;
+    if (spec.group === "hyprInput" && workspaceGestureUnmanaged(snapshot, opts))
+      delete merged.workspaceGesture;
     var payload = JSON.stringify(merged);
     var applyHypr = {};
     applyHypr[spec.group] = merged;
@@ -2604,7 +2623,11 @@ function planCommands(changes, snapshot, opts) {
     )
       cmdSnap = snapshot || {};
     var cmd = commandFor(key, list[i].value, cmdSnap, opts);
-    if (!cmd || cmd.skip) continue;
+    if (!cmd) continue;
+    if (cmd.skip) {
+      if (cmd.report) out.push(cmd);
+      continue;
+    }
     if (merged) seen[merged] = true;
     out.push(cmd);
   }
@@ -2672,6 +2695,15 @@ function runCommandsCli(argv) {
   if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) snapshot = {};
   var changes = plan && Array.isArray(plan.changes) ? plan.changes : [];
   var opts = { root: path.dirname(scriptsRoot), scripts: scriptsFromRoot(scriptsRoot) };
+  var inputFile =
+    process.env.ATMOS_INPUT_FILE || path.join(process.env.HOME || "", ".config/hypr/input.lua");
+  try {
+    var HyprPrefs = require("./HyprPrefs.js");
+    if (fs.existsSync(inputFile))
+      opts.workspaceGestureUnmanaged = HyprPrefs.inputHasUnmanagedWorkspaceGesture(
+        fs.readFileSync(inputFile, "utf8"),
+      );
+  } catch (e) {}
   for (i = 0; i < changes.length; i++) {
     var key = String(changes[i].key || "");
     if (!commandFor(key, changes[i].value, snapshot, opts)) {

--- a/services/Settings.js
+++ b/services/Settings.js
@@ -2698,11 +2698,17 @@ function runCommandsCli(argv) {
   var inputFile =
     process.env.ATMOS_INPUT_FILE || path.join(process.env.HOME || "", ".config/hypr/input.lua");
   try {
-    var HyprPrefs = require("./HyprPrefs.js");
-    if (fs.existsSync(inputFile))
-      opts.workspaceGestureUnmanaged = HyprPrefs.inputHasUnmanagedWorkspaceGesture(
-        fs.readFileSync(inputFile, "utf8"),
+    if (fs.existsSync(inputFile)) {
+      var listed = require("child_process").spawnSync(
+        "python3",
+        [path.join(scriptsRoot, "hypr-sentinel.py"), "input", "list", inputFile],
+        { encoding: "utf8" },
       );
+      if (listed.status === 0) {
+        var parsed = JSON.parse(String(listed.stdout || "").replace(/^\s+|\s+$/g, "") || "{}");
+        opts.workspaceGestureUnmanaged = parsed.workspaceGestureUnmanaged === true;
+      }
+    }
   } catch (e) {}
   for (i = 0; i < changes.length; i++) {
     var key = String(changes[i].key || "");

--- a/services/Settings.js
+++ b/services/Settings.js
@@ -1078,6 +1078,19 @@ function planImport(doc, snapshot, keys, options) {
       var to = values[key];
       var from = readValue(snap, key);
 
+      // Workspace gesture is a boolean, so unmanagedCount never fires. A
+      // live hl.gesture outside the Atmos block still owns HORIZONTAL;
+      // writing this key would either no-op or duplicate it. Skip instead.
+      if (key === "hyprInput.workspaceGesture" && snap.hyprWorkspaceGestureUnmanaged === true) {
+        warnings.push({
+          key: key,
+          message:
+            "Workspace gesture is written by hand in ~/.config/hypr/input.lua outside the Atmos block. " +
+            "Atmos leaves that line alone, so this setting is skipped.",
+        });
+        continue;
+      }
+
       // Settled before anything is validated. A value the machine already
       // holds needs no permission to stay: plymouth reports "default" as
       // its theme while the installable themes list does not contain it,

--- a/services/Snapshot.js
+++ b/services/Snapshot.js
@@ -374,6 +374,8 @@ var BOOL_ON_KEYS = {
   hyprLookManaged: true,
   hyprInputManaged: true,
   hyprWorkspaceGesture: true,
+  hyprWorkspaceGestureManaged: true,
+  hyprWorkspaceGestureUnmanaged: true,
   hyprNoGaps: true,
   hyprSquareAspect: true,
   fingerprintAvailable: true,

--- a/services/SnapshotGroups.js
+++ b/services/SnapshotGroups.js
@@ -266,6 +266,8 @@ var ALL_KEYS = Object.freeze([
   "hyprLookManaged",
   "hyprInputManaged",
   "hyprWorkspaceGesture",
+  "hyprWorkspaceGestureManaged",
+  "hyprWorkspaceGestureUnmanaged",
   "hyprNoGaps",
   "hyprSquareAspect",
   "hyprWorkspaceLayout",

--- a/tests/hypr-prefs.test.js
+++ b/tests/hypr-prefs.test.js
@@ -388,7 +388,7 @@ assert(
 function pythonInputGesture(text) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atmos-gesture-"));
   const file = path.join(dir, "input.lua");
-  let parsed = false;
+  let parsed = { workspaceGesture: false, workspaceGestureManaged: false };
   try {
     fs.writeFileSync(file, text);
     const result = spawnSync(
@@ -397,28 +397,77 @@ function pythonInputGesture(text) {
       { encoding: "utf8" },
     );
     assertEqual(result.status, 0, "hypr-sentinel.py input list exits 0");
-    parsed = String(result.stdout || "").replace(/^\s+|\s+$/g, "") === "true";
+    parsed = JSON.parse(String(result.stdout || "").replace(/^\s+|\s+$/g, "") || "{}");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
   return parsed;
 }
 
+function pythonApplyInput(existing, payload) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atmos-input-apply-"));
+  const file = path.join(dir, "input.lua");
+  let text = "";
+  try {
+    fs.writeFileSync(file, existing);
+    const result = spawnSync(
+      "python3",
+      [path.join(__dirname, "..", "scripts", "hypr-sentinel.py"), "input", "apply", file],
+      { input: JSON.stringify(payload), encoding: "utf8" },
+    );
+    assertEqual(result.status, 0, "hypr-sentinel.py input apply exits 0");
+    text = fs.readFileSync(file, "utf8");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  return text;
+}
+
+function assertGestureState(state, expected, description) {
+  assertEqual(state.workspaceGesture, expected.workspaceGesture, description + " · on");
+  assertEqual(
+    state.workspaceGestureManaged,
+    expected.workspaceGestureManaged,
+    description + " · managed",
+  );
+  assertEqual(
+    state.workspaceGestureUnmanaged,
+    expected.workspaceGestureUnmanaged,
+    description + " · unmanaged",
+  );
+}
+
+const onManaged = {
+  workspaceGesture: true,
+  workspaceGestureManaged: true,
+  workspaceGestureUnmanaged: false,
+};
+const off = {
+  workspaceGesture: false,
+  workspaceGestureManaged: false,
+  workspaceGestureUnmanaged: false,
+};
+const onUnmanaged = {
+  workspaceGesture: true,
+  workspaceGestureManaged: false,
+  workspaceGestureUnmanaged: true,
+};
+
 const liveGesture = hypr.serializeInput({ workspaceGesture: true });
-assertEqual(
-  hypr.inputHasWorkspaceGesture(liveGesture),
-  true,
-  "inputHasWorkspaceGesture sees a live managed gesture",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(liveGesture),
+  onManaged,
+  "inputWorkspaceGestureState sees a live managed gesture",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(liveGesture),
-  true,
+  onManaged,
   "hypr-sentinel.py input list sees a live managed gesture",
 );
-assertEqual(
-  hypr.inputHasWorkspaceGesture(hypr.serializeInput({ workspaceGesture: false })),
-  false,
-  "inputHasWorkspaceGesture misses a managed block with no gesture",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(hypr.serializeInput({ workspaceGesture: false })),
+  off,
+  "inputWorkspaceGestureState misses a managed block with no gesture",
 );
 
 const commentedGesture = `-- atmos:input begin
@@ -428,14 +477,14 @@ hl.config({
 -- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 -- atmos:input end
 `;
-assertEqual(
-  hypr.inputHasWorkspaceGesture(commentedGesture),
-  false,
-  "inputHasWorkspaceGesture skips a commented gesture in the sentinel",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(commentedGesture),
+  off,
+  "inputWorkspaceGestureState skips a commented gesture in the sentinel",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(commentedGesture),
-  false,
+  off,
   "hypr-sentinel.py input list skips a commented gesture in the sentinel",
 );
 
@@ -443,14 +492,14 @@ const trailingGesture = `-- atmos:input begin
 hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" }) -- keep
 -- atmos:input end
 `;
-assertEqual(
-  hypr.inputHasWorkspaceGesture(trailingGesture),
-  true,
-  "inputHasWorkspaceGesture keeps a live gesture with a trailing comment",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(trailingGesture),
+  onManaged,
+  "inputWorkspaceGestureState keeps a live gesture with a trailing comment",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(trailingGesture),
-  true,
+  onManaged,
   "hypr-sentinel.py input list keeps a live gesture with a trailing comment",
 );
 
@@ -458,14 +507,14 @@ const stringDashGesture = `-- atmos:input begin
 hint = "flags --help"; hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 -- atmos:input end
 `;
-assertEqual(
-  hypr.inputHasWorkspaceGesture(stringDashGesture),
-  true,
-  "inputHasWorkspaceGesture keeps a gesture after -- inside a string",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(stringDashGesture),
+  onManaged,
+  "inputWorkspaceGestureState keeps a gesture after -- inside a string",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(stringDashGesture),
-  true,
+  onManaged,
   "hypr-sentinel.py input list keeps a gesture after -- inside a string",
 );
 
@@ -479,27 +528,32 @@ hl.config({
 assertEqual(
   hypr.inputHasWorkspaceGesture(unmanagedGesture),
   false,
-  "inputHasWorkspaceGesture ignores an unmanaged gesture outside the sentinel",
+  "inputHasWorkspaceGesture is the managed bit and stays false for a bare gesture",
 );
-assertEqual(
+assertGestureState(
+  hypr.inputWorkspaceGestureState(unmanagedGesture),
+  onUnmanaged,
+  "inputWorkspaceGestureState reports a bare gesture as on and not managed",
+);
+assertGestureState(
   pythonInputGesture(unmanagedGesture),
-  false,
-  "hypr-sentinel.py input list ignores an unmanaged gesture outside the sentinel",
+  onUnmanaged,
+  "hypr-sentinel.py input list reports a bare gesture as on and not managed",
 );
 
 const legacyGesture = `-- omarchy-prefs:input begin
 hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 -- omarchy-prefs:input end
 `;
-assertEqual(
-  hypr.inputHasWorkspaceGesture(legacyGesture),
-  true,
-  "inputHasWorkspaceGesture reads a leftover omarchy-prefs input gesture",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(legacyGesture),
+  onManaged,
+  "inputWorkspaceGestureState reads a leftover omarchy-prefs input gesture as managed",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(legacyGesture),
-  true,
-  "hypr-sentinel.py input list reads a leftover omarchy-prefs input gesture",
+  onManaged,
+  "hypr-sentinel.py input list reads a leftover omarchy-prefs input gesture as managed",
 );
 
 const leftoverAtmosOff = [
@@ -513,25 +567,140 @@ const leftoverAtmosOff = [
   "-- atmos:input end",
   "",
 ].join("\n");
-assertEqual(
-  hypr.inputHasWorkspaceGesture(leftoverAtmosOff),
-  false,
-  "inputHasWorkspaceGesture prefers the atmos sentinel over a leftover gesture",
+assertGestureState(
+  hypr.inputWorkspaceGestureState(leftoverAtmosOff),
+  off,
+  "inputWorkspaceGestureState prefers the atmos sentinel over a leftover gesture",
 );
-assertEqual(
+assertGestureState(
   pythonInputGesture(leftoverAtmosOff),
-  false,
+  off,
   "hypr-sentinel.py input list prefers the atmos sentinel over a leftover gesture",
 );
+assertGestureState(
+  hypr.inputWorkspaceGestureState(""),
+  off,
+  "inputWorkspaceGestureState misses an empty file",
+);
+
+const bareStock = 'hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })\n';
 assertEqual(
-  hypr.inputHasWorkspaceGesture(""),
+  hypr.inputHasWorkspaceGesture(bareStock),
   false,
-  "inputHasWorkspaceGesture misses an empty file",
+  "inputHasWorkspaceGesture is false for a gesture with no sentinel",
+);
+assertGestureState(
+  hypr.inputWorkspaceGestureState(bareStock),
+  onUnmanaged,
+  "a live stock line with no sentinel is on and not managed",
+);
+assertGestureState(
+  pythonInputGesture(bareStock),
+  onUnmanaged,
+  "hypr-sentinel.py input list treats a live stock line as on and not managed",
+);
+
+const commentedStock = `-- Enable touchpad gestures for changing workspaces.
+-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+`;
+assertGestureState(
+  hypr.inputWorkspaceGestureState(commentedStock),
+  off,
+  "the commented Omarchy stock line is not an unmanaged gesture",
+);
+assertGestureState(
+  pythonInputGesture(commentedStock),
+  off,
+  "hypr-sentinel.py input list ignores the commented Omarchy stock line",
+);
+
+const unmanagedWritten = hypr.applyInputFile(unmanagedGesture, {
+  sensitivity: -0.5,
+  workspaceGesture: true,
+});
+assertEqual(
+  (unmanagedWritten.match(/hl\.gesture\(/g) || []).length,
+  1,
+  "applyInputFile does not write a managed gesture when an unmanaged one is live",
+);
+assert(
+  unmanagedWritten.indexOf(
+    'hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })',
+  ) ===
+    unmanagedWritten.lastIndexOf(
+      'hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })',
+    ),
+  "applyInputFile keeps the single unmanaged gesture line",
+);
+assert(
+  /-- atmos:input begin[\s\S]*hl\.gesture[\s\S]*-- atmos:input end/.test(unmanagedWritten) ===
+    false,
+  "applyInputFile omits hl.gesture from the atmos block when unmanaged",
+);
+assertGestureState(
+  hypr.inputWorkspaceGestureState(unmanagedWritten),
+  onUnmanaged,
+  "after a write, the unmanaged gesture is still on and not managed",
+);
+const unmanagedPython = pythonApplyInput(unmanagedGesture, {
+  sensitivity: -0.5,
+  workspaceGesture: true,
+});
+assertEqual(
+  unmanagedPython.replace(/\s+$/, ""),
+  unmanagedWritten.replace(/\s+$/, ""),
+  "hypr-sentinel.py apply matches applyInputFile when deferring to an unmanaged gesture",
+);
+
+const managedOnlyWritten = hypr.applyInputFile("-- keep input comments\n", {
+  workspaceGesture: true,
+});
+assert(
+  /-- atmos:input begin[\s\S]*hl\.gesture\(\{ fingers = 3[\s\S]*-- atmos:input end/.test(
+    managedOnlyWritten,
+  ),
+  "applyInputFile still writes a managed gesture when nothing unmanaged is live",
+);
+assertGestureState(
+  hypr.inputWorkspaceGestureState(managedOnlyWritten),
+  onManaged,
+  "a managed-only write reports on and managed",
+);
+const managedOnlyPython = pythonApplyInput("-- keep input comments\n", { workspaceGesture: true });
+assertEqual(
+  managedOnlyPython.replace(/\s+$/, ""),
+  managedOnlyWritten.replace(/\s+$/, ""),
+  "hypr-sentinel.py apply matches applyInputFile on the managed-only path",
+);
+
+const commentedStockWritten = hypr.applyInputFile(commentedStock, { workspaceGesture: true });
+assertEqual(
+  (commentedStockWritten.match(/^\s*hl\.gesture\(/gm) || []).length,
+  1,
+  "a commented stock line does not count as unmanaged, so Atmos still writes",
+);
+assert(
+  commentedStockWritten.indexOf(
+    '-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })',
+  ) !== -1,
+  "applyInputFile leaves the commented stock line where it is",
+);
+assertGestureState(
+  hypr.inputWorkspaceGestureState(commentedStockWritten),
+  onManaged,
+  "writing over a commented stock line is managed",
 );
 assertEqual(
-  hypr.inputHasWorkspaceGesture(
-    'hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })\n',
-  ),
-  false,
-  "inputHasWorkspaceGesture misses a gesture with no sentinel",
+  pythonApplyInput(commentedStock, { workspaceGesture: true }).replace(/\s+$/, ""),
+  commentedStockWritten.replace(/\s+$/, ""),
+  "hypr-sentinel.py apply matches applyInputFile over a commented stock line",
+);
+
+assert(
+  hypr.serializeInput({ workspaceGesture: true }, unmanagedGesture).indexOf("hl.gesture(") === -1,
+  "serializeInput omits the Atmos gesture when existing text has an unmanaged one",
+);
+assert(
+  hypr.serializeInput({ workspaceGesture: true }).indexOf("hl.gesture(") !== -1,
+  "serializeInput still writes the Atmos gesture with no existing unmanaged line",
 );

--- a/tests/hypr-prefs.test.js
+++ b/tests/hypr-prefs.test.js
@@ -696,6 +696,21 @@ assertEqual(
   "hypr-sentinel.py apply matches applyInputFile over a commented stock line",
 );
 
+const commentedOutUnmanaged = unmanagedWritten.replace(
+  'hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })\n',
+  '-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })\n',
+);
+const recovered = hypr.applyInputFile(commentedOutUnmanaged, { workspaceGesture: true });
+assert(
+  /-- atmos:input begin[\s\S]*hl\.gesture\(\{ fingers = 3[\s\S]*-- atmos:input end/.test(recovered),
+  "after the unmanaged line is commented out, applyInputFile writes a managed gesture",
+);
+assertGestureState(
+  hypr.inputWorkspaceGestureState(recovered),
+  onManaged,
+  "commenting the stock line out lets Atmos own the gesture",
+);
+
 assert(
   hypr.serializeInput({ workspaceGesture: true }, unmanagedGesture).indexOf("hl.gesture(") === -1,
   "serializeInput omits the Atmos gesture when existing text has an unmanaged one",

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -988,15 +988,37 @@ assert(
   "Input disables layout Set when the list is invalid or unchanged",
 );
 assert(
-  inputPageSrc.indexOf("Omarchy.hyprWorkspaceGestureUnmanaged") !== -1 &&
-    inputPageSrc.indexOf("enabled: !Omarchy.hyprWorkspaceGestureUnmanaged") !== -1 &&
-    inputPageSrc.indexOf("outside the Atmos block") !== -1,
-  "Input shows an unmanaged workspace gesture as on and not managed",
+  inputPageSrc.indexOf("checked: Omarchy.hyprWorkspaceGesture") !== -1,
+  "Input checks the workspace gesture from hyprWorkspaceGesture",
+);
+assert(
+  inputPageSrc.indexOf("enabled: !Omarchy.hyprWorkspaceGestureUnmanaged") !== -1,
+  "Input disables the workspace gesture switch when the line is unmanaged",
+);
+const gestureRowAt = inputPageSrc.indexOf('label: "Three-finger swipe"');
+assert(gestureRowAt !== -1, "Input has a Three-finger swipe row");
+const gestureRow = inputPageSrc.slice(
+  gestureRowAt,
+  inputPageSrc.indexOf("keywords: [", gestureRowAt),
+);
+assert(
+  gestureRow.indexOf("stays on and Atmos will not change it") !== -1,
+  "Input unmanaged workspace-gesture copy says the switch stays on and Atmos will not change it",
+);
+assert(
+  gestureRow.indexOf("stays off") === -1,
+  "Three-finger swipe description does not say the switch stays off",
 );
 assert(
   omarchySrc.indexOf("property bool hyprWorkspaceGestureUnmanaged") !== -1 &&
     omarchySrc.indexOf("if (hyprWorkspaceGestureUnmanaged) return") !== -1,
   "Omarchy keeps unmanaged workspace gesture state and refuses to toggle it",
+);
+assert(
+  omarchySrc.indexOf("applyHyprWorkspaceGestureFromFile") !== -1 &&
+    omarchySrc.indexOf("inputLuaView.waitForJob") !== -1 &&
+    omarchySrc.indexOf('job.key === "hyprInput"') !== -1,
+  "Omarchy refreshes workspace gesture ownership from the file after an input write",
 );
 assert(
   omarchySrc.indexOf("layouts = HyprPrefs.sanitizeLayoutList(layouts)") !== -1,
@@ -1073,11 +1095,20 @@ assert(
   !/^(const|var|let)\s+\w+\s*=\s*require\(/.test(settingsSrc),
   "Settings.js has no top-level require",
 );
+assert(
+  settingsSrc.indexOf("workspaceGestureUnmanaged") !== -1 &&
+    applySh.indexOf('status:"skipped"') !== -1,
+  "apply-settings.sh reports a no-op workspace gesture as skipped after a live re-scan",
+);
 
 const exportPage = fs.readFileSync(path.join(__dirname, "..", "pages", "ExportPage.qml"), "utf8");
 assert(
   exportPage.indexOf("writeProc.stdinEnabled = true") !== -1,
   "export re-arms stdin, so a second export is not an empty file",
+);
+assert(
+  exportPage.indexOf("workspaceGestureUnmanaged: Omarchy.liveWorkspaceGestureUnmanaged()") !== -1,
+  "import re-scans input.lua for an unmanaged workspace gesture",
 );
 
 assert(omarchySrc.indexOf("function applyLookPatch") === -1, "applyLookPatch is gone");

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -152,7 +152,11 @@ assert(
 );
 assert(
   snapshotSh.indexOf('hypr-sentinel.py" input list') !== -1,
-  "snapshot.sh reads workspaceGesture from the input sentinel",
+  "snapshot.sh reads workspaceGesture from hypr-sentinel.py input list",
+);
+assert(
+  snapshotSh.indexOf("workspaceGestureUnmanaged") !== -1,
+  "snapshot.sh exposes an unmanaged workspace gesture separately from a managed one",
 );
 assert(
   snapshotSh.indexOf("grep -q 'action = \"workspace\"'") === -1,
@@ -984,6 +988,17 @@ assert(
   "Input disables layout Set when the list is invalid or unchanged",
 );
 assert(
+  inputPageSrc.indexOf("Omarchy.hyprWorkspaceGestureUnmanaged") !== -1 &&
+    inputPageSrc.indexOf("enabled: !Omarchy.hyprWorkspaceGestureUnmanaged") !== -1 &&
+    inputPageSrc.indexOf("outside the Atmos block") !== -1,
+  "Input shows an unmanaged workspace gesture as on and not managed",
+);
+assert(
+  omarchySrc.indexOf("property bool hyprWorkspaceGestureUnmanaged") !== -1 &&
+    omarchySrc.indexOf("if (hyprWorkspaceGestureUnmanaged) return") !== -1,
+  "Omarchy keeps unmanaged workspace gesture state and refuses to toggle it",
+);
+assert(
   omarchySrc.indexOf("layouts = HyprPrefs.sanitizeLayoutList(layouts)") !== -1,
   "Omarchy validates Hyprland layouts with HyprPrefs.sanitizeLayoutList",
 );
@@ -1247,6 +1262,8 @@ const copyProps = [
   "hyprLookManaged",
   "hyprInputManaged",
   "hyprWorkspaceGesture",
+  "hyprWorkspaceGestureManaged",
+  "hyprWorkspaceGestureUnmanaged",
   "hyprNoGaps",
   "hyprSquareAspect",
   "hyprWorkspaceLayout",

--- a/tests/run
+++ b/tests/run
@@ -1002,29 +1002,30 @@ else
   echo "ok - skipping set-hypr-input.sh"
 fi
 
-if [[ -x scripts/snapshot.sh ]] && command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+if [[ -x scripts/hypr-sentinel.py ]] && command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
   gesture_snap=$(mktemp -d)
+  # Same jq read snapshot.sh uses: a live unmanaged line is on and not managed.
   cat >"$gesture_snap/input.lua" <<'LUA'
 -- Enable touchpad gestures for changing workspaces.
 hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 LUA
-  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
-  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == true and .hyprWorkspaceGestureManaged == false and .hyprWorkspaceGestureUnmanaged == true and .hyprInput.workspaceGesture == true' >/dev/null
+  parsed=$(python3 scripts/hypr-sentinel.py input list "$gesture_snap/input.lua")
+  echo "$parsed" | jq -e '.workspaceGesture == true and .workspaceGestureManaged == false and .workspaceGestureUnmanaged == true' >/dev/null
   cat >"$gesture_snap/input.lua" <<'LUA'
 -- Enable touchpad gestures for changing workspaces.
 -- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 LUA
-  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
-  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == false and .hyprWorkspaceGestureUnmanaged == false and .hyprInput.workspaceGesture == false' >/dev/null
+  parsed=$(python3 scripts/hypr-sentinel.py input list "$gesture_snap/input.lua")
+  echo "$parsed" | jq -e '.workspaceGesture == false and .workspaceGestureUnmanaged == false' >/dev/null
   cat >"$gesture_snap/input.lua" <<'LUA'
 -- atmos:input begin
 hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 -- atmos:input end
 LUA
-  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
-  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == true and .hyprWorkspaceGestureManaged == true and .hyprWorkspaceGestureUnmanaged == false' >/dev/null
+  parsed=$(python3 scripts/hypr-sentinel.py input list "$gesture_snap/input.lua")
+  echo "$parsed" | jq -e '.workspaceGesture == true and .workspaceGestureManaged == true and .workspaceGestureUnmanaged == false' >/dev/null
   rm -rf "$gesture_snap"
-  echo "ok - snapshot.sh reports managed vs unmanaged workspace gesture"
+  echo "ok - snapshot.sh input list reports managed vs unmanaged workspace gesture"
 else
   echo "ok - skipping snapshot.sh workspace gesture"
 fi

--- a/tests/run
+++ b/tests/run
@@ -352,6 +352,8 @@ hyprLookManaged
 hyprNoGaps
 hyprSquareAspect
 hyprWorkspaceGesture
+hyprWorkspaceGestureManaged
+hyprWorkspaceGestureUnmanaged
 hyprWorkspaceLayout
 idleLock
 idleScreensaver
@@ -513,7 +515,7 @@ if [[ -x scripts/snapshot.sh ]] && command -v omarchy >/dev/null 2>&1 && command
   fi
   echo "ok - snapshot.sh accounts emits users without disks"
   json=$(bash scripts/snapshot.sh)
-  echo "$json" | jq -e '.theme and .themes and has("extraThemes") and (.extraThemes | type == "array") and has("desktopApps") and (.desktopApps | type == "array") and has("tuiApps") and (.tuiApps | type == "array") and has("webApps") and (.webApps | type == "array") and .barPosition and .idleScreensaver and has("stayAwake") and has("nightlight") and has("nightlightTemperature") and has("screensaverEnabled") and has("barVisible") and has("dns") and has("bluetooth") and has("suspendEnabled") and has("powerProfile") and has("powerProfileAc") and has("powerProfileBattery") and (.powerProfiles | type == "array") and has("crashCapture") and has("plymouth") and (.plymouthThemes | type == "array") and has("doNotDisturb") and has("weatherLocation") and has("weatherCoords") and has("weatherAuto") and has("weatherPresent") and has("weatherUnit") and has("weatherRefreshMinutes") and has("reminderCount") and has("reminderActive") and has("reminders") and (.reminders | type == "array") and has("clockFormat") and has("clockFormatAlt") and has("clockWeekStart") and has("clockPresent") and has("clockBirthYear") and has("clockLifeExpectancy") and has("indicatorsPresent") and has("indicatorsAlwaysShow") and has("indicatorsItems") and (.indicatorsItems | type == "array") and has("agentsPresent") and has("agentsRefreshIntervalSec") and has("agentsSync") and has("agentsSyncDir") and has("agentsSyncFileName") and has("agentsSyncDeviceId") and has("spacerPresent") and has("spacerSize") and has("trayPresent") and has("trayHidden") and (.trayHidden | type == "array") and has("trayPinned") and (.trayPinned | type == "array") and has("powerPresent") and has("powerShowPercentage") and has("isLaptop") and has("batteryPresent") and has("monitors") and (.monitors | type == "array") and has("internalPresent") and has("internalEnabled") and has("externalPresent") and has("mirroring") and has("touchpadPresent") and has("touchpadEnabled") and has("touchscreenPresent") and has("touchscreenEnabled") and has("keyboardBacklightPresent") and has("keyboardBrightness") and has("wifiConnected") and has("wifiBandSelected") and (.wifiBands | type == "array") and has("wifiIface") and has("netKind") and has("netIface") and has("netIp") and has("wifiHw") and has("wifiRadio") and has("wifiConnections") and (.wifiConnections | type == "array") and has("bluetoothDevices") and (.bluetoothDevices | type == "array") and has("audioSinks") and (.audioSinks | type == "array") and has("audioSources") and (.audioSources | type == "array") and has("audioOutputVolume") and has("audioOutputMuted") and has("audioInputVolume") and has("audioInputMuted") and has("audioTuningMatch") and has("audioTuningOn") and has("disks") and (.disks | type == "array") and has("hardware") and (.hardware | type == "object") and has("luksDevices") and (.luksDevices | type == "array") and has("swapDevices") and (.swapDevices | type == "array") and has("snapperPresent") and has("snapperConfigs") and (.snapperConfigs | type == "array") and has("snapshots") and (.snapshots | type == "array") and has("hibernationAvailable") and has("hibernationSupported") and has("hibernationConfigured") and has("screensaverBranded") and has("aboutBranded") and has("timezone") and has("timezones") and (.timezones | type == "array") and has("hostname") and has("keyboardLayout") and has("keyboardLayouts") and (.keyboardLayouts | type == "array") and has("ntp") and has("ntpAvailable") and has("ntpSynchronized") and has("locale") and has("locales") and (.locales | type == "array") and has("parallelDownloads") and has("fullName") and has("currentUser") and has("avatarPath") and has("users") and (.users | type == "array") and has("groups") and (.groups | type == "array") and has("hyprLook") and has("hyprInput") and has("hyprLookManaged") and has("hyprNoGaps") and has("fingerprintAvailable") and has("sshdEnabled") and has("omarchyChannel") and has("updateAvailable") and has("plugins") and (.plugins | type == "array") and has("voxtypeInstalled") and has("fstrimEnabled") and has("directBootAvailable") and has("mimePdf") and has("picturesDir") and has("videosDir") and has("recordingActive") and has("webcamOverlay") and has("services") and has("gaming") and has("extras") and has("hooks") and (.hooks | type == "array") and has("autostart") and (.autostart | type == "array") and has("autostartManaged") and has("nightlightDay") and has("nightlightNight") and has("nightlightNightOn") and has("tailscalePeers") and (.tailscalePeers | type == "array") and (.hyprLook | has("cursorSize")) and (.hyprLook | has("activeOpacity")) and (.hyprLook | has("inactiveOpacity")) and (.hyprInput | has("workspaceGesture")) and (.hyprInput | has("kbLayoutOverride")) and has("bindings") and (.bindings | type == "array") and has("bindingsManaged") and has("windowRules") and (.windowRules | type == "array") and has("windowRulesManaged") and has("keybindings") and (.keybindings | type == "array") and has("focusedClass") and has("cupsActive") and has("printerSetup") and has("hwNvidia") and has("hwVulkan") and has("hwIntel") and has("dmiProduct") and has("cpuStat") and has("memoryStat") and has("cpuIdentity") and has("gpuIdentity") and has("npuIdentity") and has("atmosRevision") and has("atmosChannel") and has("atmosInstalled")' >/dev/null
+  echo "$json" | jq -e '.theme and .themes and has("extraThemes") and (.extraThemes | type == "array") and has("desktopApps") and (.desktopApps | type == "array") and has("tuiApps") and (.tuiApps | type == "array") and has("webApps") and (.webApps | type == "array") and .barPosition and .idleScreensaver and has("stayAwake") and has("nightlight") and has("nightlightTemperature") and has("screensaverEnabled") and has("barVisible") and has("dns") and has("bluetooth") and has("suspendEnabled") and has("powerProfile") and has("powerProfileAc") and has("powerProfileBattery") and (.powerProfiles | type == "array") and has("crashCapture") and has("plymouth") and (.plymouthThemes | type == "array") and has("doNotDisturb") and has("weatherLocation") and has("weatherCoords") and has("weatherAuto") and has("weatherPresent") and has("weatherUnit") and has("weatherRefreshMinutes") and has("reminderCount") and has("reminderActive") and has("reminders") and (.reminders | type == "array") and has("clockFormat") and has("clockFormatAlt") and has("clockWeekStart") and has("clockPresent") and has("clockBirthYear") and has("clockLifeExpectancy") and has("indicatorsPresent") and has("indicatorsAlwaysShow") and has("indicatorsItems") and (.indicatorsItems | type == "array") and has("agentsPresent") and has("agentsRefreshIntervalSec") and has("agentsSync") and has("agentsSyncDir") and has("agentsSyncFileName") and has("agentsSyncDeviceId") and has("spacerPresent") and has("spacerSize") and has("trayPresent") and has("trayHidden") and (.trayHidden | type == "array") and has("trayPinned") and (.trayPinned | type == "array") and has("powerPresent") and has("powerShowPercentage") and has("isLaptop") and has("batteryPresent") and has("monitors") and (.monitors | type == "array") and has("internalPresent") and has("internalEnabled") and has("externalPresent") and has("mirroring") and has("touchpadPresent") and has("touchpadEnabled") and has("touchscreenPresent") and has("touchscreenEnabled") and has("keyboardBacklightPresent") and has("keyboardBrightness") and has("wifiConnected") and has("wifiBandSelected") and (.wifiBands | type == "array") and has("wifiIface") and has("netKind") and has("netIface") and has("netIp") and has("wifiHw") and has("wifiRadio") and has("wifiConnections") and (.wifiConnections | type == "array") and has("bluetoothDevices") and (.bluetoothDevices | type == "array") and has("audioSinks") and (.audioSinks | type == "array") and has("audioSources") and (.audioSources | type == "array") and has("audioOutputVolume") and has("audioOutputMuted") and has("audioInputVolume") and has("audioInputMuted") and has("audioTuningMatch") and has("audioTuningOn") and has("disks") and (.disks | type == "array") and has("hardware") and (.hardware | type == "object") and has("luksDevices") and (.luksDevices | type == "array") and has("swapDevices") and (.swapDevices | type == "array") and has("snapperPresent") and has("snapperConfigs") and (.snapperConfigs | type == "array") and has("snapshots") and (.snapshots | type == "array") and has("hibernationAvailable") and has("hibernationSupported") and has("hibernationConfigured") and has("screensaverBranded") and has("aboutBranded") and has("timezone") and has("timezones") and (.timezones | type == "array") and has("hostname") and has("keyboardLayout") and has("keyboardLayouts") and (.keyboardLayouts | type == "array") and has("ntp") and has("ntpAvailable") and has("ntpSynchronized") and has("locale") and has("locales") and (.locales | type == "array") and has("parallelDownloads") and has("fullName") and has("currentUser") and has("avatarPath") and has("users") and (.users | type == "array") and has("groups") and (.groups | type == "array") and has("hyprLook") and has("hyprInput") and has("hyprLookManaged") and has("hyprWorkspaceGesture") and has("hyprWorkspaceGestureManaged") and has("hyprWorkspaceGestureUnmanaged") and has("hyprNoGaps") and has("fingerprintAvailable") and has("sshdEnabled") and has("omarchyChannel") and has("updateAvailable") and has("plugins") and (.plugins | type == "array") and has("voxtypeInstalled") and has("fstrimEnabled") and has("directBootAvailable") and has("mimePdf") and has("picturesDir") and has("videosDir") and has("recordingActive") and has("webcamOverlay") and has("services") and has("gaming") and has("extras") and has("hooks") and (.hooks | type == "array") and has("autostart") and (.autostart | type == "array") and has("autostartManaged") and has("nightlightDay") and has("nightlightNight") and has("nightlightNightOn") and has("tailscalePeers") and (.tailscalePeers | type == "array") and (.hyprLook | has("cursorSize")) and (.hyprLook | has("activeOpacity")) and (.hyprLook | has("inactiveOpacity")) and (.hyprInput | has("workspaceGesture")) and (.hyprInput | has("kbLayoutOverride")) and has("bindings") and (.bindings | type == "array") and has("bindingsManaged") and has("windowRules") and (.windowRules | type == "array") and has("windowRulesManaged") and has("keybindings") and (.keybindings | type == "array") and has("focusedClass") and has("cupsActive") and has("printerSetup") and has("hwNvidia") and has("hwVulkan") and has("hwIntel") and has("dmiProduct") and has("cpuStat") and has("memoryStat") and has("cpuIdentity") and has("gpuIdentity") and has("npuIdentity") and has("atmosRevision") and has("atmosChannel") and has("atmosInstalled")' >/dev/null
   echo "ok - snapshot.sh emits a usable JSON object"
 else
   echo "ok - skipping live snapshot (omarchy/jq not available)"
@@ -956,10 +958,75 @@ LUA
     rm -rf "$input_home"
     exit 1
   fi
+
+  cat >"$input_home/input.lua" <<'LUA'
+-- Enable touchpad gestures for changing workspaces.
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+LUA
+  listed=$(python3 scripts/hypr-sentinel.py input list "$input_home/input.lua")
+  echo "$listed" | jq -e '.workspaceGesture == true and .workspaceGestureManaged == false and .workspaceGestureUnmanaged == true' >/dev/null
+  ATMOS_INPUT_FILE="$input_home/input.lua" ATMOS_SKIP_HYPR=1 \
+    bash scripts/set-hypr-input.sh '{"sensitivity":-0.2,"workspaceGesture":true}'
+  gesture_count=$(grep -c 'hl.gesture' "$input_home/input.lua" || true)
+  if [[ $gesture_count -ne 1 ]]; then
+    echo "not ok - set-hypr-input.sh wrote a duplicate gesture over an unmanaged line ($gesture_count)"
+    rm -rf "$input_home"
+    exit 1
+  fi
+  if awk '/-- atmos:input begin/,/-- atmos:input end/' "$input_home/input.lua" | grep -q 'hl.gesture'; then
+    echo "not ok - set-hypr-input.sh wrote hl.gesture into the atmos block despite an unmanaged line"
+    rm -rf "$input_home"
+    exit 1
+  fi
+  grep -q -- '-- atmos:input begin' "$input_home/input.lua"
+  grep -q 'sensitivity = -0.2' "$input_home/input.lua"
+
+  cat >"$input_home/input.lua" <<'LUA'
+-- Enable touchpad gestures for changing workspaces.
+-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+LUA
+  listed=$(python3 scripts/hypr-sentinel.py input list "$input_home/input.lua")
+  echo "$listed" | jq -e '.workspaceGesture == false and .workspaceGestureUnmanaged == false' >/dev/null
+  ATMOS_INPUT_FILE="$input_home/input.lua" ATMOS_SKIP_HYPR=1 \
+    bash scripts/set-hypr-input.sh '{"workspaceGesture":true}'
+  if ! awk '/-- atmos:input begin/,/-- atmos:input end/' "$input_home/input.lua" | grep -q 'hl.gesture'; then
+    echo "not ok - set-hypr-input.sh skipped a managed gesture over a commented stock line"
+    rm -rf "$input_home"
+    exit 1
+  fi
+  grep -q -- '-- hl.gesture' "$input_home/input.lua"
+
   rm -rf "$input_home"
-  echo "ok - set-hypr-input.sh writes an input sentinel, strips leftover prefs, and rejects a flag"
+  echo "ok - set-hypr-input.sh writes an input sentinel, defers to an unmanaged gesture, and rejects a flag"
 else
   echo "ok - skipping set-hypr-input.sh"
+fi
+
+if [[ -x scripts/snapshot.sh ]] && command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  gesture_snap=$(mktemp -d)
+  cat >"$gesture_snap/input.lua" <<'LUA'
+-- Enable touchpad gestures for changing workspaces.
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+LUA
+  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
+  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == true and .hyprWorkspaceGestureManaged == false and .hyprWorkspaceGestureUnmanaged == true and .hyprInput.workspaceGesture == true' >/dev/null
+  cat >"$gesture_snap/input.lua" <<'LUA'
+-- Enable touchpad gestures for changing workspaces.
+-- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+LUA
+  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
+  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == false and .hyprWorkspaceGestureUnmanaged == false and .hyprInput.workspaceGesture == false' >/dev/null
+  cat >"$gesture_snap/input.lua" <<'LUA'
+-- atmos:input begin
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+-- atmos:input end
+LUA
+  snap_json=$(ATMOS_INPUT_FILE="$gesture_snap/input.lua" HOME="$gesture_snap" bash scripts/snapshot.sh)
+  echo "$snap_json" | jq -e '.hyprWorkspaceGesture == true and .hyprWorkspaceGestureManaged == true and .hyprWorkspaceGestureUnmanaged == false' >/dev/null
+  rm -rf "$gesture_snap"
+  echo "ok - snapshot.sh reports managed vs unmanaged workspace gesture"
+else
+  echo "ok - skipping snapshot.sh workspace gesture"
 fi
 
 if [[ -x scripts/set-nightlight-temp.sh ]]; then

--- a/tests/run
+++ b/tests/run
@@ -1656,6 +1656,42 @@ JSON
   grep -q '"scrollFactor":0.4' <<<"$out"
   rm -rf "$input_dir"
   echo "ok - apply-settings.sh keeps hyprInput layout override and workspace gesture"
+
+  stale_dir=$(mktemp -d)
+  mkdir -p "$stale_dir/.config/hypr"
+  cat >"$stale_dir/.config/hypr/input.lua" <<'LUA'
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+LUA
+  printf '{"hyprInput":{"workspaceGesture":false,"sensitivity":0}}' >"$stale_dir/snapshot.json"
+  cat >"$stale_dir/plan.json" <<'JSON'
+{
+  "schema": 1,
+  "changes": [
+    { "key": "hyprInput.workspaceGesture", "value": true, "from": false }
+  ]
+}
+JSON
+  stale_out=$(HOME="$stale_dir" ATMOS_INPUT_FILE="$stale_dir/.config/hypr/input.lua" ATMOS_SKIP_HYPR=1 \
+    bash scripts/apply-settings.sh --snapshot "$stale_dir/snapshot.json" --plan "$stale_dir/plan.json")
+  echo "$stale_out" | jq -e '.results | map(select(.key == "hyprInput.workspaceGesture")) | .[0].status == "skipped"' >/dev/null
+  if echo "$stale_out" | jq -e '.results | any(.key == "hyprInput.workspaceGesture" and .status == "applied")' >/dev/null; then
+    echo "not ok - apply-settings.sh reported an unmanaged workspace gesture as applied"
+    rm -rf "$stale_dir"
+    exit 1
+  fi
+  gesture_count=$(grep -c 'hl.gesture' "$stale_dir/.config/hypr/input.lua" || true)
+  if [[ $gesture_count -ne 1 ]]; then
+    echo "not ok - apply-settings.sh wrote a duplicate gesture over a stale snapshot ($gesture_count)"
+    rm -rf "$stale_dir"
+    exit 1
+  fi
+  if grep -q -- '-- atmos:input begin' "$stale_dir/.config/hypr/input.lua"; then
+    echo "not ok - apply-settings.sh wrote an input block for a skipped workspace gesture"
+    rm -rf "$stale_dir"
+    exit 1
+  fi
+  rm -rf "$stale_dir"
+  echo "ok - apply-settings.sh skips a workspace gesture when the live file is unmanaged"
 else
   echo "ok - skipping apply-settings.sh hyprInput merge"
 fi

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -647,6 +647,65 @@ assertEqual(
   "planImport reads workspaceGesture from hyprInput, not a top-level key",
 );
 
+const unmanagedGestureOn = settings.planImport(
+  settings.parseSettingsMarkdown(
+    "```toml atmos:meta\nschema = 1\n```\n" +
+      "```toml atmos:input\nhyprInput.workspaceGesture = false\n```\n",
+  ),
+  {
+    hyprInput: { workspaceGesture: true },
+    hyprWorkspaceGestureUnmanaged: true,
+  },
+  null,
+  {},
+);
+assertEqual(
+  unmanagedGestureOn.changes.length,
+  0,
+  "import skips workspaceGesture when a live unmanaged gesture owns it",
+);
+assertEqual(
+  unmanagedGestureOn.unchanged.length,
+  0,
+  "an unmanaged gesture is not an unchanged write",
+);
+assertEqual(
+  unmanagedGestureOn.warnings.length,
+  1,
+  "import warns instead of rewriting a hand-written gesture",
+);
+assert(
+  unmanagedGestureOn.warnings[0].message.indexOf("written by hand") !== -1,
+  "the unmanaged gesture warning says the line is written by hand",
+);
+assert(
+  unmanagedGestureOn.warnings[0].message.indexOf("skipped") !== -1,
+  "the unmanaged gesture warning says the setting is skipped",
+);
+
+const unmanagedGestureSame = settings.planImport(
+  settings.parseSettingsMarkdown(
+    "```toml atmos:meta\nschema = 1\n```\n" +
+      "```toml atmos:input\nhyprInput.workspaceGesture = true\n```\n",
+  ),
+  {
+    hyprInput: { workspaceGesture: true },
+    hyprWorkspaceGestureUnmanaged: true,
+  },
+  null,
+  {},
+);
+assertEqual(
+  unmanagedGestureSame.changes.length,
+  0,
+  "import still skips workspaceGesture when the imported value already matches",
+);
+assertEqual(
+  unmanagedGestureSame.warnings.length,
+  1,
+  "matching an unmanaged gesture still warns instead of claiming a write",
+);
+
 const selected = planFor(
   "```toml atmos:meta\nschema = 1\n```\n" +
     '```toml atmos:appearance\ntheme = "catppuccin"\n```\n' +

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -683,6 +683,26 @@ assert(
   "the unmanaged gesture warning says the setting is skipped",
 );
 
+const staleUnmanaged = settings.planImport(
+  settings.parseSettingsMarkdown(
+    "```toml atmos:meta\nschema = 1\n```\n" +
+      "```toml atmos:input\nhyprInput.workspaceGesture = true\n```\n",
+  ),
+  { hyprInput: { workspaceGesture: false } },
+  null,
+  { workspaceGestureUnmanaged: true },
+);
+assertEqual(
+  staleUnmanaged.changes.length,
+  0,
+  "a live unmanaged scan skips workspaceGesture even when the snapshot flag is missing",
+);
+assertEqual(
+  staleUnmanaged.warnings.length,
+  1,
+  "a live unmanaged scan still warns instead of planning a write",
+);
+
 const unmanagedGestureSame = settings.planImport(
   settings.parseSettingsMarkdown(
     "```toml atmos:meta\nschema = 1\n```\n" +

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -726,6 +726,30 @@ assertEqual(
   "matching an unmanaged gesture still warns instead of claiming a write",
 );
 
+const skippedGesture = settings.planCommands(
+  [{ key: "hyprInput.workspaceGesture", value: true }],
+  { hyprInput: { workspaceGesture: false, sensitivity: 0 } },
+  { workspaceGestureUnmanaged: true },
+);
+assertEqual(skippedGesture.length, 1, "planCommands reports a skipped unmanaged gesture");
+assertEqual(skippedGesture[0].skip, true, "the unmanaged gesture command is a skip");
+assertEqual(
+  skippedGesture[0].key,
+  "hyprInput.workspaceGesture",
+  "the skip keeps the workspace gesture key",
+);
+
+const otherInput = settings.commandFor(
+  "hyprInput.sensitivity",
+  -0.2,
+  { hyprInput: { workspaceGesture: true, sensitivity: 0 } },
+  { workspaceGestureUnmanaged: true },
+);
+assert(
+  otherInput.stdin.indexOf("workspaceGesture") === -1,
+  "an unmanaged live gesture is omitted from a paired input write",
+);
+
 const selected = planFor(
   "```toml atmos:meta\nschema = 1\n```\n" +
     '```toml atmos:appearance\ntheme = "catppuccin"\n```\n' +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #16. Owner decision was option 2 — Atmos defers. Diagnosis of the HORIZONTAL shadow and the ownership choice is from @nixfred.

Uncommenting Omarchy’s stock `hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })` then changing Atmos → Input used to write the same line into `-- atmos:input`. Hyprland then rejected the second as “Previous HORIZONTAL shadows new HORIZONTAL”. Detection only looked inside the sentinel, so the toggle showed off while the swipe already worked.

If a live unmanaged workspace gesture exists outside the Atmos / leftover input sentinels:

1. The writer never emits Atmos’s `hl.gesture` line, even when `workspaceGesture` is true.
2. Snapshot reports the gesture as **on and not managed** (`hyprWorkspaceGesture` true, `hyprWorkspaceGestureUnmanaged` true).
3. Input → Three-finger swipe is checked and disabled. Copy matches that: the switch stays on and Atmos will not change it. Comment that line out to let Atmos own it.
4. Import skips this key and warns rather than rewriting hand-written config.

A commented stock example still does not count as unmanaged. The managed-only path still writes.

### Review follow-up

- Copy and tests now assert on-and-not-managed (not “stays off”). The “stays off” check is scoped to the Three-finger swipe row so layout/variant Set copy does not false-fail.
- After an input write, Omarchy re-scans `input.lua` (FileView + `waitForJob`) and refreshes the three gesture flags, so commenting the stock line out actually lets Atmos own the row.
- Import re-scans the live file (same scan as the writer). `apply-settings.sh` reports `skipped` instead of `applied` when the writer would no-op the gesture.
- Detector stays “any live `action = workspace` means defer,” including vertical / left / right. Hyprland clashes on HORIZONTAL; over-defer is the rule. Documented on the scan.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12941ed8-25e1-40bc-afba-ffe59274b844?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12941ed8-25e1-40bc-afba-ffe59274b844&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

