### PR TITLE
fix: ./tests/run aborts when the developer's input.lua has an unmanaged workspace gesture

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -1704,7 +1704,10 @@ JSON
   ]
 }
 JSON
-  out=$(bash scripts/apply-settings.sh --dry-run --snapshot "$input_dir/snapshot.json" \
+  mkdir -p "$input_dir/.config/hypr"
+  : >"$input_dir/.config/hypr/input.lua"
+  out=$(HOME="$input_dir" ATMOS_INPUT_FILE="$input_dir/.config/hypr/input.lua" \
+    bash scripts/apply-settings.sh --dry-run --snapshot "$input_dir/snapshot.json" \
     --plan "$input_dir/plan.json")
   inputs=$(grep -c 'set-hypr-input.sh' <<<"$out" || true)
   if [[ $inputs -ne 1 ]]; then


### PR DESCRIPTION
## What happens

`./tests/run` exits 1 on `561cc9f`, stopping after 3597 assertions with **no failure message**:

```
$ ./tests/run; echo "exit: $?"
...
ok - apply-settings.sh groups writers, pairs values, skips settled toggles, and writes an undo plan
exit: 1
```

Nothing prints because the assertion that fails is a bare `grep -q` under `set -euo pipefail`.

## Cause

Not a product bug — the product is right and the test is wrong.

The block at `tests/run:1684` builds a snapshot carrying `workspaceGesture: true` and asserts the value survives into the payload handed to `set-hypr-input.sh`. It invokes `apply-settings.sh` **without overriding `HOME`**, so the deferral logic added in 30d2b8b reads the *developer's real* `~/.config/hypr/input.lua`.

If that file has a workspace gesture outside the `atmos:input` sentinel — e.g.

```lua
hl.gesture({ fingers = 2, direction = "swipe", mods = "SUPER", action = "workspace" })
```

— then `apply-settings.sh` correctly drops `workspaceGesture` from the payload rather than writing a duplicate. That is the #21 feature behaving exactly as intended. The test then fails at `tests/run:1716`.

Confirmed by running one fixture three ways:

| `HOME` | `workspaceGesture` in payload |
|---|---|
| real (unmanaged gesture present) | absent → test fails |
| empty temp dir | `"workspaceGesture":true` → test passes |
| temp dir with an unmanaged `hl.gesture(... action = "workspace")` | absent → test fails |

So the suite passes or fails depending on whose machine it runs on.

## Fix

Sandbox `HOME` and `ATMOS_INPUT_FILE`, exactly as the neighbouring unmanaged-gesture test at `tests/run:1736` already does.

## Verification

Before: `exit 1`, aborts at 3597 ok.
After: `exit 0`, **3606 ok, 0 not ok**, suite runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH