### PR TITLE
feat: tile Atmos

### DIFF
--- a/packaging/hypr-atmos.lua
+++ b/packaging/hypr-atmos.lua
@@ -1,6 +1,4 @@
--- Float and center the Atmos window.
+-- Tile the Atmos window like other apps.
 -- Install as ~/.config/hypr/atmos.lua and require("hypr.atmos")
 -- from hyprland.lua next to require("hypr.omafetch"), before toggles.
-o.window("dev.csfh.atmos", { float = true })
-o.window("dev.csfh.atmos", { center = true })
-o.window("dev.csfh.atmos", { size = { 960, 680 } })
+o.window("dev.csfh.atmos", { tile = true })

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -33,12 +33,27 @@ TOGGLES_LINE = 'require("default.hypr.toggles")'
 WINDOW_CLASS = "dev.csfh.atmos"
 PREFS_WINDOW_SEED = "\n".join(
     [
+        "-- Tile the Atmos window like other apps.",
+        f'o.window("{WINDOW_CLASS}", {{ tile = true }})',
+    ]
+)
+# The seed above used to float and center the window. Existing installs
+# still carry those exact lines; rewrite only that block so a customized
+# rule is never touched.
+FLOAT_WINDOW_SEED = "\n".join(
+    [
         "-- Float and center the Atmos window.",
         f'o.window("{WINDOW_CLASS}", {{ float = true }})',
         f'o.window("{WINDOW_CLASS}", {{ center = true }})',
         f'o.window("{WINDOW_CLASS}", {{ size = {{ 960, 680 }} }})',
     ]
 )
+
+
+def normalize_prefs_window_seed(text: str) -> str:
+    if FLOAT_WINDOW_SEED in (text or ""):
+        return text.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
+    return text
 
 
 def lua_number(n: float | int) -> str:
@@ -1283,6 +1298,8 @@ def apply(kind: str, path: Path, payload: dict | None, reset: bool) -> str:
     text = path.read_text() if path.exists() else ""
     if kind == "windows" and not text.strip():
         text = PREFS_WINDOW_SEED + "\n"
+    if kind == "windows":
+        text = normalize_prefs_window_seed(text)
     if kind == "look":
         text = strip_sentinel(text, LEGACY_LOOK_BEGIN, LEGACY_LOOK_END)
         begin, end, serialize = LOOK_BEGIN, LOOK_END, serialize_look

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -37,9 +37,18 @@ PREFS_WINDOW_SEED = "\n".join(
         f'o.window("{WINDOW_CLASS}", {{ tile = true }})',
     ]
 )
+FLOAT_SEED_LINES = {
+    f'o.window("{WINDOW_CLASS}", {{ float = true }})',
+    f'o.window("{WINDOW_CLASS}", {{ center = true }})',
+    f'o.window("{WINDOW_CLASS}", {{ size = {{ 960, 680 }} }})',
+}
+FLOAT_SEED_COMMENT = "-- Float and center the Atmos window."
+TILE_SEED_COMMENT = "-- Tile the Atmos window like other apps."
+TILE_SEED_LINE = f'o.window("{WINDOW_CLASS}", {{ tile = true }})'
 # The seed above used to float and center the window. Existing installs
-# still carry those exact lines; rewrite only that block so a customized
-# rule is never touched.
+# still carry those exact lines, either as the bare seed or under the
+# packaging header comments; rewrite only those verbatim lines so a
+# customized rule is never touched.
 FLOAT_WINDOW_SEED = "\n".join(
     [
         "-- Float and center the Atmos window.",
@@ -51,9 +60,28 @@ FLOAT_WINDOW_SEED = "\n".join(
 
 
 def normalize_prefs_window_seed(text: str) -> str:
-    if FLOAT_WINDOW_SEED in (text or ""):
-        return text.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
-    return text
+    src = text or ""
+    if FLOAT_WINDOW_SEED in src:
+        return src.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
+    if TILE_SEED_LINE in src:
+        return src
+    if FLOAT_SEED_COMMENT not in src:
+        return src
+    lines = src.split("\n")
+    if not any(ln.strip() in FLOAT_SEED_LINES for ln in lines):
+        return src
+    kept = [ln for ln in lines if ln.strip() not in FLOAT_SEED_LINES]
+    out = []
+    inserted = False
+    for ln in kept:
+        out.append(ln)
+        if not inserted and ln.strip() == FLOAT_SEED_COMMENT:
+            out.append(TILE_SEED_LINE)
+            inserted = True
+    src = "\n".join(out)
+    if not inserted:
+        src = TILE_SEED_LINE + "\n" + src
+    return src.replace(FLOAT_SEED_COMMENT, TILE_SEED_COMMENT)
 
 
 def lua_number(n: float | int) -> str:

--- a/services/WindowRules.js
+++ b/services/WindowRules.js
@@ -400,10 +400,8 @@ function ensureLayoutRequire(text) {
 
 function prefsSeed() {
   return [
-    "-- Float and center the Atmos window.",
-    'o.window("' + WINDOW_CLASS + '", { float = true })',
-    'o.window("' + WINDOW_CLASS + '", { center = true })',
-    'o.window("' + WINDOW_CLASS + '", { size = { 960, 680 } })',
+    "-- Tile the Atmos window like other apps.",
+    'o.window("' + WINDOW_CLASS + '", { tile = true })',
   ].join("\n");
 }
 

--- a/tests/run
+++ b/tests/run
@@ -1346,8 +1346,10 @@ fi
 if [[ -x scripts/set-hypr-windows.sh ]] && command -v python3 >/dev/null 2>&1; then
   win_home=$(mktemp -d)
   cat >"$win_home/atmos.lua" <<'LUA'
+-- Float and center the Atmos window.
 o.window("dev.csfh.atmos", { float = true })
 o.window("dev.csfh.atmos", { center = true })
+o.window("dev.csfh.atmos", { size = { 960, 680 } })
 LUA
   cat >"$win_home/hyprland.lua" <<'LUA'
 require("hypr.autostart")
@@ -1355,12 +1357,17 @@ require("default.hypr.toggles")
 LUA
   ATMOS_WINDOWS_FILE="$win_home/atmos.lua" ATMOS_HYPRLAND_FILE="$win_home/hyprland.lua" ATMOS_SKIP_HYPR=1 \
     bash scripts/set-hypr-windows.sh '{"items":[{"match":"^Emulator$","placement":"float","center":true,"width":1280,"height":800}]}'
-  grep -q 'o.window("dev.csfh.atmos", { float = true })' "$win_home/atmos.lua"
+  grep -q 'o.window("dev.csfh.atmos", { tile = true })' "$win_home/atmos.lua"
+  if grep -q 'o.window("dev.csfh.atmos", { float = true })' "$win_home/atmos.lua"; then
+    echo "not ok - set-hypr-windows.sh left the float seed"
+    rm -rf "$win_home"
+    exit 1
+  fi
   grep -q -- '-- atmos:windows begin' "$win_home/atmos.lua"
   grep -q 'o.window("^Emulator$", { float = true, center = true, size = { 1280, 800 } })' "$win_home/atmos.lua"
   grep -q 'require("hypr.atmos")' "$win_home/hyprland.lua"
   listed=$(python3 scripts/hypr-sentinel.py windows list "$win_home/atmos.lua")
-  echo "$listed" | jq -e 'map(select(.match == "dev.csfh.atmos" and .managed == false)) | length == 2' >/dev/null
+  echo "$listed" | jq -e 'map(select(.match == "dev.csfh.atmos" and .managed == false)) | length == 1' >/dev/null
   echo "$listed" | jq -e 'map(select(.match == "^Emulator$" and .managed == true)) | length == 1' >/dev/null
   rm -rf "$win_home"
   echo "ok - set-hypr-windows.sh writes a sentinel and ensures the prefs require"
@@ -1399,7 +1406,10 @@ o.bind("SUPER + F", "Files", "nautilus")
 -- atmos:bindings end
 LUA
   cat >"$reset_home/atmos.lua" <<'LUA'
+-- Float and center the Atmos window.
 o.window("dev.csfh.atmos", { float = true })
+o.window("dev.csfh.atmos", { center = true })
+o.window("dev.csfh.atmos", { size = { 960, 680 } })
 -- atmos:windows begin
 o.window("^Emulator$", { float = true })
 -- atmos:windows end
@@ -1446,7 +1456,12 @@ LUA
     rm -rf "$reset_home"
     exit 1
   fi
-  grep -q 'o.window("dev.csfh.atmos", { float = true })' "$reset_home/atmos.lua"
+  grep -q 'o.window("dev.csfh.atmos", { tile = true })' "$reset_home/atmos.lua"
+  if grep -q 'o.window("dev.csfh.atmos", { float = true })' "$reset_home/atmos.lua"; then
+    echo "not ok - reset-atmos.sh left the float seed"
+    rm -rf "$reset_home"
+    exit 1
+  fi
   if grep -q -- '-- atmos:windows begin' "$reset_home/atmos.lua"; then
     echo "not ok - reset-atmos.sh left the windows sentinel"
     rm -rf "$reset_home"

--- a/tests/window-rules.test.js
+++ b/tests/window-rules.test.js
@@ -128,10 +128,60 @@ assertEqual(rules.clampSize(50), 0, "clampSize rejects below 100");
 assertEqual(rules.clampSize(5000), 0, "clampSize rejects above 4000");
 assertEqual(rules.clampSize("nope"), 0, "clampSize rejects NaN");
 assert(
-  rules.prefsSeed().indexOf('o.window("dev.csfh.atmos"') !== -1,
-  "prefsSeed floats the Atmos class",
+  rules.prefsSeed().indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1,
+  "prefsSeed tiles the Atmos class",
 );
-assert(rules.prefsSeed().indexOf("size = { 960, 680 }") !== -1, "prefsSeed sets the Atmos size");
+assert(
+  rules.prefsSeed().indexOf("float") === -1 && rules.prefsSeed().indexOf("center") === -1,
+  "prefsSeed leaves floating and centering out",
+);
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atmos-seed-"));
+  try {
+    const lua = path.join(dir, "atmos.lua");
+    fs.writeFileSync(
+      lua,
+      '-- Float and center the Atmos window.\no.window("dev.csfh.atmos", { float = true })\no.window("dev.csfh.atmos", { center = true })\no.window("dev.csfh.atmos", { size = { 960, 680 } })\n',
+    );
+    const result = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(result.status, 0, "hypr-sentinel.py windows apply exits 0");
+    const written = fs.readFileSync(lua, "utf8");
+    assert(
+      written.indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1 &&
+        written.indexOf("float = true") === -1,
+      "hypr-sentinel.py windows apply migrates the float seed to tile",
+    );
+    fs.writeFileSync(lua, '-- mine\no.window("dev.csfh.atmos", { float = true })\n');
+    const custom = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(custom.status, 0, "hypr-sentinel.py windows apply exits 0 on custom rules");
+    assert(
+      fs.readFileSync(lua, "utf8").indexOf("float = true") !== -1,
+      "hypr-sentinel.py windows apply keeps a customized float rule",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
 assertEqual(
   rules.describe({ placement: "tile", workspace: "5" }),
   "tile \u00b7 workspace 5",

--- a/tests/window-rules.test.js
+++ b/tests/window-rules.test.js
@@ -178,6 +178,29 @@ assert(
       fs.readFileSync(lua, "utf8").indexOf("float = true") !== -1,
       "hypr-sentinel.py windows apply keeps a customized float rule",
     );
+    fs.writeFileSync(
+      lua,
+      '-- Float and center the Atmos window.\n-- Install as ~/.config/hypr/atmos.lua and require("hypr.atmos")\n-- from hyprland.lua next to require("hypr.omafetch"), before toggles.\no.window("dev.csfh.atmos", { float = true })\no.window("dev.csfh.atmos", { center = true })\no.window("dev.csfh.atmos", { size = { 960, 680 } })\n',
+    );
+    const headed = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(headed.status, 0, "hypr-sentinel.py windows apply exits 0 on a packaged header");
+    const headedText = fs.readFileSync(lua, "utf8");
+    assert(
+      headedText.indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1 &&
+        headedText.indexOf("float = true") === -1 &&
+        headedText.indexOf('require("hypr.atmos")') !== -1,
+      "hypr-sentinel.py windows apply migrates under packaging comments",
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
The seeded rule floated, centered, and fixed the prefs window at 960x680. It now tiles.

## What changed

- `packaging/hypr-atmos.lua`, `scripts/hypr-sentinel.py` (`PREFS_WINDOW_SEED`), `services/WindowRules.js` (`prefsSeed()`): seed `o.window("dev.csfh.atmos", { tile = true })` instead of float/center/size. Fresh installs and fresh seeds tile.
- Migration for existing installs: the sentinel rewrites the historical float seed to tile on every windows write and on reset, whether it sits bare or under the packaging header comments. Only those verbatim lines are ever rewritten; a customized rule is left alone.
- No QML change needed: the prefs window is a normal toplevel, so the tile rule applies directly.
- Tests: sentinel migration (bare seed, packaged header, custom-rule preservation) in `tests/window-rules.test.js`; `tests/run` windows/reset fixtures simulate an existing float install and assert tile output.

## Verify

- `npm run lint`, `npm run fmt:check`, `./tests/run` (exit 0), python `ast.parse` on the sentinel clean.
- Live on Hyprland: after migrate + `hyprctl reload`, the window reports `floating: False`. `~/.config/hypr/atmos.lua` carries the tile seed; a hand-customized float rule survives untouched.