### PR TITLE
fix: Atmos does not start on alpha.12 — inputLuaView is a bare child of a QtObject

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -3374,8 +3374,7 @@ QtObject {
     }
   }
 
-  FileView {
-    id: inputLuaView
+  property FileView inputLuaView: FileView {
     path: root.inputLuaFile
     watchChanges: false
     printErrors: false


### PR DESCRIPTION
## What happens

Atmos does not launch on `bad62ea` (tagged `v0.0.1-alpha.12`). Quickshell refuses the config outright:

```
ERROR: Failed to load configuration
ERROR:   caused by @shell.qml[145:35]: Type AppearancePage unavailable
ERROR:   caused by @pages/AppearancePage.qml[9:1]: Type PrefsPage unavailable
ERROR:   caused by @components/PrefsPage.qml[23:3]: Type PrefsFlickable unavailable
ERROR:   caused by @components/PrefsFlickable.qml[-1:-1]: Type AccountsStore unavailable
ERROR:   caused by @services/AccountsStore.qml[-1:-1]: Type Omarchy unavailable
ERROR:   caused by @services/Omarchy.qml[3377:3]: Cannot assign to non-existent default property
```

The cascade is misleading — the real failure is the last line. `Omarchy` fails to construct, so everything importing the singleton fails with it.

## Cause

`services/Omarchy.qml:22` is a `QtObject`, which has no default property, so an object declared as a bare child of it has nowhere to be assigned. `inputLuaView` was introduced this way in 30d2b8b:

```qml
  FileView {
    id: inputLuaView
    ...
  }
```

It is the only bare object block in the file. The other seven — `extraThemesWatcher`, `extraThemesWatcherRestart`, `extraThemesDebounce`, `refreshTimer`, `snapshotProc`, `mutProc`, `jobProc` — are each held by an explicit property.

## Fix

Match the file's existing convention. The `id` is dropped because the property name is already what the three call sites at `services/Omarchy.qml:862-865` use, and it resolves in the singleton's scope exactly as `extraThemesWatcher` does.

## Verification

Reproduced and fixed against a clean install staged from `alpha` at `bad62ea` (`scripts/update-atmos.sh apply`). Before the patch the shell exits during load with the error above; after it, `Configuration Loaded` and the process stays up with an empty error log.

`./tests/run` is 3396 ok / 0 not ok both before and after — worth flagging that nothing under `tests/` instantiates QML, so a fatal load error currently ships green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH