### PR TITLE
feat: live theme preview with instant apply

### DIFF
--- a/components/PrefsSelect.qml
+++ b/components/PrefsSelect.qml
@@ -19,6 +19,9 @@ Item {
   readonly property bool useSearch: searchable || (options && options.length >= 8)
 
   signal changed(string value)
+  // Non-committing check: hover or arrow-highlight asks the page to show
+  // what an option looks like. Only pickValue() commits through changed().
+  signal previewed(string value)
 
   implicitWidth: Theme.controlColumnWidth
   implicitHeight: Theme.controlHeight
@@ -88,6 +91,18 @@ Item {
   function pickCurrent() {
     if (list.currentIndex < 0 || list.currentIndex >= (shownOptions || []).length) return
     pickValue(optionValue(shownOptions[list.currentIndex]))
+  }
+
+  function previewValue(next) {
+    next = String(next || "")
+    if (!next) return
+    root.previewed(next)
+  }
+
+  function previewCurrent() {
+    if (!popup.opened) return
+    if (list.currentIndex < 0 || list.currentIndex >= (shownOptions || []).length) return
+    previewValue(optionValue(shownOptions[list.currentIndex]))
   }
 
   function togglePopup() {
@@ -196,7 +211,12 @@ Item {
       else list.forceActiveFocus()
       Qt.callLater(root.placePopup)
     }
-    onClosed: root.filter = ""
+    onClosed: {
+      root.filter = ""
+      // Closing without a pick falls back to the shown value, so a hover
+      // preview resets instead of sticking on an uncommitted option.
+      root.previewValue(root.shownValue)
+    }
 
     background: Rectangle {
       color: Theme.background
@@ -258,6 +278,7 @@ Item {
         highlightFollowsCurrentItem: true
         Keys.onReturnPressed: root.pickCurrent()
         Keys.onSpacePressed: root.pickCurrent()
+        onCurrentIndexChanged: root.previewCurrent()
 
         // Same viewport wheel handler as PrefsFlickable. Delegate MouseAreas
         // swallow the wheel, and a WheelHandler on this ListView never fires.
@@ -286,7 +307,7 @@ Item {
           required property int index
           width: list.width
           height: Theme.rowHeight - 10
-          color: optionMouse.containsMouse || index === list.currentIndex || root.optionValue(modelData) === root.shownValue
+          color: optionMouse.containsMouse || index === list.currentIndex
             ? Theme.fill(Theme.selectedFill)
             : "transparent"
 
@@ -307,6 +328,7 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
+            onEntered: root.previewValue(root.optionValue(modelData))
             onClicked: root.pickValue(root.optionValue(modelData))
           }
         }

--- a/pages/AppearancePage.qml
+++ b/pages/AppearancePage.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Quickshell.Io
 import "../components"
 import "../services"
 import "../services/HyprSunset.js" as HyprSunset
@@ -23,6 +24,60 @@ PrefsPage {
   readonly property string dayParsed: HyprSunset.parseTime(root.dayDraft)
   readonly property string nightParsed: HyprSunset.parseTime(root.nightDraft)
   readonly property bool nightTimesValid: root.dayParsed.length > 0 && root.nightParsed.length > 0
+
+  // Maintainer hover preview: checking the open theme list shows what a
+  // theme looks like without committing. Only a click applies via setTheme.
+  property string themePreviewName: ""
+  property var themePreviewColors: []
+  property var themePreviewImages: []
+  property int themePreviewImageIdx: 0
+  readonly property string themePreviewSource: root.themePreviewImages.length > 0 ? ("file://" + encodeURI(root.themePreviewImages[root.themePreviewImageIdx])) : ""
+
+  function showThemePreview(name) {
+    name = String(name || "")
+    if (!name) return
+    if (name === root.themePreviewName && root.themePreviewColors.length > 0) return
+    root.themePreviewName = name
+    root.themePreviewImageIdx = 0
+    root.themePreviewImages = Theme.previewCandidates(name)
+    root.themePreviewRequest = name
+    root.themePreviewPaths = Theme.colorCandidates(name)
+    root.themePreviewPathIdx = 0
+    root.readPreviewColors()
+  }
+
+  // Async, non-blocking palette resolve. The label and the thumbnail update
+  // the same frame as the hover; the dots follow when the read lands, so
+  // sweeping the list never hitches the UI.
+  property string themePreviewRequest: ""
+  property var themePreviewPaths: []
+  property int themePreviewPathIdx: 0
+  property string themePreviewExpected: ""
+
+  function readPreviewColors() {
+    var paths = root.themePreviewPaths || []
+    if (root.themePreviewPathIdx >= paths.length) {
+      if (root.themePreviewRequest === root.themePreviewName)
+        root.themePreviewColors = Theme.defaultSwatches()
+      return
+    }
+    root.themePreviewExpected = paths[root.themePreviewPathIdx]
+    previewColorsFile.path = root.themePreviewExpected
+  }
+
+  property FileView previewColorsFile: FileView {
+    printErrors: false
+    watchChanges: false
+    onLoaded: {
+      if (previewColorsFile.path !== root.themePreviewExpected) return
+      root.themePreviewColors = Theme.swatchesFromText(previewColorsFile.text())
+    }
+    onLoadFailed: {
+      if (previewColorsFile.path !== root.themePreviewExpected) return
+      root.themePreviewPathIdx++
+      root.readPreviewColors()
+    }
+  }
 
   function openAddTheme() {
     root.themeUrlDraft = ""
@@ -70,11 +125,25 @@ PrefsPage {
     removeThemeConfirm.parent = root.prefsOverlay
     addThemeDialog.parent = root.prefsOverlay
     root.syncExtraToRemove()
+    if (Omarchy.theme.length > 0) root.showThemePreview(Omarchy.theme)
+  }
+
+  // Warm the native theme-preview cache without touching the mut queue: any
+  // queued write bumps writeSeq, which silently discards the in-flight look
+  // snapshot and leaves every dropdown empty. Plain in-page Process instead.
+  Process {
+    id: themePreviewWarmer
+    running: true
+    command: ["bash", "-c", "omarchy theme switcher --preload >/dev/null 2>&1 &"]
   }
 
   Connections {
     target: Omarchy
     function onExtraThemesChanged() { root.syncExtraToRemove() }
+    function onThemeChanged() {
+      if (root.themePreviewName.length === 0 && Omarchy.theme.length > 0)
+        root.showThemePreview(Omarchy.theme)
+    }
     function onNightlightDayChanged() { root.dayDraft = Omarchy.nightlightDay }
     function onNightlightNightChanged() { root.nightDraft = Omarchy.nightlightNight }
   }
@@ -146,16 +215,76 @@ PrefsPage {
 
     SettingRow {
       label: "Current theme"
-      description: "The palette in use right now. The shell and themed apps follow this."
+      description: "The palette in use right now. Open the list and hover a theme to see it first. Click to apply it."
       hint: "omarchy theme set"
       query: root.query
-      keywords: ["appearance", "color", "style", "palette"]
+      keywords: ["appearance", "color", "style", "palette", "preview", "hover"]
 
       PrefsSelect {
         value: Omarchy.theme
         options: Omarchy.themes
         enabled: Omarchy.themes.length > 0
         onChanged: function(value) { if (value !== Omarchy.theme) Omarchy.setTheme(value) }
+        onPreviewed: function(value) { root.showThemePreview(value) }
+      }
+    }
+
+    SettingRow {
+      available: root.themePreviewName.length > 0
+      stretchControl: true
+      label: "Theme preview"
+      description: "Previewing " + root.themePreviewName + ". Click a theme above to apply it."
+      hint: "omarchy theme switcher"
+      query: root.query
+      keywords: ["appearance", "preview", "thumbnail", "hover", "palette", "swatch"]
+
+      Column {
+        width: parent.width
+        spacing: Theme.space
+
+        Row {
+          spacing: Theme.stackGap
+
+          Repeater {
+            model: root.themePreviewColors
+
+            Rectangle {
+              required property var modelData
+              width: Theme.checkSize
+              height: Theme.checkSize
+              color: modelData
+              border.width: Theme.borderWidth
+              border.color: Theme.borderColor()
+            }
+          }
+        }
+
+        Image {
+          visible: root.themePreviewSource.length > 0
+          width: parent.width
+          height: Math.round(parent.width * 9 / 16)
+          fillMode: Image.PreserveAspectCrop
+          asynchronous: true
+          cache: true
+          source: root.themePreviewSource
+          onStatusChanged: {
+            if (status === Image.Error && root.themePreviewImageIdx + 1 < root.themePreviewImages.length)
+              root.themePreviewImageIdx++
+          }
+        }
+      }
+    }
+
+    SettingRow {
+      label: "Theme switcher"
+      description: "Pick from thumbnail previews the same way omarchy theme switcher does."
+      hint: "omarchy theme switcher"
+      query: root.query
+      keywords: ["appearance", "preview", "thumbnail", "picker", "browse", "switcher"]
+
+      PrefsButton {
+        text: "Open switcher…"
+        onClicked: Omarchy.openThemeSwitcher()
       }
     }
 

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -780,10 +780,14 @@ QtObject {
     themeSetProc.running = true
   }
   function openThemeSwitcher() {
-    runCommand(["bash", "-c", "theme=$(omarchy theme switcher || true); [[ -n $theme ]] && omarchy theme set \"$theme\" >/dev/null 2>&1 &"], {
-      key: "theme",
-      refresh: "none"
-    })
+    // Fire-and-forget on its own process, like fireThemeSet: the native
+    // picker blocks waiting for a choice, and holding mutProc that long
+    // stalls every other queued setting. The theme.name watcher picks up
+    // the result as an outside switch.
+    var argv = ["bash", "-c", "theme=$(omarchy theme switcher || true); [[ -n $theme ]] && omarchy theme set \"$theme\" >/dev/null 2>&1 &"]
+    themeSwitcherProc.running = false
+    themeSwitcherProc.command = argv
+    themeSwitcherProc.running = true
   }
   function refreshTheme() { runCommand(["omarchy", "theme", "refresh"]) }
   function openThemeFolder() {
@@ -2974,6 +2978,12 @@ QtObject {
   // a running snapshot read cannot delay it; omarchy-theme-set serializes
   // concurrent switches on its own lock and the theme.name watcher confirms.
   property Process themeSetProc: Process {
+    command: ["true"]
+  }
+
+  // Fire-and-forget native theme picker. The picker blocks waiting for a
+  // choice, so it gets its own process instead of holding the mut queue.
+  property Process themeSwitcherProc: Process {
     command: ["true"]
   }
 

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -131,6 +131,10 @@ QtObject {
   // already shows it optimistically; while set, a snapshot that still
   // reports the old theme is stale and must not flap the label back.
   property string pendingTheme: ""
+  // Themes we clicked away from, newest last. Watcher events that still
+  // carry one of these are pre-swap noise from an in-flight switch, not a
+  // new selection.
+  property var recentThemes: []
   property double themeRequestedAt: 0
   property string background: ""
   property string font: ""
@@ -740,6 +744,12 @@ QtObject {
     if (!name || name === theme) return
     var cmd = SettingsJs.commandFor("theme", name, snapshotData, scriptOpts())
     if (!cmd || cmd.skip) return
+    // Remember the theme we clicked away from: watcher events that still
+    // carry it (or an earlier one) are pre-swap noise, not a new selection.
+    var history = Array.isArray(root.recentThemes) ? root.recentThemes.slice() : []
+    if (history[history.length - 1] !== root.theme) history.push(root.theme)
+    while (history.length > 4) history.shift()
+    root.recentThemes = history
     // Optimistic label: the dropdown shows the new theme on this frame
     // instead of waiting for theme.name and a snapshot round-trip.
     root.applySnapshot(JSON.stringify({ theme: name }))
@@ -2780,15 +2790,27 @@ QtObject {
     var name = ThemeJs.themeNameFromSlug(slug, root.themes)
     if (!name) return
     // Our own request landing clears the optimistic hold and pulls the new
-    // background and templates. A different theme landing well after our own
-    // request came from outside (terminal, switcher); it wins immediately.
-    var confirmed = name === root.pendingTheme
-    if (confirmed) root.pendingTheme = ""
-    else if (Date.now() - root.themeRequestedAt > 5000) root.pendingTheme = ""
+    // background and templates.
+    if (root.pendingTheme.length > 0 && name === root.pendingTheme) {
+      root.pendingTheme = ""
+      root.recentThemes = []
+      if (name !== root.theme)
+        root.applySnapshot(JSON.stringify({ theme: name }))
+      root.scheduleRefresh("look")
+      return
+    }
+    var recent = Date.now() - root.themeRequestedAt < 5000
+    // Pre-swap watcher noise while our switch is in flight: staging touches
+    // current/ before theme.name is rewritten, so the files still carry a
+    // theme we already clicked away from. Never paint that over the steady
+    // optimistic label.
+    if (recent && (root.recentThemes || []).indexOf(name) !== -1) return
+    // Anything else is an outside switch (terminal, native switcher): it
+    // wins immediately and confirmation no longer applies to it.
+    root.pendingTheme = ""
+    root.recentThemes = []
     if (name !== root.theme) {
       root.applySnapshot(JSON.stringify({ theme: name }))
-      root.scheduleRefresh("look")
-    } else if (confirmed) {
       root.scheduleRefresh("look")
     }
   }

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -750,8 +750,13 @@ QtObject {
     // process instead of the mut queue so a busy snapshot read cannot delay
     // the switch, the same way Omarchy's Switch theme action backgrounds it.
     root.fireThemeSet(cmd.argv)
-    // Paint Atmos chrome from the theme files while the detached set runs.
-    Theme.applyNamedTheme(name)
+    // Paint Atmos chrome from the theme files on the next loop, not here:
+    // applyNamedTheme does blocking file reads, and anything blocking in
+    // this handler delays the frame that paints the optimistic label above.
+    // The posted update renders first; the timer then repaints the chrome
+    // while the detached set runs.
+    root.pendingPaint = name
+    themePaintTimer.restart()
   }
   function fireThemeSet(argv) {
     if (!(argv instanceof Array) || argv.length === 0) return
@@ -2948,6 +2953,20 @@ QtObject {
   // concurrent switches on its own lock and the theme.name watcher confirms.
   property Process themeSetProc: Process {
     command: ["true"]
+  }
+
+  // Deferred Atmos chrome paint for setTheme. Rapid clicks coalesce onto the
+  // latest theme; the theme.name watcher repaints again when it lands, so a
+  // dropped intermediate paint is harmless.
+  property string pendingPaint: ""
+  property Timer themePaintTimer: Timer {
+    interval: 1
+    repeat: false
+    onTriggered: {
+      var name = root.pendingPaint
+      root.pendingPaint = ""
+      if (name) Theme.applyNamedTheme(name)
+    }
   }
 
   property Process jobProc: Process {

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -127,6 +127,11 @@ QtObject {
 
   property string lastError: ""
   property string theme: ""
+  // Theme change awaiting confirmation from the theme.name file. The label
+  // already shows it optimistically; while set, a snapshot that still
+  // reports the old theme is stale and must not flap the label back.
+  property string pendingTheme: ""
+  property double themeRequestedAt: 0
   property string background: ""
   property string font: ""
   property int textSize: 12
@@ -733,20 +738,31 @@ QtObject {
   function setTheme(name) {
     name = String(name || "")
     if (!name || name === theme) return
-    Theme.applyNamedTheme(name)
     var cmd = SettingsJs.commandFor("theme", name, snapshotData, scriptOpts())
     if (!cmd || cmd.skip) return
-    // Import argv stays omarchy theme set. Detach here so mutProc does not
-    // wait for omarchy-theme-set to recolor the shell.
-    var argv = ["bash", "-c", "\"$@\" >/dev/null 2>&1 &", "theme-set"]
+    // Optimistic label: the dropdown shows the new theme on this frame
+    // instead of waiting for theme.name and a snapshot round-trip.
+    root.applySnapshot(JSON.stringify({ theme: name }))
+    root.pendingTheme = name
+    root.themeRequestedAt = Date.now()
+    themeConfirmTimer.restart()
+    // Import argv stays omarchy theme set. Fire it on a dedicated detached
+    // process instead of the mut queue so a busy snapshot read cannot delay
+    // the switch, the same way Omarchy's Switch theme action backgrounds it.
+    root.fireThemeSet(cmd.argv)
+    // Paint Atmos chrome from the theme files while the detached set runs.
+    Theme.applyNamedTheme(name)
+  }
+  function fireThemeSet(argv) {
+    if (!(argv instanceof Array) || argv.length === 0) return
+    // Detach here so the theme process does not wait for omarchy-theme-set
+    // to recolor the shell and retint apps.
+    var detached = ["bash", "-c", "\"$@\" >/dev/null 2>&1 &", "theme-set"]
     var i
-    for (i = 0; i < cmd.argv.length; i++) argv.push(cmd.argv[i])
-    runCommand(argv, {
-      key: cmd.coalesceKey || "theme",
-      apply: cmd.apply,
-      refresh: "none",
-      sudo: cmd.sudo === true
-    })
+    for (i = 0; i < argv.length; i++) detached.push(argv[i])
+    themeSetProc.running = false
+    themeSetProc.command = detached
+    themeSetProc.running = true
   }
   function openThemeSwitcher() {
     runCommand(["bash", "-c", "theme=$(omarchy theme switcher || true); [[ -n $theme ]] && omarchy theme set \"$theme\" >/dev/null 2>&1 &"], {
@@ -2758,10 +2774,39 @@ QtObject {
     slug = String(slug || "").replace(/^\s+|\s+$/g, "")
     var name = ThemeJs.themeNameFromSlug(slug, root.themes)
     if (!name) return
+    // Our own request landing clears the optimistic hold and pulls the new
+    // background and templates. A different theme landing well after our own
+    // request came from outside (terminal, switcher); it wins immediately.
+    var confirmed = name === root.pendingTheme
+    if (confirmed) root.pendingTheme = ""
+    else if (Date.now() - root.themeRequestedAt > 5000) root.pendingTheme = ""
     if (name !== root.theme) {
       root.applySnapshot(JSON.stringify({ theme: name }))
       root.scheduleRefresh("look")
+    } else if (confirmed) {
+      root.scheduleRefresh("look")
     }
+  }
+
+  // The detached theme set reports instant success, so confirm against the
+  // theme.name file. A switch that never lands surfaces an error and resyncs
+  // instead of leaving a half-applied desktop behind a success label.
+  function confirmThemeSwitch() {
+    if (!root.pendingTheme.length) return
+    var slug = Theme.currentThemeSlug()
+    var name = ThemeJs.themeNameFromSlug(slug, root.themes)
+    var want = root.pendingTheme
+    root.pendingTheme = ""
+    if (name !== want) {
+      lastError = "Theme change to " + want + " is still on " + (name || "an unknown theme") + ". Try it again."
+      root.scheduleRefresh("all")
+    }
+  }
+
+  property Timer themeConfirmTimer: Timer {
+    interval: 20000
+    repeat: false
+    onTriggered: root.confirmThemeSwitch()
   }
 
   onThemesChanged: {
@@ -2833,8 +2878,20 @@ QtObject {
       var job = root.ioJob
       if (exitCode === 0) {
         root.lastError = ""
-        if (WorkQueue.shouldApplyRead(job, root.ioQueue))
-          root.applySnapshot(snapOut.text)
+        if (WorkQueue.shouldApplyRead(job, root.ioQueue)) {
+          var text = snapOut.text
+          // While a theme switch is pending, the label already shows the new
+          // theme. A snapshot that still reports the previous one is stale;
+          // keep the optimistic value instead of flapping back to it.
+          if (root.pendingTheme.length) {
+            var parsed = SnapshotJs.parseSnapshot(text)
+            if (parsed && parsed.theme && parsed.theme !== root.pendingTheme) {
+              parsed.theme = root.pendingTheme
+              text = JSON.stringify(parsed)
+            }
+          }
+          root.applySnapshot(text)
+        }
       } else {
         root.lastError = String(snapErr.text || "omarchy snapshot failed").replace(/^\s+|\s+$/g, "")
       }
@@ -2884,6 +2941,13 @@ QtObject {
       }
       root.ioFinished()
     }
+  }
+
+  // Fire-and-forget theme applies. Theme switching bypasses the mut queue so
+  // a running snapshot read cannot delay it; omarchy-theme-set serializes
+  // concurrent switches on its own lock and the theme.name watcher confirms.
+  property Process themeSetProc: Process {
+    command: ["true"]
   }
 
   property Process jobProc: Process {

--- a/services/Theme.js
+++ b/services/Theme.js
@@ -119,6 +119,37 @@ function mergeShell(themeValues, userValues) {
   return merged;
 }
 
+function previewExtensions() {
+  return ["png", "jpg", "jpeg", "webp", "gif", "bmp"];
+}
+
+function previewCandidates(name, cacheHome) {
+  var slug = themeSlug(name);
+  if (!slug || slug.indexOf("/") !== -1 || slug.charAt(0) === ".") return [];
+  var base = String(cacheHome || "").replace(/\/+$/, "");
+  if (!base) return [];
+  var dir = base + "/.cache/omarchy/theme-selector/previews/" + slug + ".";
+  var exts = previewExtensions();
+  var out = [];
+  for (var i = 0; i < exts.length; i++) out.push(dir + exts[i]);
+  return out;
+}
+
+function swatchList(parsed) {
+  var src = parsed || {};
+  function hex(value, fallback) {
+    var s = String(value || "");
+    return /^#[0-9A-Fa-f]{6}$/.test(s) ? s : fallback;
+  }
+  return [
+    hex(src.background, "#101315"),
+    hex(src.foreground, "#cacccc"),
+    hex(src.accent, "#cacccc"),
+    hex(src.muted, "#707880"),
+    hex(src.urgent, "#a55555"),
+  ];
+}
+
 function numberToken(values, key, fallback) {
   var n = Number(values && values[key]);
   return isFinite(n) ? n : fallback;

--- a/services/Theme.qml
+++ b/services/Theme.qml
@@ -12,6 +12,7 @@ QtObject {
   readonly property string currentThemePath: currentDir + "/theme"
   readonly property string currentThemeNameFile: currentDir + "/theme.name"
   readonly property string userShellPath: home + "/.config/omarchy/shell.toml"
+  readonly property string previewCacheDir: home + "/.cache/omarchy/theme-selector/previews"
 
   property color foreground: "#cacccc"
   property color background: "#101315"
@@ -165,6 +166,38 @@ QtObject {
     peekFile.reload()
     peekFile.waitForJob()
     return peekFile.text() || ""
+  }
+
+  function previewCandidates(name) {
+    return ThemeJs.previewCandidates(name, root.home)
+  }
+
+  // Non-committing read: a theme's colors.toml without touching the live
+  // current/theme files. Hover previews call this, never setTheme.
+  function readThemeColors(name) {
+    var paths = ThemeJs.themeFileCandidates(name, "colors.toml", root.home)
+    var i
+    for (i = 0; i < paths.length; i++) {
+      var raw = root.readPath(paths[i])
+      if (raw) return ThemeJs.parseColors(raw)
+    }
+    return ThemeJs.parseColors("")
+  }
+
+  function previewSwatches(name) {
+    return ThemeJs.swatchList(root.readThemeColors(name))
+  }
+
+  function colorCandidates(name) {
+    return ThemeJs.themeFileCandidates(name, "colors.toml", root.home)
+  }
+
+  function swatchesFromText(raw) {
+    return ThemeJs.swatchList(ThemeJs.parseColors(raw))
+  }
+
+  function defaultSwatches() {
+    return ThemeJs.swatchList({})
   }
 
   function applyNamedTheme(name) {

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -335,8 +335,19 @@ assert(
   "a stale snapshot keeps the pending theme instead of flapping the label back",
 );
 assert(
-  hoverOmarchySrc.indexOf("var confirmed = name === root.pendingTheme") !== -1 &&
-    hoverOmarchySrc.indexOf("} else if (confirmed) {") !== -1,
+  hoverOmarchySrc.indexOf("root.recentThemes = history") !== -1 &&
+    hoverOmarchySrc.indexOf("property var recentThemes:") !== -1,
+  "setTheme remembers clicked-away themes so pre-swap noise is recognizable",
+);
+assert(
+  hoverOmarchySrc.indexOf(
+    "if (recent && (root.recentThemes || []).indexOf(name) !== -1) return",
+  ) !== -1,
+  "pre-swap watcher noise never paints over the steady optimistic label",
+);
+assert(
+  hoverOmarchySrc.indexOf("if (root.pendingTheme.length > 0 && name === root.pendingTheme) {") !==
+    -1,
   "the theme.name watcher confirms the pending switch and refreshes the look",
 );
 assert(

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -326,6 +326,11 @@ assert(
   "setTheme fires on a dedicated detached process instead of the mut queue",
 );
 assert(
+  hoverOmarchySrc.indexOf("root.pendingPaint = name") !== -1 &&
+    hoverOmarchySrc.indexOf("property Timer themePaintTimer: Timer") !== -1,
+  "setTheme defers the blocking chrome paint so the label frame renders first",
+);
+assert(
   hoverOmarchySrc.indexOf("parsed.theme = root.pendingTheme") !== -1,
   "a stale snapshot keeps the pending theme instead of flapping the label back",
 );

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -326,6 +326,11 @@ assert(
   "setTheme fires on a dedicated detached process instead of the mut queue",
 );
 assert(
+  hoverOmarchySrc.indexOf("property Process themeSwitcherProc: Process") !== -1 &&
+    hoverOmarchySrc.indexOf("themeSwitcherProc.command = argv") !== -1,
+  "the native switcher no longer holds the mut queue while picking",
+);
+assert(
   hoverOmarchySrc.indexOf("root.pendingPaint = name") !== -1 &&
     hoverOmarchySrc.indexOf("property Timer themePaintTimer: Timer") !== -1,
   "setTheme defers the blocking chrome paint so the label frame renders first",

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -186,3 +186,181 @@ assert(
   !shell.haystackMatches("network", shell.joinSearchHaystack(["Theme", "font"])),
   "haystackMatches rejects unrelated rows",
 );
+
+assertEqual(
+  theme.previewExtensions().join(","),
+  "png,jpg,jpeg,webp,gif,bmp",
+  "previewExtensions lists the switcher image types",
+);
+assertEqual(
+  theme.previewCandidates("Tokyo Night", "/home/u")[0],
+  "/home/u/.cache/omarchy/theme-selector/previews/tokyo-night.png",
+  "previewCandidates points at the native switcher cache",
+);
+assertEqual(
+  theme.previewCandidates("Tokyo Night", "/home/u").length,
+  6,
+  "previewCandidates covers every image extension",
+);
+assertEqual(
+  theme.previewCandidates("../x", "/home/u").length,
+  0,
+  "previewCandidates rejects a path slug",
+);
+assertEqual(theme.previewCandidates("x", "").length, 0, "previewCandidates needs a home");
+assertEqual(
+  theme
+    .swatchList({
+      background: "#1a1b26",
+      foreground: "#a9b1d6",
+      accent: "#7aa2f7",
+      muted: "#414868",
+      urgent: "#f7768e",
+    })
+    .join(","),
+  "#1a1b26,#a9b1d6,#7aa2f7,#414868,#f7768e",
+  "swatchList keeps background-first preview order",
+);
+assertEqual(
+  theme.swatchList({}).join(","),
+  "#101315,#cacccc,#cacccc,#707880,#a55555",
+  "swatchList falls back to the default palette",
+);
+
+const hoverSelectSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsSelect.qml"),
+  "utf8",
+);
+assert(
+  hoverSelectSrc.indexOf("signal previewed(string value)") !== -1,
+  "PrefsSelect reports a hovered option without committing",
+);
+assert(
+  hoverSelectSrc.indexOf("onEntered: root.previewValue(") !== -1,
+  "PrefsSelect previews on hover",
+);
+assert(
+  hoverSelectSrc.indexOf("onCurrentIndexChanged: root.previewCurrent()") !== -1,
+  "PrefsSelect previews when arrow keys move the highlight",
+);
+assert(
+  hoverSelectSrc.indexOf("Only pickValue() commits") !== -1,
+  "PrefsSelect documents that only a pick commits",
+);
+assert(
+  hoverSelectSrc.indexOf("root.previewValue(root.shownValue)") !== -1,
+  "PrefsSelect resets the preview to the shown value on close",
+);
+const hoverAppearanceSrc = fs.readFileSync(
+  path.join(__dirname, "..", "pages", "AppearancePage.qml"),
+  "utf8",
+);
+assert(
+  hoverAppearanceSrc.indexOf("onPreviewed: function(value) { root.showThemePreview(value) }") !==
+    -1,
+  "Current theme shows a hover preview instead of applying",
+);
+assert(
+  hoverAppearanceSrc.indexOf('label: "Theme switcher"') !== -1 &&
+    hoverAppearanceSrc.indexOf('text: "Open switcher…"') !== -1 &&
+    hoverAppearanceSrc.indexOf("Omarchy.openThemeSwitcher()") !== -1,
+  "Theme offers the native thumbnail switcher next to the dropdown",
+);
+assert(
+  hoverAppearanceSrc.indexOf("liveApply") === -1 &&
+    hoverAppearanceSrc.indexOf("onHighlighted") === -1,
+  "Current theme hover never calls setTheme",
+);
+assert(
+  hoverAppearanceSrc.indexOf("Nothing is applied until you click a theme.") === -1,
+  "Theme preview keeps no note below the swatches",
+);
+assert(
+  hoverAppearanceSrc.indexOf("Click a theme above to apply it.") !== -1,
+  "Theme preview description still tells how to apply",
+);
+assert(
+  hoverAppearanceSrc.indexOf(
+    "if (Omarchy.theme.length > 0) root.showThemePreview(Omarchy.theme)",
+  ) !== -1 &&
+    hoverAppearanceSrc.indexOf(
+      "if (root.themePreviewName.length === 0 && Omarchy.theme.length > 0)",
+    ) !== -1,
+  "Theme preview starts on the current theme",
+);
+assert(
+  hoverAppearanceSrc.indexOf("Omarchy.ensureThemePreviews()") === -1,
+  "Appearance never warms previews through the mut queue",
+);
+assert(
+  hoverAppearanceSrc.indexOf("root.themePreviewRequest = name") !== -1 &&
+    hoverAppearanceSrc.indexOf("Theme.previewSwatches(") === -1,
+  "hover preview resolves the palette async instead of blocking the UI",
+);
+assert(
+  hoverAppearanceSrc.indexOf("property FileView previewColorsFile: FileView") !== -1 &&
+    hoverAppearanceSrc.indexOf("watchChanges: false") !== -1,
+  "hover preview reads colors through a one-shot FileView",
+);
+assert(
+  hoverAppearanceSrc.indexOf("id: themePreviewWarmer") !== -1 &&
+    hoverAppearanceSrc.indexOf("omarchy theme switcher --preload >/dev/null 2>&1 &") !== -1,
+  "Appearance warms the native preview cache with an in-page Process",
+);
+const hoverOmarchySrc = fs.readFileSync(
+  path.join(__dirname, "..", "services", "Omarchy.qml"),
+  "utf8",
+);
+assert(
+  hoverOmarchySrc.indexOf("ensureThemePreviews") === -1,
+  "no queued preview job can bump writeSeq and discard the look snapshot",
+);
+assert(
+  hoverOmarchySrc.indexOf("root.applySnapshot(JSON.stringify({ theme: name }))") !== -1,
+  "setTheme shows the new theme immediately instead of waiting for a snapshot",
+);
+assert(
+  hoverOmarchySrc.indexOf("function fireThemeSet(argv)") !== -1 &&
+    hoverOmarchySrc.indexOf("property Process themeSetProc: Process") !== -1 &&
+    hoverOmarchySrc.indexOf("root.fireThemeSet(cmd.argv)") !== -1,
+  "setTheme fires on a dedicated detached process instead of the mut queue",
+);
+assert(
+  hoverOmarchySrc.indexOf("parsed.theme = root.pendingTheme") !== -1,
+  "a stale snapshot keeps the pending theme instead of flapping the label back",
+);
+assert(
+  hoverOmarchySrc.indexOf("var confirmed = name === root.pendingTheme") !== -1 &&
+    hoverOmarchySrc.indexOf("} else if (confirmed) {") !== -1,
+  "the theme.name watcher confirms the pending switch and refreshes the look",
+);
+assert(
+  hoverOmarchySrc.indexOf("property string pendingTheme:") !== -1 &&
+    hoverOmarchySrc.indexOf("root.pendingTheme = name") !== -1 &&
+    hoverOmarchySrc.indexOf("themeConfirmTimer.restart()") !== -1,
+  "setTheme tracks the requested theme for confirmation",
+);
+assert(
+  hoverOmarchySrc.indexOf("function confirmThemeSwitch()") !== -1 &&
+    hoverOmarchySrc.indexOf("Theme change to ") !== -1 &&
+    hoverOmarchySrc.indexOf("property Timer themeConfirmTimer: Timer") !== -1,
+  "an unlanded theme switch surfaces an error and resyncs",
+);
+assert(
+  hoverSelectSrc.indexOf("optionMouse.containsMouse || index === list.currentIndex") !== -1 &&
+    hoverSelectSrc.indexOf("root.optionValue(modelData) === root.shownValue") === -1,
+  "popup rows highlight hover and position only, never the committed theme",
+);
+const hoverThemeQml = fs.readFileSync(path.join(__dirname, "..", "services", "Theme.qml"), "utf8");
+assert(
+  hoverThemeQml.indexOf("function readThemeColors(") !== -1 &&
+    hoverThemeQml.indexOf("function previewSwatches(") !== -1 &&
+    hoverThemeQml.indexOf("without touching the live") !== -1,
+  "Theme reads a preview without touching the live theme",
+);
+assert(
+  hoverThemeQml.indexOf("function colorCandidates(") !== -1 &&
+    hoverThemeQml.indexOf("function swatchesFromText(") !== -1 &&
+    hoverThemeQml.indexOf("function defaultSwatches(") !== -1,
+  "Theme exposes async palette pieces for the hover preview",
+);


### PR DESCRIPTION
Live theme previews with instant, flap-free apply.

## What this does

**Live preview (hover/keyboard, no commit)**
- Hovering or arrowing through the Current theme list previews the palette dots and the native switcher thumbnail without applying anything. Only click/Enter commits.
- `components/PrefsSelect.qml`: non-committing `previewed` signal (row hover + highlight move); closing without a pick re-previews the shown value; only `pickValue()` commits.
- `pages/AppearancePage.qml`: Theme preview row (swatches + 16:9 thumbnail), async palette resolve via one-shot FileView, preview cache warmed with an in-page Process (never the mut queue).
- `services/Theme.js` / `services/Theme.qml`: preview cache candidates, non-committing color reads, async swatch helpers.

**Instant apply, steady label**
- `setTheme` (`services/Omarchy.qml`): the label updates optimistically on the same frame; `omarchy theme set` fires detached on a dedicated `themeSetProc` (bypasses the mut queue); the Atmos chrome paint is deferred to a single-shot timer so the label frame renders first; the request is tracked via `pendingTheme` + confirm timer.
- The native switcher (`openThemeSwitcher`) runs on its own `themeSwitcherProc` too: the picker blocks waiting for a choice, and holding `mutProc` that long stalled every other queued setting. The theme.name watcher picks up the result as an outside switch.
- Watcher/snapshot guards: stale snapshots keep the pending theme; pre-swap watcher noise (staging touches `current/` before `theme.name` is rewritten) is recognized via `recentThemes` history and ignored instead of flapping the label; the landed request confirms and refreshes the look; outside switches (terminal, native switcher) win immediately. Unlanded switches still error and resync via `confirmThemeSwitch`.
- `tests/theme.test.js`: assertions locking all of the above.

## Verify

- `npm run lint`, `npm run fmt:check`, `./tests/run` (exit 0), `qmllint services/Omarchy.qml` clean.
- Manual: Appearance -> hover/arrow previews without applying; click/Enter switches label + desktop together with no bounce; native switcher no longer stalls other settings; `omarchy theme set` in a terminal still syncs back.

## Follow-ups (not in this PR)

- Chrome can briefly show pre-swap colors during staging (the desktop has not swapped yet either); the label stays steady.
- Consider shortening the 20s `themeConfirmTimer`.
- Video backgrounds have no thumbnail path yet.
- CHANGELOG entry at the next alpha tag.