### PR TITLE
fix: refuse a second Atmos instance, which can currently race itself over config files

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -1806,6 +1806,38 @@ QtObject {
     runJob(["bash", diagReportScript, "agent"], header, "diag-report", { refresh: "none" })
   }
 
+  // One Atmos at a time.
+  //
+  // Quickshell already refuses a second instance of the same config path,
+  // which is why this looks solved and is not: running one copy from the
+  // install and another from a checkout opens two windows, and both write
+  // the same configuration files. Settings are shared mutable state on disk,
+  // so two writers race and the loser's change is lost silently.
+  //
+  // The lock is on the app, not the path. flock holds an exclusive lock for
+  // as long as the holder lives, so the kernel releases it if Atmos crashes
+  // -- something a lockfile holding a PID cannot promise.
+  property bool lostInstanceLock: false
+
+  readonly property string instanceLockPath: {
+    var dir = Quickshell.env("XDG_RUNTIME_DIR")
+    if (!dir) dir = "/tmp"
+    return dir + "/atmos.lock"
+  }
+
+  property Process instanceLock: Process {
+    running: true
+    // -n fails immediately rather than queueing behind the instance that
+    // already owns it. tail -f /dev/null parks cheaply and dies with us.
+    command: ["flock", "-n", root.instanceLockPath, "-c", "exec tail -f /dev/null"]
+    onExited: function (exitCode) {
+      // 1 is flock's "someone else holds it". Any other code means flock is
+      // missing or broken, and refusing to start over a missing utility
+      // would be worse than the race this prevents.
+      if (exitCode === 1) root.lostInstanceLock = true
+    }
+  }
+
   function clearLastError() {
     lastError = ""
   }

--- a/shell.qml
+++ b/shell.qml
@@ -771,6 +771,40 @@ ShellRoot {
       }
     }
 
+    // A second Atmos is refused, and told why. Quitting silently would look
+    // like a crash; continuing would let two windows race over the same
+    // config files.
+    Connections {
+      target: Omarchy
+      function onLostInstanceLockChanged() {
+        if (Omarchy.lostInstanceLock) secondInstanceDialog.open()
+      }
+    }
+
+    PrefsDialog {
+      id: secondInstanceDialog
+      title: "Atmos is already open"
+      closePolicy: Popup.NoAutoClose
+
+      PrefsText {
+        width: parent.width
+        text: "Another Atmos is running on this machine. Two of them would write the same configuration files at the same time, and whichever finished second would quietly overwrite the other, so this one will close.\n\nSwitch to the window that is already open."
+        color: Theme.foreground
+        font.family: Theme.fontFamily
+        font.pixelSize: Theme.labelSize
+        wrapMode: Text.WordWrap
+      }
+
+      Row {
+        anchors.right: parent.right
+        PrefsButton {
+          text: "Close this one"
+          primary: true
+          onClicked: Qt.quit()
+        }
+      }
+    }
+
     PrefsDialog {
       id: sudoModeDialog
       title: "Administrator password"


### PR DESCRIPTION
## The problem

Quickshell refuses a second instance of the *same config path*, which makes this look solved. It isn't. Run one copy from the install and another from a checkout:

```
$ quickshell -n -p ~/.local/share/atmos   # instance A
$ quickshell -n -p ~/Projects/atmos       # instance B — starts happily
```

Two Atmos windows, both writing the same files under `~/.config/`.

Settings are shared mutable state on disk, so the two race. The loser's change is lost with nothing to indicate it happened — the second window just shows a value the first one replaced a moment ago. Easy to hit while developing, and possible for anyone who has ever run Atmos from a clone.

## The fix

An `flock` on the app rather than on the config path, in `$XDG_RUNTIME_DIR`.

`flock` holds the lock for as long as the holder process lives, so the kernel releases it if Atmos crashes. A lockfile containing a PID cannot promise that — it goes stale and then needs its own recovery logic.

Verified three ways:

| Case | Result |
|---|---|
| Another instance holds it | exit 1, second instance reports why and closes |
| Nothing holds it | acquired, held for the process lifetime |
| Holder receives SIGKILL | released immediately, reacquirable, no stale lock |

## Notes

A refused instance says why rather than disappearing. Quitting silently reads as a crash; continuing leaves the race in place.

Falls back to `/tmp` when `XDG_RUNTIME_DIR` is unset. Any `flock` exit code other than 1 is treated as "flock is missing or broken, carry on" — refusing to start over a missing utility would be worse than the race this prevents.

Suite green on this branch: 3556 ok, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH