### PR TITLE
feat: say which config file a section writes

### DIFF
--- a/components/PrefsGroup.qml
+++ b/components/PrefsGroup.qml
@@ -15,6 +15,12 @@ Column {
   // Ordinary settings are a heading plus rows.
   property bool framed: false
 
+  // The config file this section writes, and whether Atmos owns it or only
+  // edits inside its own sentinel. Opt-in per section: a section that has
+  // not declared it renders exactly as it does today.
+  property string writesFile: ""
+  property bool writesManaged: true
+
   width: parent ? parent.width : 640
   spacing: Theme.headingGap
   // The section stays in the layout even when it has no matching rows.
@@ -98,6 +104,32 @@ Column {
   readonly property bool showHelp: LayoutJs.sectionHelpOpen(root.helpPayload)
   readonly property int contentPad: Theme.rowPad
   readonly property int titleInset: root.framed ? root.contentPad + Theme.copyInset : Theme.copyInset
+
+  // "What will this touch?" -- the single most trust-building thing a
+  // settings panel can say, and Atmos is unusual in already knowing the
+  // answer, because it tracks managed versus hand-written config for the
+  // sentinel deferral. This only surfaces it.
+  Item {
+    width: parent.width
+    visible: root.writesFile.length > 0 && root.title.length > 0
+    implicitHeight: visible ? provenanceLabel.implicitHeight + Theme.titleGap : 0
+    height: implicitHeight
+
+    Text {
+      id: provenanceLabel
+      anchors.left: parent.left
+      anchors.leftMargin: root.titleInset
+      anchors.right: parent.right
+      anchors.rightMargin: root.titleInset
+      anchors.bottom: parent.bottom
+      text: root.writesFile + (root.writesManaged ? "  ·  managed by Atmos" : "  ·  your file, Atmos edits in place")
+      color: Theme.muted
+      opacity: Theme.metaOpacity
+      font.family: Theme.fontFamily
+      font.pixelSize: Theme.captionSize
+      elide: Text.ElideMiddle
+    }
+  }
 
   Item {
     id: headingHost

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -36,6 +36,7 @@ PrefsPage {
   PrefsGroup {
     title: "Pointer"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Sensitivity and acceleration for the mouse and trackpad. These write a managed block in ~/.config/hypr/input.lua."
 
     SettingRow {
@@ -108,6 +109,7 @@ PrefsPage {
   PrefsGroup {
     title: "Touchpad"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Feel for the trackpad. The on/off switch for the device itself is on Displays."
 
     SettingRow {
@@ -189,6 +191,7 @@ PrefsPage {
   PrefsGroup {
     title: "Keyboard"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Repeat and numlock for Hyprland. The console and login layout stay on System."
 
     SettingRow {


### PR DESCRIPTION
Every settings panel asks you to trust it with your config, and almost none tell you what they are about to touch.

Atmos is unusual here: it already tracks managed versus hand-written config in order to defer to unmanaged gestures. This just surfaces what you already compute.

A section declares `writesFile` and the path renders under the heading as a muted caption. `writesManaged` says whether Atmos owns the file or only edits inside its own sentinel.

## It is already written down, just in the wrong place

`InputPage`'s Pointer section already says *"These write a managed block in ~/.config/hypr/input.lua"* — in its `detail` text. That only shows if you open the section help, which means the reassurance reaches only people who already trusted the app enough to go looking. Putting it in the heading inverts that.

## Scope

Sections, not rows. Rows carry no catalogue key, so per-row provenance would mean editing hundreds of call sites across every page — and a section maps to one file anyway.

Opt-in in both directions: a section that has not declared `writesFile` renders exactly as it does today. Demonstrated on InputPage's three sections; the rest of the app is untouched.

Suite green: 3556 ok, 0 failures.
---

**Take it or leave it.** This is one idea offered on its own, not part of a set you have to accept or reject together — each of these PRs stands alone and none depends on the others. If it is not the direction you want for Atmos, close it without explanation and no hard feelings; you know what this app should be and I do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH