### PR TITLE
fix: run background pickers off the mut queue

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -800,16 +800,21 @@ QtObject {
     })
   }
   function openBackgroundSwitcher() {
-    runCommand(["omarchy", "theme", "bg-switcher"], {
-      key: "background",
-      refresh: "all"
-    })
+    // Fire-and-forget on its own process: the image picker blocks waiting
+    // for a choice, and holding mutProc that long stalls every other queued
+    // setting. The background watcher picks up the result.
+    var switcherArgv = ["omarchy", "theme", "bg-switcher"]
+    bgPickerProc.running = false
+    bgPickerProc.command = switcherArgv
+    bgPickerProc.running = true
   }
   function setBackgroundFromFile() {
-    runCommand(["bash", "-c", "path=$(omarchy file select --title \"Set background\" --extensions \"jpg jpeg png gif webp bmp\" || true); [[ -n $path ]] && omarchy theme bg set \"$path\""], {
-      key: "background",
-      refresh: "all"
-    })
+    // Same fire-and-forget: the file picker blocks waiting for a choice.
+    // The background watcher picks up the applied file.
+    var fileArgv = ["bash", "-c", "path=$(omarchy file select --title \"Set background\" --extensions \"jpg jpeg png gif webp bmp\" || true); [[ -n $path ]] && omarchy theme bg set \"$path\""]
+    bgPickerProc.running = false
+    bgPickerProc.command = fileArgv
+    bgPickerProc.running = true
   }
   function openBackgroundFolder() { runCommand(["omarchy", "theme", "bg", "install"]) }
   function cacheBackgrounds() { runCommand(["omarchy", "theme", "bg", "cache"]) }
@@ -2857,6 +2862,12 @@ QtObject {
     onLoaded: root.loadFavorites(text())
     onLoadFailed: root.favoriteItems = []
     onFileChanged: reload()
+  }
+
+  // Fire-and-forget background pickers. Both wait for a user choice, so
+  // they get their own process instead of holding the mut queue.
+  property Process bgPickerProc: Process {
+    command: ["true"]
   }
 
   property Process mutProc: Process {

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -186,3 +186,11 @@ assert(
   !shell.haystackMatches("network", shell.joinSearchHaystack(["Theme", "font"])),
   "haystackMatches rejects unrelated rows",
 );
+
+const bgOmarchySrc = fs.readFileSync(path.join(__dirname, "..", "services", "Omarchy.qml"), "utf8");
+assert(
+  bgOmarchySrc.indexOf("property Process bgPickerProc: Process") !== -1 &&
+    bgOmarchySrc.indexOf("bgPickerProc.command = switcherArgv") !== -1 &&
+    bgOmarchySrc.indexOf("bgPickerProc.command = fileArgv") !== -1,
+  "the background pickers no longer hold the mut queue while picking",
+);


### PR DESCRIPTION
Both background pickers wait for a user choice, and running them through `runCommand` held `mutProc` that whole time, stalling every other queued setting.

## What changed

- `services/Omarchy.qml`: `openBackgroundSwitcher` (image picker) and `setBackgroundFromFile` (file picker) now fire on their own `bgPickerProc` instead of the mut queue. Same fire-and-forget shape as the theme switcher path: reopening kills the previous picker, and the background watcher picks up the result, so the dropped `refresh: all` is covered.
- Fast non-interactive paths (`bg next`, folder open, cache) stay on the queue untouched.
- `tests/theme.test.js`: assertion locking the new wiring.

## Verify

- `npm run lint`, `npm run fmt:check`, `./tests/run` (exit 0), `qmllint services/Omarchy.qml` clean.
- Manual: open the background switcher (or Choose file), and while it is open change another setting — both go through instead of the setting hanging.