### PR TITLE
fix: declare inputLuaView as typed property for pragma Singleton

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -3374,8 +3374,7 @@ QtObject {
     }
   }
 
-  FileView {
-    id: inputLuaView
+  property FileView inputLuaView: FileView {
     path: root.inputLuaFile
     watchChanges: false
     printErrors: false


### PR DESCRIPTION
Fixes #23.

## Problem

On launch, atmos fails to load with:

```
ERROR: caused by @services/Omarchy.qml[3377:3]: Cannot assign to non-existent default property
```

`services/Omarchy.qml` is a `pragma Singleton` component, but line 3377 declared a bare `FileView {}` child object. QML refuses to compile a non-visual child without a default property inside a `pragma Singleton` root, which breaks the whole component chain.

Minimal reproducer:
```qml
pragma Singleton
import QtQuick
import Quickshell
import Quickshell.Io

QtObject {
  FileView {}
}
```
fails with the same message, while removing `pragma Singleton` or using a typed `property FileView` works.

## Fix

Declare `inputLuaView` as a typed `property FileView` initializer, matching the pattern already used in `services/Theme.qml`. Behaviour is unchanged since the function bodies still resolve `inputLuaView`.

## Verification

`atmos` now starts with `Configuration Loaded` on quickshell 0.3.1.