### PR TITLE
feat: Simple and Everything, folding advanced rows without hiding them

### DIFF
--- a/components/PrefsPage.qml
+++ b/components/PrefsPage.qml
@@ -59,6 +59,28 @@ Item {
           font.family: Theme.fontFamily
           font.pixelSize: Theme.pageDescriptionSize
         }
+
+        Row {
+          spacing: Theme.space
+          visible: root.query.length === 0 && !root.embed && root.title.length > 0
+          topPadding: Theme.titleGap
+
+          PrefsButton {
+            text: Disclosure.simple ? "Simple" : "Everything"
+            onClicked: Disclosure.simple = !Disclosure.simple
+          }
+
+          PrefsText {
+            anchors.verticalCenter: parent.verticalCenter
+            text: Disclosure.simple
+              ? "advanced rows folded — search still finds them"
+              : "showing every option"
+            color: Theme.muted
+            opacity: Theme.metaOpacity
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.captionSize
+          }
+        }
       }
 
       Column {

--- a/components/SettingRow.qml
+++ b/components/SettingRow.qml
@@ -21,6 +21,11 @@ Item {
   property string valueText: ""
   property bool stretchControl: false
   property bool available: true
+
+  // Mark a row advanced and it folds away in Simple mode. Folded is not
+  // removed -- search still reaches it and unfolds it, which is the
+  // difference between progressive disclosure and hiding options.
+  property bool advanced: false
   // List rows (wifi SSIDs, devices) stay out of the section modal.
   property bool sectionHelp: true
   // Find a setting indexes SettingRow blocks unless this is false.
@@ -46,7 +51,9 @@ Item {
   }
 
   readonly property bool matches: ShellConfigJs.haystackMatches(query, searchHaystack)
-  readonly property bool shown: available && matches
+  readonly property bool folded: root.advanced && Disclosure.simple
+    && String(root.query || "").length === 0
+  readonly property bool shown: available && matches && !folded
 
   property string favoriteHub: ""
   readonly property string resolvedHubId: {

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -63,6 +63,7 @@ PrefsPage {
 
     SettingRow {
       label: "Acceleration"
+      advanced: true
       description: "Adaptive speeds up as you move. Flat keeps a steady ratio."
       hint: "~/.config/hypr/input.lua · input.accel_profile"
       query: root.query
@@ -84,6 +85,7 @@ PrefsPage {
 
     SettingRow {
       label: "Scroll inertia"
+      advanced: true
       description: "How a high-resolution or free-spin mouse wheel is turned into scroll events. Smooth keeps the fine motion. Stepped turns it into clicks."
       hint: "~/.config/hypr/input.lua · input.emulate_discrete_scroll"
       query: root.query
@@ -174,6 +176,7 @@ PrefsPage {
 
     SettingRow {
       label: "Three-finger drag"
+      advanced: true
       description: "Three fingers down and moving drags, like a click-and-hold."
       hint: "~/.config/hypr/input.lua · input.touchpad.drag_3fg"
       query: root.query

--- a/services/Disclosure.qml
+++ b/services/Disclosure.qml
@@ -1,0 +1,20 @@
+pragma Singleton
+import QtQuick
+
+// Simple / Everything.
+//
+// The two loudest complaints about desktop settings apps are opposites:
+// macOS takes options away and buries what is left; KDE shows you everything
+// at once and drowns you. Both are the same complaint about a missing fold,
+// so add the fold rather than pick a side.
+//
+// Simple never removes anything. A folded row is still found by search and
+// unfolded by it, so an option is always one keystroke away and never a dead
+// end -- which is exactly the part macOS gets wrong, since there a buried
+// setting is unreachable unless you already know its name.
+//
+// Not persisted. A settings app that silently came back in a reduced mode
+// you had forgotten choosing would be indistinguishable from a bug.
+QtObject {
+  property bool simple: false
+}

--- a/services/qmldir
+++ b/services/qmldir
@@ -1,3 +1,4 @@
 singleton Theme 1.0 Theme.qml
 singleton AccountsStore 1.0 AccountsStore.qml
 singleton Omarchy 1.0 Omarchy.qml
+singleton Disclosure 1.0 Disclosure.qml


### PR DESCRIPTION
The two loudest complaints about desktop settings apps are opposites. macOS takes options away and buries what is left; KDE shows you everything at once and drowns you.

Both are the same complaint about a **missing fold**. So add the fold rather than pick a side.

A row declares `advanced: true` and folds away in Simple mode. The page header carries the toggle and says which mode it is in.

## The rule that makes this disclosure rather than hiding

**Folded is not removed.** The fold is skipped whenever a query is active, so search reaches straight past it and surfaces the row anyway. A folded option is one keystroke away and never a dead end — which is exactly the part macOS gets wrong, because there a buried setting is unreachable unless you already know its name.

## Not persisted, deliberately

A settings app that came back in a reduced mode the user had forgotten choosing would be indistinguishable from a bug.

## Opt-in both ways

Nothing folds unless a row asks to, so every page that has not been triaged renders exactly as it does today, and Everything mode is byte-identical regardless.

Demonstrated on InputPage: Acceleration, Scroll inertia and Three-finger drag fold; Sensitivity, Natural scroll and Scroll speed stay, because those are what people actually open that page to change. Which rows deserve which side is your call, not mine — this just provides the mechanism.

Suite green: 3556 ok, 0 failures.
---

**Take it or leave it.** This is one idea offered on its own, not part of a set you have to accept or reject together — each of these PRs stands alone and none depends on the others. If it is not the direction you want for Atmos, close it without explanation and no hard feelings; you know what this app should be and I do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDgvpARXJrbbBGapRFmmcH