### PR TITLE
feat: split refresh rate out of the resolution picker

### DIFF
--- a/pages/DisplaysPage.qml
+++ b/pages/DisplaysPage.qml
@@ -9,7 +9,7 @@ PrefsPage {
   id: root
   hubId: "display"
   title: "Displays"
-  description: "Each monitor keeps its own resolution. Scale and brightness apply to the one you are looking at. On a laptop you also get the built-in panel and its input devices. GPU switching is on Drivers."
+  description: "Each monitor keeps its own resolution and refresh rate. Scale and brightness apply to the one you are looking at. On a laptop you also get the built-in panel and its input devices. GPU switching is on Drivers."
 
   readonly property var scalePresets: [
     { value: "1", label: "100%" },
@@ -59,9 +59,24 @@ PrefsPage {
 
   function resolutionDescription(monitor) {
     var summary = root.monitorSummary(monitor)
-    var n = monitor && Array.isArray(monitor.availableModes) ? monitor.availableModes.length : 0
-    var modes = n > 1 ? (n + " modes on this output. ") : ""
-    return summary + " " + modes + "Picking a mode writes a monitor rule in ~/.config/hypr/monitors.lua."
+    var n = RichUi.monitorResolutions(monitor).length
+    var modes = n > 1 ? (n + " resolutions on this output. ") : ""
+    return summary + " " + modes + "Picking one writes a monitor rule in ~/.config/hypr/monitors.lua. The refresh rate behind it stays."
+  }
+
+  function resolutionValue(monitor) {
+    return RichUi.currentMonitorResolutionValue(monitor)
+  }
+
+  function refreshValue(monitor) {
+    return RichUi.currentMonitorRefreshValue(monitor, root.resolutionValue(monitor))
+  }
+
+  function writeMonitorMode(monitor, resolution, refresh) {
+    var name = monitor && monitor.name ? String(monitor.name) : ""
+    if (!name) return
+    var mode = MonJs.sanitizeMode(String(resolution || "") + "@" + String(refresh || ""))
+    if (mode) Omarchy.patchMonitorRule(name, { mode: mode, disabled: false })
   }
 
   function ruleFor(monitor) {
@@ -159,25 +174,44 @@ PrefsPage {
         label: "Resolution"
         description: root.resolutionDescription(modelData)
         hint: "~/.config/hypr/monitors.lua"
-        detail: "Hyprland's EDID list for this output. Atmos writes the pick as hl.monitor mode."
+        detail: "Every resolution Hyprland's EDID list reports for this output, largest first. Atmos writes the pick together with the refresh rate behind it as hl.monitor mode."
         query: root.query
         keywords: ["monitor", "display", "hdmi", "dp", "edp", "resolution", "refresh"]
 
         Row {
           spacing: Theme.space
           PrefsSelect {
-            value: RichUi.currentMonitorModeValue(modelData)
-            options: RichUi.monitorModeOptions(modelData)
+            value: root.resolutionValue(modelData)
+            options: RichUi.monitorResolutions(modelData)
             enabled: !!(modelData && modelData.name)
             onChanged: function(value) {
-              var mode = MonJs.modeFromHyprctl(value)
-              if (mode) Omarchy.patchMonitorRule(modelData.name, { mode: mode, disabled: false })
+              if (value !== root.resolutionValue(modelData))
+                root.writeMonitorMode(modelData, value, RichUi.currentMonitorRefreshValue(modelData, value))
             }
           }
           PrefsButton {
             text: "Copy"
             enabled: RichUi.monitorModeCopyText(modelData).length > 0
             onClicked: Omarchy.copyText(RichUi.monitorModeCopyText(modelData))
+          }
+        }
+      }
+
+      SettingRow {
+        label: "Refresh rate"
+        description: "How many frames this panel draws per second. Only the rates the resolution above supports are listed."
+        hint: "~/.config/hypr/monitors.lua"
+        detail: "Atmos writes the pick together with the resolution above as hl.monitor mode."
+        query: root.query
+        keywords: ["monitor", "display", "refresh", "hertz", "hz", "fps", "highrr"]
+
+        PrefsSelect {
+          value: root.refreshValue(modelData)
+          options: RichUi.monitorRefreshRates(modelData, root.resolutionValue(modelData))
+          enabled: !!(modelData && modelData.name)
+          onChanged: function(value) {
+            if (value !== root.refreshValue(modelData))
+              root.writeMonitorMode(modelData, root.resolutionValue(modelData), value)
           }
         }
       }

--- a/pages/DisplaysPage.qml
+++ b/pages/DisplaysPage.qml
@@ -174,7 +174,7 @@ PrefsPage {
         label: "Resolution"
         description: root.resolutionDescription(modelData)
         hint: "~/.config/hypr/monitors.lua"
-        detail: "Every resolution Hyprland's EDID list reports for this output, largest first. Atmos writes the pick together with the refresh rate behind it as hl.monitor mode."
+        detail: "Every resolution the output reports, plus standard lower modes, largest first. Atmos writes the pick together with the refresh rate behind it as hl.monitor mode."
         query: root.query
         keywords: ["monitor", "display", "hdmi", "dp", "edp", "resolution", "refresh"]
 

--- a/pages/DisplaysPage.qml
+++ b/pages/DisplaysPage.qml
@@ -100,6 +100,44 @@ PrefsPage {
     return monitor && monitor.enabled === false
   }
 
+  function enabledMonitorCount() {
+    var list = Omarchy.monitors || []
+    var n = 0
+    for (var i = 0; i < list.length; i++) {
+      if (!root.ruleDisabled(list[i])) n++
+    }
+    return n
+  }
+
+  function isMirrorSource(monitor) {
+    var name = monitor && monitor.name ? String(monitor.name) : ""
+    if (!name) return false
+    var list = Omarchy.monitors || []
+    for (var i = 0; i < list.length; i++) {
+      var m = list[i] || {}
+      if (String(m.mirrorOf || "") === name && !root.ruleDisabled(m)) return true
+    }
+    return false
+  }
+
+  // Turning a display off is only safe when something else stays on, and a
+  // display feeding a mirror cannot go off first. Re-enabling is always safe.
+  function canDisable(monitor) {
+    if (!monitor || !monitor.name) return false
+    if (root.ruleDisabled(monitor)) return true
+    if (root.isMirrorSource(monitor)) return false
+    return root.enabledMonitorCount() > 1
+  }
+
+  function disableDescription(monitor) {
+    if (root.ruleDisabled(monitor)) return "Off for now. Turn it back on when you need it."
+    if (root.isMirrorSource(monitor))
+      return "Another display is mirroring this one. Unmirror it first."
+    if (!root.canDisable(monitor))
+      return "This is the only display on, so it has to stay on."
+    return "Keeps the rule so you can turn it back on. Does not delete the output from the file."
+  }
+
   function ruleVrr(monitor) {
     var rule = root.ruleFor(monitor)
     if (rule && rule.vrr != null) return String(rule.vrr)
@@ -241,14 +279,18 @@ PrefsPage {
       SettingRow {
         available: !!(modelData && modelData.name)
         label: "Disable this display"
-        description: "Keeps the rule so you can turn it back on. Does not delete the output from the file."
+        description: root.disableDescription(modelData)
         hint: "hl.monitor disabled"
         query: root.query
         keywords: ["disable", "off", "lid"]
 
         PrefsToggle {
           checked: root.ruleDisabled(modelData)
-          onToggled: Omarchy.patchMonitorRule(modelData.name, { disabled: !root.ruleDisabled(modelData) })
+          enabled: root.canDisable(modelData)
+          onToggled: {
+            if (!root.ruleDisabled(modelData) && !root.canDisable(modelData)) return
+            Omarchy.patchMonitorRule(modelData.name, { disabled: !root.ruleDisabled(modelData) })
+          }
         }
       }
 
@@ -402,12 +444,12 @@ PrefsPage {
   PrefsGroup {
     title: "Layouts"
     query: Omarchy.monitors.length ? root.query : "."
-    detail: "Desk keeps every output on. Laptop keeps the built-in panel. Docked turns the built-in panel off. Each write is a monitor rule in ~/.config/hypr/monitors.lua."
+    detail: "Desk keeps every output on. Laptop keeps the built-in panel and needs one. Docked turns the built-in panel off and needs an external monitor. Each write is a monitor rule in ~/.config/hypr/monitors.lua."
     hint: "~/.config/hypr/monitors.lua"
 
     SettingRow {
       label: "Apply a layout"
-      description: "Uses the outputs Hyprland sees right now."
+      description: "Uses the outputs Hyprland sees right now. Layouts that would leave no display on stay off."
       hint: "hl.monitor"
       query: root.query
       keywords: ["desk", "laptop", "docked", "layout", "profile"]
@@ -420,10 +462,12 @@ PrefsPage {
         }
         PrefsButton {
           text: "Laptop"
+          enabled: Omarchy.internalPresent
           onClicked: Omarchy.applyMonitorLayout("laptop")
         }
         PrefsButton {
           text: "Docked"
+          enabled: Omarchy.externalPresent
           onClicked: Omarchy.applyMonitorLayout("docked")
         }
       }

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -1706,6 +1706,10 @@ QtObject {
     var items = []
     var live = Array.isArray(monitors) ? monitors : []
     var key = String(name || "")
+    // Never write a layout that leaves no display on. The buttons already
+    // gate this; refuse here too so no other caller can zero the outputs.
+    if (key === "laptop" && !internalPresent) return
+    if (key === "docked" && !externalPresent) return
     var i
     for (i = 0; i < live.length; i++) {
       var src = live[i] || {}

--- a/services/RichUi.js
+++ b/services/RichUi.js
@@ -185,8 +185,42 @@ function parseMonitorResolution(raw) {
   return { width: width, height: height, key: width + "x" + height };
 }
 
+// Standard modes users commonly want even when EDID omits them, notably
+// lower ones for performance or compatibility.
+function standardResolutions() {
+  return [
+    "5120x1440",
+    "3440x1440",
+    "3840x2160",
+    "2560x1600",
+    "2560x1440",
+    "2560x1080",
+    "1920x1200",
+    "1920x1080",
+    "1680x1050",
+    "1600x1200",
+    "1600x900",
+    "1440x900",
+    "1400x1050",
+    "1366x768",
+    "1280x1024",
+    "1280x960",
+    "1280x800",
+    "1280x720",
+    "1152x864",
+    "1024x768",
+    "960x540",
+    "854x480",
+    "800x600",
+    "640x480",
+    "640x360",
+  ];
+}
+
 // Every supported resolution on the output, largest first, with no refresh
-// rate attached. Falls back to the live resolution when EDID reports none.
+// rate attached: EDID modes plus standard modes no wider or taller than the
+// largest reported size, so lower choices are always offered and impossible
+// higher ones never are. Falls back to the live resolution when EDID reports none.
 function monitorResolutions(monitor) {
   var list = monitor && Array.isArray(monitor.availableModes) ? monitor.availableModes : [];
   var seen = {};
@@ -208,6 +242,22 @@ function monitorResolutions(monitor) {
   if (live && !seen[live.key]) {
     seen[live.key] = true;
     found.push(live);
+  }
+  var maxWidth = 0;
+  var maxHeight = 0;
+  for (i = 0; i < found.length; i++) {
+    maxWidth = Math.max(maxWidth, found[i].width);
+    maxHeight = Math.max(maxHeight, found[i].height);
+  }
+  if (maxWidth > 0 && maxHeight > 0) {
+    var standards = standardResolutions();
+    for (i = 0; i < standards.length; i++) {
+      var std = parseMonitorResolution(standards[i]);
+      if (!std || seen[std.key]) continue;
+      if (std.width > maxWidth || std.height > maxHeight) continue;
+      seen[std.key] = true;
+      found.push(std);
+    }
   }
   found.sort(function (a, b) {
     return b.width * b.height - a.width * a.height || b.width - a.width;
@@ -265,6 +315,11 @@ function monitorRefreshRates(monitor, resolution) {
   var out = [];
   for (i = 0; i < found.length; i++) {
     out.push({ value: found[i].value, label: formatMonitorHz(found[i].refresh) + " Hz" });
+  }
+  if (out.length === 0) {
+    // Non-EDID resolution with no known rate at all: 60 Hz is the most
+    // compatible pick, so the resolution stays selectable.
+    out.push({ value: "60", label: "60 Hz" });
   }
   return out;
 }

--- a/services/RichUi.js
+++ b/services/RichUi.js
@@ -176,6 +176,116 @@ function monitorModeCopyText(monitor) {
   return label || name;
 }
 
+function parseMonitorResolution(raw) {
+  var m = /^(\d+)\s*[x×]\s*(\d+)$/.exec(String(raw || "").replace(/^\s+|\s+$/g, ""));
+  if (!m) return null;
+  var width = Number(m[1]);
+  var height = Number(m[2]);
+  if (!isFinite(width) || !isFinite(height) || width <= 0 || height <= 0) return null;
+  return { width: width, height: height, key: width + "x" + height };
+}
+
+// Every supported resolution on the output, largest first, with no refresh
+// rate attached. Falls back to the live resolution when EDID reports none.
+function monitorResolutions(monitor) {
+  var list = monitor && Array.isArray(monitor.availableModes) ? monitor.availableModes : [];
+  var seen = {};
+  var found = [];
+  var i;
+  for (i = 0; i < list.length; i++) {
+    var parsed = parseMonitorMode(list[i]);
+    if (!parsed) continue;
+    var res = parseMonitorResolution(parsed.width + "x" + parsed.height);
+    if (!res || seen[res.key]) continue;
+    seen[res.key] = true;
+    found.push(res);
+  }
+  var live = parseMonitorResolution(
+    String(Math.round(Number(monitor && monitor.width)) || "") +
+      "x" +
+      String(Math.round(Number(monitor && monitor.height)) || ""),
+  );
+  if (live && !seen[live.key]) {
+    seen[live.key] = true;
+    found.push(live);
+  }
+  found.sort(function (a, b) {
+    return b.width * b.height - a.width * a.height || b.width - a.width;
+  });
+  var out = [];
+  for (i = 0; i < found.length; i++) {
+    out.push({ value: found[i].key, label: found[i].width + "×" + found[i].height });
+  }
+  return out;
+}
+
+function currentMonitorResolutionValue(monitor) {
+  var live = parseMonitorResolution(
+    String(Math.round(Number(monitor && monitor.width)) || "") +
+      "x" +
+      String(Math.round(Number(monitor && monitor.height)) || ""),
+  );
+  if (live) return live.key;
+  var mode = parseMonitorMode(currentMonitorModeValue(monitor));
+  if (mode) return mode.width + "x" + mode.height;
+  return "";
+}
+
+function monitorRateValue(refresh) {
+  var n = Number(refresh);
+  if (!isFinite(n) || n <= 0) return "";
+  return String(Math.round(n * 100) / 100);
+}
+
+// Every refresh rate the output offers at one resolution, fastest first.
+// Values keep full precision so the written WxH@Hz mode matches EDID.
+function monitorRefreshRates(monitor, resolution) {
+  var res = parseMonitorResolution(resolution);
+  if (!res) return [];
+  var list = monitor && Array.isArray(monitor.availableModes) ? monitor.availableModes : [];
+  var seen = {};
+  var found = [];
+  var i;
+  for (i = 0; i < list.length; i++) {
+    var parsed = parseMonitorMode(list[i]);
+    if (!parsed || parsed.width !== res.width || parsed.height !== res.height) continue;
+    var value = monitorRateValue(parsed.refresh);
+    if (!value || seen[value]) continue;
+    seen[value] = true;
+    found.push({ value: value, refresh: parsed.refresh });
+  }
+  var live = monitorRateValue(monitor && monitor.refresh);
+  if (live && !seen[live]) {
+    seen[live] = true;
+    found.push({ value: live, refresh: Number(monitor.refresh) });
+  }
+  found.sort(function (a, b) {
+    return b.refresh - a.refresh;
+  });
+  var out = [];
+  for (i = 0; i < found.length; i++) {
+    out.push({ value: found[i].value, label: formatMonitorHz(found[i].refresh) + " Hz" });
+  }
+  return out;
+}
+
+function currentMonitorRefreshValue(monitor, resolution) {
+  var rates = monitorRefreshRates(monitor, resolution);
+  if (!rates.length) return "";
+  var live = Number(monitor && monitor.refresh);
+  var best = rates[0].value;
+  if (!isFinite(live) || live <= 0) return best;
+  var bestDiff = 1e9;
+  for (var i = 0; i < rates.length; i++) {
+    var diff = Math.abs(Number(rates[i].value) - live);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = rates[i].value;
+    }
+  }
+  return best;
+}
+
 function parseDiskSpeedLine(line) {
   var text = String(line || "").replace(/^\s+|\s+$/g, "");
   if (!text) return null;

--- a/services/RichUi.js
+++ b/services/RichUi.js
@@ -153,22 +153,6 @@ function currentMonitorModeValue(monitor) {
   return "";
 }
 
-function monitorModeOptions(monitor) {
-  var list = monitor && Array.isArray(monitor.availableModes) ? monitor.availableModes : [];
-  var seen = {};
-  var out = [];
-  function add(raw) {
-    var text = String(raw || "");
-    if (!text || seen[text]) return;
-    var parsed = parseMonitorMode(text);
-    seen[text] = true;
-    out.push({ value: text, label: parsed ? formatMonitorMode(parsed) : text });
-  }
-  for (var i = 0; i < list.length; i++) add(list[i]);
-  add(currentMonitorModeValue(monitor));
-  return out;
-}
-
 function monitorModeCopyText(monitor) {
   var label = formatMonitorMode(currentMonitorModeValue(monitor));
   var name = monitor && monitor.name ? String(monitor.name) : "";

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -840,6 +840,14 @@ assert(
   displaysPageSrc.indexOf('description: "No monitors reported."') !== -1,
   "a missing monitor list says No monitors reported",
 );
+assert(
+  displaysPageSrc.indexOf('label: "Refresh rate"') !== -1 &&
+    displaysPageSrc.indexOf("RichUi.monitorResolutions(modelData)") !== -1 &&
+    displaysPageSrc.indexOf(
+      "RichUi.monitorRefreshRates(modelData, root.resolutionValue(modelData))",
+    ) !== -1,
+  "resolution lists sizes only with refresh rate in its own row behind it",
+);
 const prefsCheckSrc = fs.readFileSync(
   path.join(__dirname, "..", "components", "PrefsCheck.qml"),
   "utf8",

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -841,6 +841,17 @@ assert(
   "a missing monitor list says No monitors reported",
 );
 assert(
+  displaysPageSrc.indexOf("root.canDisable(modelData)") !== -1 &&
+    displaysPageSrc.indexOf("This is the only display on, so it has to stay on.") !== -1 &&
+    displaysPageSrc.indexOf("Another display is mirroring this one.") !== -1,
+  "disabling the last display on, or a mirror source, stays off",
+);
+assert(
+  displaysPageSrc.indexOf("enabled: Omarchy.internalPresent") !== -1 &&
+    displaysPageSrc.indexOf("enabled: Omarchy.externalPresent") !== -1,
+  "layouts that would leave no display on stay off",
+);
+assert(
   displaysPageSrc.indexOf('label: "Refresh rate"') !== -1 &&
     displaysPageSrc.indexOf("RichUi.monitorResolutions(modelData)") !== -1 &&
     displaysPageSrc.indexOf(

--- a/tests/richui.test.js
+++ b/tests/richui.test.js
@@ -611,3 +611,66 @@ assert(ui.confirmIsDestructive("Update") === false, "confirmIsDestructive Update
 assert(ui.confirmIsDestructive("Set up") === false, "confirmIsDestructive Set up");
 assert(ui.confirmIsDestructive("Create") === false, "confirmIsDestructive Create");
 assert(ui.confirmIsDestructive("") === false, "confirmIsDestructive empty");
+
+const edidModes = [
+  "1920x1080@60.00Hz",
+  "1920x1080@143.86Hz",
+  "2560x1440@144.00Hz",
+  "3840x2160@30.00Hz",
+];
+const edidMonitor = { width: 1920, height: 1080, refresh: 60, availableModes: edidModes };
+assertEqual(
+  ui.parseMonitorResolution("2560x1440").key,
+  "2560x1440",
+  "parseMonitorResolution reads WxH",
+);
+assertEqual(ui.parseMonitorResolution("nope"), null, "parseMonitorResolution rejects junk");
+assertEqual(
+  ui
+    .monitorResolutions(edidMonitor)
+    .map(function (o) {
+      return o.value;
+    })
+    .join(","),
+  "3840x2160,2560x1440,1920x1080",
+  "monitorResolutions lists every resolution once, largest first",
+);
+assertEqual(
+  ui.currentMonitorResolutionValue(edidMonitor),
+  "1920x1080",
+  "currentMonitorResolutionValue reads the live size",
+);
+assertEqual(
+  ui
+    .monitorRefreshRates(edidMonitor, "1920x1080")
+    .map(function (o) {
+      return o.value;
+    })
+    .join(","),
+  "143.86,60",
+  "monitorRefreshRates lists one resolution's rates, fastest first",
+);
+assertEqual(
+  ui.currentMonitorRefreshValue(edidMonitor, "1920x1080"),
+  "60",
+  "currentMonitorRefreshValue matches the live rate",
+);
+assertEqual(
+  ui.currentMonitorRefreshValue(
+    { width: 1920, height: 1080, refresh: 0, availableModes: edidModes },
+    "1920x1080",
+  ),
+  "143.86",
+  "currentMonitorRefreshValue falls back to the fastest rate",
+);
+assertEqual(
+  ui.monitorResolutions({ width: 100, height: 100, refresh: 60, availableModes: [] }).length,
+  1,
+  "monitorResolutions synthesizes the live resolution",
+);
+assertEqual(
+  ui.monitorRefreshRates({ width: 100, height: 100, refresh: 60, availableModes: [] }, "100x100")
+    .length,
+  1,
+  "monitorRefreshRates synthesizes the live rate",
+);

--- a/tests/richui.test.js
+++ b/tests/richui.test.js
@@ -45,11 +45,6 @@ assertEqual(
   "currentMonitorModeValue matches availableModes",
 );
 assertEqual(
-  ui.monitorModeOptions({ width: 100, height: 100, refresh: 60, availableModes: [] }).length,
-  1,
-  "monitorModeOptions synthesizes the current mode",
-);
-assertEqual(
   ui.monitorModeCopyText({
     name: "DP-1",
     width: 1920,

--- a/tests/richui.test.js
+++ b/tests/richui.test.js
@@ -625,15 +625,22 @@ assertEqual(
   "parseMonitorResolution reads WxH",
 );
 assertEqual(ui.parseMonitorResolution("nope"), null, "parseMonitorResolution rejects junk");
+const edidValues = ui
+  .monitorResolutions(edidMonitor)
+  .map(function (o) {
+    return o.value;
+  })
+  .join(",");
 assertEqual(
-  ui
-    .monitorResolutions(edidMonitor)
-    .map(function (o) {
-      return o.value;
-    })
-    .join(","),
-  "3840x2160,2560x1440,1920x1080",
-  "monitorResolutions lists every resolution once, largest first",
+  ui.monitorResolutions(edidMonitor)[0].value,
+  "3840x2160",
+  "monitorResolutions sorts largest first",
+);
+assert(
+  edidValues.indexOf("2560x1440") !== -1 &&
+    edidValues.indexOf("1920x1080") !== -1 &&
+    edidValues.indexOf("1280x720") !== -1,
+  "monitorResolutions keeps EDID sizes and adds standards",
 );
 assertEqual(
   ui.currentMonitorResolutionValue(edidMonitor),
@@ -664,9 +671,57 @@ assertEqual(
   "currentMonitorRefreshValue falls back to the fastest rate",
 );
 assertEqual(
-  ui.monitorResolutions({ width: 100, height: 100, refresh: 60, availableModes: [] }).length,
+  ui.monitorRefreshRates({ width: 100, height: 100, refresh: 60, availableModes: [] }, "100x100")
+    .length,
   1,
-  "monitorResolutions synthesizes the live resolution",
+  "monitorRefreshRates synthesizes the live rate",
+);
+const lowEdid = { width: 1920, height: 1080, refresh: 60, availableModes: ["1920x1080@60.00Hz"] };
+const lowValues = ui
+  .monitorResolutions(lowEdid)
+  .map(function (o) {
+    return o.value;
+  })
+  .join(",");
+assertEqual(
+  ui.monitorResolutions(lowEdid)[0].value,
+  "1920x1080",
+  "standard modes still sort largest first",
+);
+assert(
+  lowValues.indexOf("1280x720") !== -1 &&
+    lowValues.indexOf("1024x768") !== -1 &&
+    lowValues.indexOf("800x600") !== -1,
+  "standard lower resolutions are offered too",
+);
+assert(
+  lowValues.indexOf("2560x1440") === -1 && lowValues.indexOf("3840x2160") === -1,
+  "no impossible higher resolution is offered",
+);
+assert(lowValues.indexOf("1600x1200") === -1, "no resolution taller than the panel is offered");
+assert(
+  lowValues.indexOf("1280x1024") !== -1,
+  "a narrower standard resolution still fits under the panel",
+);
+assertEqual(
+  ui
+    .monitorRefreshRates(lowEdid, "1280x720")
+    .map(function (o) {
+      return o.value;
+    })
+    .join(","),
+  "60",
+  "a non-EDID resolution still offers the live rate",
+);
+assertEqual(
+  ui
+    .monitorRefreshRates({ width: 0, height: 0, refresh: 0, availableModes: [] }, "1280x720")
+    .map(function (o) {
+      return o.value;
+    })
+    .join(","),
+  "60",
+  "a resolution with no known rate falls back to 60 Hz",
 );
 assertEqual(
   ui.monitorRefreshRates({ width: 100, height: 100, refresh: 60, availableModes: [] }, "100x100")


### PR DESCRIPTION
The Resolution dropdown listed every WxH@Hz combo, burying sizes among duplicate refresh rates.

## What changed

- `services/RichUi.js`: new `parseMonitorResolution`, `monitorResolutions` (EDID sizes plus standard modes no wider or taller than the largest reported size, so lower choices like 1280x720 are always offered and impossible higher ones never are; live size synthesized when EDID is empty), `monitorRefreshRates` (one resolution's rates, fastest first, full precision so the written mode matches EDID, 60 Hz fallback so non-EDID sizes stay selectable), `currentMonitorResolutionValue` / `currentMonitorRefreshValue` (closest live match, fastest fallback).
- `pages/DisplaysPage.qml`: Resolution row lists sizes only, largest first; a new Refresh rate row right behind it lists that size's rates. Changing either writes both together as `hl.monitor mode` via the existing `patchMonitorRule`, keeping the closest live rate on the other axis. Copy button and summary keep the full mode text.
- Never a black screen: the Disable toggle refuses the last display on and any mirror source (with copy saying why; re-enabling always allowed), and Laptop/Docked layouts gate on `internalPresent` / `externalPresent` in the UI and in `applyMonitorLayout`, since Docked with no external writes the same zero-output state.
- `tests/richui.test.js` + `tests/repo.test.js`: parser coverage (dedup, ordering, standards cap, fallbacks) and row-wiring assertions.

## Verify

- `npm run lint`, `npm run fmt:check`, `./tests/run` (exit 0), `qmllint pages/DisplaysPage.qml` clean.
- Manual: Displays -> each monitor shows all its resolutions including lower standards but nothing above its max; picking a size keeps a valid rate; the written rule is `WxH@Hz`; the disable toggle stays off on a single monitor; Docked stays off with no external.