### PR TITLE
feat: hover a theme and see it, instead of reading its name

### DIFF
--- a/components/PrefsSelect.qml
+++ b/components/PrefsSelect.qml
@@ -20,6 +20,22 @@ Item {
 
   signal changed(string value)
 
+  // Emitted as the pointer moves over options, and with "" when it leaves.
+  // A caller that wants to show the value live subscribes; one that does not
+  // is unaffected.
+  signal previewed(string value)
+
+  // Last value handed out, so a repeat of the same option does not re-apply
+  // on every mouse move across one row.
+  property string hoveredOption: ""
+
+  function hoverOption(value) {
+    var next = String(value || "")
+    if (next === root.hoveredOption) return
+    root.hoveredOption = next
+    root.previewed(next)
+  }
+
   implicitWidth: Theme.controlColumnWidth
   implicitHeight: Theme.controlHeight
   width: implicitWidth
@@ -82,6 +98,7 @@ Item {
     changed(next)
     if (value === next) _holding = false
     refreshDisplayLabel()
+    root.hoverOption("")
     popup.close()
   }
 
@@ -196,7 +213,13 @@ Item {
       else list.forceActiveFocus()
       Qt.callLater(root.placePopup)
     }
-    onClosed: root.filter = ""
+    onClosed: {
+      root.filter = ""
+      // Closing by any route -- Escape, click-away, picking a value -- puts
+      // the real value back. Without this, dismissing the popup while a row
+      // is hovered leaves you looking at a preview you never chose.
+      root.hoverOption("")
+    }
 
     background: Rectangle {
       color: Theme.background
@@ -243,6 +266,13 @@ Item {
             verticalAlignment: Text.AlignVCenter
           }
         }
+      }
+
+      // One place that reverts, so there is no race between a row losing the
+      // pointer and its neighbour gaining it.
+      HoverHandler {
+        id: listHover
+        onHoveredChanged: if (!hovered) root.hoverOption("")
       }
 
       ListView {
@@ -307,6 +337,12 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
+            // Enter only. The matching revert is on the list and on the
+            // popup, never on the row -- moving between two adjacent rows
+            // can fire the old row's onExited after the new row's onEntered,
+            // which undoes the preview the instant it is set and makes the
+            // whole feature look like it does nothing.
+            onEntered: root.hoverOption(root.optionValue(modelData))
             onClicked: root.pickValue(root.optionValue(modelData))
           }
         }

--- a/pages/AppearancePage.qml
+++ b/pages/AppearancePage.qml
@@ -156,6 +156,20 @@ PrefsPage {
         options: Omarchy.themes
         enabled: Omarchy.themes.length > 0
         onChanged: function(value) { if (value !== Omarchy.theme) Omarchy.setTheme(value) }
+
+        // Hover a theme and Atmos repaints in it, reverting on the way out.
+        // Atmos is the shell, so it can show you a palette instead of
+        // describing one -- a settings app that is only a client of the
+        // desktop structurally cannot do this.
+        //
+        // Deliberately in-process: applyNamedTheme recolours this window and
+        // writes nothing. Previewing by running the real theme setter would
+        // mean a system write on every pointer move, which thrashes the
+        // machine, races itself, and strands you on the wrong theme the
+        // first time a revert is missed.
+        onPreviewed: function(value) {
+          Theme.applyNamedTheme(value.length > 0 ? value : Omarchy.theme)
+        }
       }
     }
 


### PR DESCRIPTION
Atmos **is** the shell. Not a client asking the desktop to change — the thing doing the drawing. So it can show you a palette rather than describe one.

GNOME, macOS and Windows structurally cannot do this: in all three the settings app is a separate client, and a live preview would mean committing the change and taking it back. This is one of the few places where being the compositor's own shell is a real advantage, and it seemed a shame not to use it.

Hovering an option in the theme picker repaints Atmos in that palette and puts it back when the pointer leaves.

## In-process on purpose

`Theme.applyNamedTheme` recolours the window and **writes nothing**. The tempting version — run the real theme setter on hover, undo on exit — means a system write on every pointer move. It thrashes the machine, races itself when the pointer outruns the writer, and strands you on the wrong theme the first time a revert is missed. A preview that can change something is not a preview.

## The detail that decides whether it works at all

Reverting per row does **not** work. Moving between two adjacent options fires the old row's `onExited` and the new row's `onEntered`, and the order is not guaranteed — so the exit handler frequently runs last and restores the real theme the instant the new one is applied. The feature looks completely dead while firing correctly dozens of times a second. I lost a while to that one.

There is now exactly one place that reverts: the pointer leaving the list, or the popup closing by any route. No two handlers can fight. Repeats are filtered as well, or every mouse move inside a single row re-reads the theme files.

## Generalises

`PrefsSelect` emits `previewed` on option hover and `""` on exit. Any picker whose value can be shown cheaply can subscribe — font size, gaps and animations are the obvious next ones. Callers that do not subscribe are unaffected.

Suite green: 3556 ok, 0 failures.
---

**Take it or leave it.** This is one idea offered on its own, not part of a set you have to accept or reject together — each of these PRs stands alone and none depends on the others. If it is not the direction you want for Atmos, close it without explanation and no hard feelings; you know what this app should be and I do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH