### PR TITLE
feat: live status in the sidebar instead of decorative icons

### DIFF
--- a/services/NavStatus.js
+++ b/services/NavStatus.js
@@ -1,0 +1,164 @@
+// Derive a small live badge for each hub in the sidebar.
+//
+// The sidebar already carries a per-hub icon, but it is decoration -- it
+// says the same thing whether a unit just failed or everything is fine.
+// This turns that column into a status readout: the point is that you learn
+// something about the machine without opening a page, and that anything
+// actually wrong finds you instead of waiting to be discovered.
+//
+// Rules this follows on purpose:
+//   * Only real state earns a badge. No badge is a valid, common answer,
+//     and a hub with nothing to say stays silent rather than showing a 0.
+//   * Only three inks, matching Theme: warn for something wrong, ok for
+//     something actively good, info for a neutral count. Grayscale chrome
+//     stays grayscale.
+//   * Every read is defensive. This runs on every sidebar row on every
+//     state change, so it must never throw on a half-populated snapshot.
+
+function arr(v) {
+  return Array.isArray(v) ? v : [];
+}
+
+function isFailedUnit(row) {
+  if (!row) return false;
+  var active = String(row.active || "").toLowerCase();
+  var sub = String(row.sub || "").toLowerCase();
+  return active === "failed" || sub === "failed";
+}
+
+// tone: "warn" | "ok" | "info". text is short -- one or two glyphs plus a
+// small number, never a word, because the column is 220px wide and the
+// label already owns most of it.
+function badge(text, tone, title) {
+  if (text === null || text === undefined || text === "") return null;
+  return { text: String(text), tone: tone || "info", title: title || "" };
+}
+
+function servicesBadge(state) {
+  var units = arr(state.systemdUnits);
+  var failed = 0;
+  for (var i = 0; i < units.length; i++) {
+    if (isFailedUnit(units[i])) failed += 1;
+  }
+  if (failed > 0)
+    return badge("▲" + failed, "warn", failed + " failed unit" + (failed === 1 ? "" : "s"));
+  return null;
+}
+
+function bluetoothBadge(state) {
+  // Positive evidence only, for the same reason as networkBadge: the
+  // singleton declares bluetooth false before any snapshot has run, and the
+  // ready gate can open while that default is still in place. Reporting a
+  // radio "off" when it is on is the same false alarm in a different row.
+  //
+  // A connected device is something Atmos genuinely knows. A radio being off
+  // is something the user turned off themselves.
+  var devices = arr(state.bluetoothDevices);
+  var connected = 0;
+  for (var i = 0; i < devices.length; i++) {
+    if (devices[i] && devices[i].connected === true) connected += 1;
+  }
+  if (connected > 0) return badge("●" + connected, "ok", connected + " connected");
+  return null;
+}
+
+function displayBadge(state) {
+  var monitors = arr(state.monitors);
+  if (monitors.length === 0) return null;
+  var off = 0;
+  for (var i = 0; i < monitors.length; i++) {
+    if (monitors[i] && monitors[i].disabled === true) off += 1;
+  }
+  if (off > 0)
+    return badge(monitors.length - off + "/" + monitors.length, "warn", off + " output disabled");
+  if (monitors.length > 1)
+    return badge(String(monitors.length), "info", monitors.length + " outputs");
+  return null;
+}
+
+function networkBadge(state) {
+  var kind = String(state.netKind || "").toLowerCase();
+  if (kind === "ethernet") return badge("eth", "ok", "Wired");
+  if (kind === "wifi") {
+    var ssid = String(state.netSsid || "");
+    return badge("●", "ok", ssid ? "Connected to " + ssid : "Connected");
+  }
+  // Anything else is silent, including "disconnected".
+  //
+  // This badge has now cried wolf twice. The singleton declares netKind as
+  // "disconnected" before any snapshot runs, and snapshotReady is set true
+  // even when the snapshot was skipped or failed -- so the ready gate can
+  // open while the defaults are still in place, and a working wifi
+  // connection gets a warning triangle.
+  //
+  // Rather than chase a third guard, the badge now only ever speaks when it
+  // has positive evidence: a named connection type. Being offline is the one
+  // thing a user never needs an indicator to tell them, and a false alarm
+  // here costs more than the missing signal is worth.
+  return null;
+}
+
+function softwareBadge(state) {
+  var n = 0;
+  if (state.updateAvailable === true) n += 1;
+  if (state.atmosUpdateAvailable === true) n += 1;
+  if (n > 0) return badge("↑" + n, "info", n + " update" + (n === 1 ? "" : "s") + " available");
+  return null;
+}
+
+function disksBadge(state) {
+  var disks = arr(state.disks);
+  var bad = 0;
+  for (var i = 0; i < disks.length; i++) {
+    var d = disks[i];
+    if (!d) continue;
+    var health = String(d.health || d.smart || "").toLowerCase();
+    if (health && health !== "ok" && health !== "passed" && health !== "good") bad += 1;
+  }
+  if (bad > 0) return badge("▲" + bad, "warn", bad + " disk needs attention");
+  return null;
+}
+
+function forHub(id, state) {
+  var s = state || {};
+  // Nothing is knowable until the snapshot has answered once.
+  //
+  // Guarding on undefined was not enough, and this is the second time this
+  // bug has been fixed. The singleton's declared defaults are themselves
+  // alarming values -- netKind starts at "disconnected" and bluetooth starts
+  // at false -- so a freshly launched window reported the network down and
+  // the radio off on a machine where neither was true, every single launch.
+  // "Unknown" has to be asked about explicitly, because the resting state of
+  // the data is indistinguishable from bad news.
+  if (s.ready !== true) return null;
+  switch (String(id || "")) {
+    case "services":
+      return servicesBadge(s);
+    case "bluetooth":
+      return bluetoothBadge(s);
+    case "display":
+      return displayBadge(s);
+    case "network":
+      return networkBadge(s);
+    case "software":
+      return softwareBadge(s);
+    case "disks":
+      return disksBadge(s);
+    default:
+      return null;
+  }
+}
+
+// The hubs that can ever produce a badge, so a caller can cheaply skip the
+// rest rather than running the switch for all 27 on every state change.
+function badgedHubs() {
+  return ["services", "bluetooth", "display", "network", "software", "disks"];
+}
+
+function hasBadge(id) {
+  var list = badgedHubs();
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] === id) return true;
+  }
+  return false;
+}

--- a/services/Theme.qml
+++ b/services/Theme.qml
@@ -49,6 +49,15 @@ QtObject {
   readonly property string iconStar: "star-line"
   readonly property string iconStarOn: "star-fill"
   readonly property int radius: 0
+
+  // Sidebar status badges. A step above caption so the glyph reads at a
+  // glance, which is the point of putting state in the nav rather than on
+  // the page.
+  readonly property int badgeSize: Math.max(12, fontSize + 1)
+  // Status ink. Grayscale chrome stays grayscale; only genuine state earns
+  // colour, and only these two.
+  readonly property color ok: "#6f8f6f"
+  readonly property color warn: "#b5904f"
   readonly property real normalFill: ThemeJs.numberToken(root.shellValues, "controls.normal-fill-alpha", 0.04)
   readonly property real hoverFill: ThemeJs.numberToken(root.shellValues, "controls.hover-cursor-fill-alpha", 0.08)
   readonly property real selectedFill: ThemeJs.numberToken(root.shellValues, "controls.selected-fill-alpha", 0.18)

--- a/shell.qml
+++ b/shell.qml
@@ -9,6 +9,7 @@ import "services/Accounts.js" as AccountsJs
 import "services/Hubs.js" as HubsJs
 import "services/Layout.js" as LayoutJs
 import "services/RichUi.js" as RichUi
+import "services/NavStatus.js" as NavStatusJs
 import "components"
 import "pages"
 import "pages/windows" as Win
@@ -26,6 +27,20 @@ ShellRoot {
   readonly property string profileHost: AccountsJs.profileHost(Omarchy.currentUser, Omarchy.hostname)
 
   readonly property var pages: HubsJs.navPages()
+
+  // The only state the sidebar badges read, bound once here so a change
+  // re-evaluates one object rather than every nav row independently.
+  readonly property var navState: ({
+    ready: Omarchy.snapshotReady,
+    systemdUnits: Omarchy.systemdUnits,
+    bluetoothDevices: Omarchy.bluetoothDevices,
+    monitors: Omarchy.monitors,
+    netKind: Omarchy.netKind,
+    netSsid: Omarchy.netSsid,
+    disks: Omarchy.disks,
+    updateAvailable: Omarchy.updateAvailable,
+    atmosUpdateAvailable: Omarchy.atmosUpdateAvailable
+  })
 
   readonly property var groupedPages: {
     var q = root.query
@@ -564,16 +579,40 @@ ShellRoot {
 
                     Text {
                       anchors.left: navIcon.right
-                      anchors.right: parent.right
+                      anchors.right: navBadge.visible ? navBadge.left : parent.right
                       anchors.verticalCenter: parent.verticalCenter
                       anchors.leftMargin: Theme.space
-                      anchors.rightMargin: Theme.pad
+                      anchors.rightMargin: navBadge.visible ? Theme.space : Theme.pad
                       text: modelData.title
                       color: Theme.foreground
                       font.family: Theme.fontFamily
                       font.pixelSize: Theme.labelSize
                       font.bold: navItem.selected
                       elide: Text.ElideRight
+                    }
+
+                    // Live state at the edge of the row. Silent when there
+                    // is nothing to say, which is the common case: a row
+                    // with no badge renders exactly as it does today.
+                    Text {
+                      id: navBadge
+                      anchors.right: parent.right
+                      anchors.rightMargin: Theme.pad
+                      anchors.verticalCenter: parent.verticalCenter
+                      readonly property var badge: NavStatusJs.forHub(
+                        modelData ? modelData.id : "", root.navState)
+                      visible: !!badge
+                      text: badge ? badge.text : ""
+                      color: {
+                        if (!badge) return Theme.muted
+                        if (badge.tone === "warn") return Theme.warn
+                        if (badge.tone === "ok") return Theme.ok
+                        return Theme.muted
+                      }
+                      font.family: Theme.fontFamily
+                      font.pixelSize: Theme.badgeSize
+                      Accessible.role: Accessible.StaticText
+                      Accessible.name: badge ? badge.title : ""
                     }
 
                     MouseArea {


### PR DESCRIPTION
## What it does

Each hub's icon currently says the same thing whether a unit just failed or everything is fine. This makes that column a status readout, so you learn something about the machine without opening a page.

| Hub | Shows | When |
|---|---|---|
| Services | `▲2` | units have failed |
| Displays | `2/3` | an output is disabled |
| Network | `●` / `eth` | connected |
| Bluetooth | `●2` | devices connected |
| Software | `↑2` | updates waiting |
| Disks | `▲1` | SMART is unhappy |

All from state Atmos already collects — `systemdUnits`, `bluetoothDevices`, `monitors`, `netKind`, `disks`, the two update flags. **No new process, no new polling, no new snapshot field.**

## Restraint, on purpose

A sidebar full of badges is noise, so:

- **Only real state earns one.** Silence is the common case and the healthy answer. A hub with nothing to say renders exactly as it does today, and no badge ever shows a `0`.
- **Two inks plus muted.** Grayscale chrome stays grayscale; only genuine state gets colour.
- **A glyph and a small number, never a word.** The column is 220px and the label already owns most of it.

## One thing worth flagging in your code

Network and Bluetooth speak **only on positive evidence** and never report "disconnected" or "off". That is not squeamishness — it is working around something real:

`netKind` is declared `"disconnected"` and `bluetooth` is declared `false` before any snapshot runs. And `snapshotReady` is set in `snapshotProc.onExited` **whether or not `applySnapshot` actually ran** — a read superseded by `shouldApplyRead`, or a failed run, still sets the flag:

```qml
if (exitCode === 0) {
  if (WorkQueue.shouldApplyRead(job, root.ioQueue))
    root.applySnapshot(snapOut.text)     // may be skipped
}
root.snapshotReady = true                 // set regardless
```

So "ready" can be true while the alarming defaults are still in place. During development that put a warning triangle on a working wifi connection. You may want to look at that independently of this PR — it affects anything else that trusts `snapshotReady`.

## Robustness

Every read is defensive, because this runs for every row on every state change. Exercised against `null`, wrong types, arrays of `null`, and prototype-named hub ids (`constructor`, `__proto__`). `shell.qml` binds one `navState` object rather than letting 27 rows each reach into the singleton.

Suite green: 3556 ok, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH