### PR TITLE
fix: single-instance lock that dies with Atmos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,4 @@ Atmos is a standalone Quickshell preferences app for Omarchy. Do not import `qs.
 - Keep parsers in `services/*.js` so Node can test them without Quickshell.
 - Do not import `qs.Ui`. Restyle Qt Quick Controls through `Prefs*` wrappers. Visual language lives in `services/Theme.qml`; use those tokens instead of one-off sizes.
 - Do not launch floating terminals for settings work. Long jobs use `Omarchy.runJob` or an in-page `Process`.
+- One Atmos at a time. `scripts/instance-lock.sh` holds `$XDG_RUNTIME_DIR/atmos-$UID.lock` (or `/tmp/atmos-$UID.lock`) on its own fd and `exec`s `tail --pid=$PPID`. Do not use `flock -c`. A second instance sets `lostInstanceLock`; `runCommand` / `runJob` / `enqueueIo` no-op and `shell.qml` opens the already-open dialog from `onCompleted` as well as the changed signal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to Atmos. Each section is a git tag on `main` and `alpha`. Install and in-app Update follow the `alpha` branch.
 
+## Unreleased
+
+### Fixed
+
+- A second Atmos from a different path (install plus a checkout) is refused. Quickshell only keys single-instance on the config path; an app-level flock in `$XDG_RUNTIME_DIR` now dies with the process, and the loser cannot write. ([#27](https://github.com/csfh/atmos/issues/27))
+
 ## [v0.0.1-alpha.17] - 2026-09-09
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,10 @@
 
 **ATMOS_SKIP_HYPR** — Shell env that skips Hypr writes. Lives in `atmos-env.sh` / `apply-settings.sh`, not in JS.
 
+**Instance lock** — App-level `flock` so install + checkout cannot both write `~/.config`. Helper is `scripts/instance-lock.sh`: lock an fd on itself, `exec tail --pid=$parent`. Path is `$XDG_RUNTIME_DIR/atmos-$UID.lock` or `/tmp/atmos-$UID.lock`. `ATMOS_INSTANCE_LOCK` overrides for tests. Lost lock: `Omarchy.lostInstanceLock`; writes no-op.
+
+**ATMOS_INSTANCE_LOCK** — Test override for the instance lock file path.
+
 **Look payload** — A snapshot (or `job.apply`) whose group is `look`. Not the Appearance hub.
 
 **job.apply** — Optional object on an enqueueIo job (`kind` `mut` or `job`). `mutProc` and `jobProc` adopt it on success as an object (no JSON round-trip through the Emit parser), then enqueue the job's refresh group.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Quickshell](https://quickshell.org) preferences window for [Omarchy](https://
 ./bin/atmos
 ```
 
-A second launch focuses the window that is already open. Pass a page if you want to land somewhere specific:
+A second launch of the same install focuses the window that is already open. A second copy from a different path (install plus a checkout) is refused — both would write `~/.config`. Pass a page if you want to land somewhere specific:
 
 ```bash
 ./bin/atmos appearance

--- a/scripts/instance-lock.sh
+++ b/scripts/instance-lock.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Hold an exclusive flock for the life of the parent Atmos process.
+#
+# Quickshell only refuses a second instance of the same -p path, so an
+# install and a checkout can both write ~/.config. This lock is on the
+# app, not the path. flock is kernel-released; a PID file can go stale.
+#
+# Contract:
+#   - Exit 1 immediately if another holder already has the lock.
+#   - Hold the lock on this process, then exec tail. Do not use flock -c
+#     or flock FILE COMMAND: both fork, and the lock fd is inherited by
+#     a grandchild that can outlive Atmos (reparented to init).
+#   - Die with the parent: tail --pid=$parent exits when Atmos disappears,
+#     including SIGKILL. QProcess killing this pid also releases the lock.
+#   - Exit 0 (do not hold) if flock is missing. Refusing to start over a
+#     missing utility is worse than the race this prevents.
+#
+# Lock path: $XDG_RUNTIME_DIR/atmos-$UID.lock, or /tmp/atmos-$UID.lock
+# when XDG_RUNTIME_DIR is unset. Override with ATMOS_INSTANCE_LOCK.
+
+set -euo pipefail
+
+if ! command -v flock >/dev/null 2>&1; then
+  exit 0
+fi
+
+parent=$PPID
+uid=$(id -u)
+dir=${XDG_RUNTIME_DIR:-/tmp}
+lock=${ATMOS_INSTANCE_LOCK:-$dir/atmos-$uid.lock}
+
+# Open the lock file on this process, then exec tail so the same pid
+# keeps the fd. GNU tail --pid exits when the captured parent dies.
+exec 9>"$lock"
+flock -n 9 || exit 1
+exec tail --pid="$parent" --sleep-interval=0.1 -f /dev/null

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -71,6 +71,7 @@ QtObject {
   readonly property string createHookScript: shellDir + "/scripts/create-hook.sh"
   readonly property string setHookSampleScript: shellDir + "/scripts/set-hook-sample.sh"
   readonly property string diagReportScript: shellDir + "/scripts/diag-report.sh"
+  readonly property string instanceLockScript: shellDir + "/scripts/instance-lock.sh"
   readonly property string envFile: Quickshell.env("HOME") + "/.config/environment.d/10-atmos.conf"
   readonly property string presentationFile: Quickshell.env("HOME") + "/.local/state/omarchy/atmos-presentation.json"
   readonly property string favoritesFile: Quickshell.env("HOME") + "/.local/state/omarchy/atmos-favorites.json"
@@ -465,6 +466,10 @@ QtObject {
   }
 
   function startIoJob(job) {
+    if (lostInstanceLock && job.kind !== "read") {
+      ioFinished()
+      return
+    }
     if (job.kind === "read") {
       snapshotProc.command = ["bash", root.snapshotScript, job.group || "all"]
       snapshotProc.running = true
@@ -506,6 +511,7 @@ QtObject {
   }
 
   function runCommand(argv, opts) {
+    if (lostInstanceLock) return
     if (!(argv instanceof Array) || argv.length === 0) return
     opts = opts || {}
     enqueueIo({
@@ -635,7 +641,7 @@ QtObject {
   // Job record: kind ("read"|"mut"|"job"), argv, stdin, key, apply, refresh,
   // sudo, jobKind, onStdoutLine, onFinished. apply is consumed for mut and job.
   function enqueueIo(job) {
-    if (!job) return
+    if (!job || lostInstanceLock) return
     if (job.sudo && !passwordlessSudo) {
       sudoPendingJob = job
       sudoError = ""
@@ -665,8 +671,7 @@ QtObject {
       sudoPendingJob = null
       if (pending) {
         pending.sudo = false
-        WorkQueue.enqueueWrite(ioQueue, pending)
-        kickIo()
+        enqueueIo(pending)
       }
       return
     }
@@ -682,6 +687,7 @@ QtObject {
   }
 
   function runJob(argv, stdinText, kind, opts) {
+    if (lostInstanceLock) return
     if (!(argv instanceof Array) || argv.length === 0) return
     opts = opts || {}
     kind = String(kind || "")
@@ -1804,6 +1810,31 @@ QtObject {
     var header = DiagnosticsJs.reportText(diagnostics)
     if (!header) return
     runJob(["bash", diagReportScript, "agent"], header, "diag-report", { refresh: "none" })
+  }
+
+  // One Atmos at a time.
+  //
+  // Quickshell already refuses a second instance of the same config path,
+  // which is why this looks solved and is not: running one copy from the
+  // install and another from a checkout opens two windows, and both write
+  // the same configuration files. Settings are shared mutable state on disk,
+  // so two writers race and the loser's change is lost silently.
+  //
+  // The lock is on the app, not the path. scripts/instance-lock.sh flocks
+  // an fd on itself and execs tail --pid=$PPID so the holder dies with
+  // Atmos (including SIGKILL). flock -c is unsafe: the lock fd lands on
+  // a grandchild tail that is reparented to init.
+  property bool lostInstanceLock: false
+
+  property Process instanceLock: Process {
+    running: true
+    command: ["bash", root.instanceLockScript]
+    onExited: function (exitCode) {
+      // 1 is flock's "someone else holds it". Any other code means flock is
+      // missing or broken, and refusing to start over a missing utility
+      // would be worse than the race this prevents.
+      if (exitCode === 1) root.lostInstanceLock = true
+    }
   }
 
   function clearLastError() {

--- a/shell.qml
+++ b/shell.qml
@@ -771,6 +771,44 @@ ShellRoot {
       }
     }
 
+    // A second Atmos is refused, and told why. Quitting silently would look
+    // like a crash; continuing would let two windows race over the same
+    // config files. Open from onCompleted as well as the changed signal:
+    // lostInstanceLock may already be true when Connections attaches.
+    Connections {
+      target: Omarchy
+      function onLostInstanceLockChanged() {
+        if (Omarchy.lostInstanceLock) secondInstanceDialog.open()
+      }
+      Component.onCompleted: {
+        if (Omarchy.lostInstanceLock) secondInstanceDialog.open()
+      }
+    }
+
+    PrefsDialog {
+      id: secondInstanceDialog
+      title: "Atmos is already open"
+      closePolicy: Popup.NoAutoClose
+
+      PrefsText {
+        width: parent.width
+        text: "Another Atmos is running on this machine. Two of them would write the same configuration files at the same time, and whichever finished second would quietly overwrite the other, so this one will close.\n\nSwitch to the window that is already open."
+        color: Theme.foreground
+        font.family: Theme.fontFamily
+        font.pixelSize: Theme.labelSize
+        wrapMode: Text.WordWrap
+      }
+
+      Row {
+        anchors.right: parent.right
+        PrefsButton {
+          text: "Close this one"
+          primary: true
+          onClicked: Qt.quit()
+        }
+      }
+    }
+
     PrefsDialog {
       id: sudoModeDialog
       title: "Administrator password"

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1561,7 +1561,10 @@ assert(
   runCommandBody.indexOf("lostInstanceLock") !== -1,
   "runCommand no-ops when the instance lock is lost",
 );
-assert(runJobBody.indexOf("lostInstanceLock") !== -1, "runJob no-ops when the instance lock is lost");
+assert(
+  runJobBody.indexOf("lostInstanceLock") !== -1,
+  "runJob no-ops when the instance lock is lost",
+);
 const enqueueIoStart = omarchySrc.indexOf("function enqueueIo(");
 const enqueueIoEnd = omarchySrc.indexOf("function requestSudoMode(", enqueueIoStart);
 const enqueueIoBody = omarchySrc.slice(enqueueIoStart, enqueueIoEnd);

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1477,6 +1477,9 @@ const updateStart = omarchySrc.indexOf("function updateThemes(");
 const updateEnd = omarchySrc.indexOf("function removeTheme(", updateStart);
 const updateBody = omarchySrc.slice(updateStart, updateEnd);
 assert(updateBody.indexOf('refresh: "look"') !== -1, "updateThemes refreshes look");
+const runCommandStart = omarchySrc.indexOf("function runCommand(");
+const runCommandEnd = omarchySrc.indexOf("function scriptOpts(", runCommandStart);
+const runCommandBody = omarchySrc.slice(runCommandStart, runCommandEnd);
 const runJobStart = omarchySrc.indexOf("function runJob(");
 const runJobEnd = omarchySrc.indexOf("function cancelJob(", runJobStart);
 const runJobBody = omarchySrc.slice(runJobStart, runJobEnd);
@@ -1517,4 +1520,69 @@ const readAt = jobProcSrc.indexOf("enqueueRead", applyAt);
 assert(
   applyAt !== -1 && readAt !== -1 && applyAt < readAt,
   "jobProc calls applyWritePatch before enqueueRead",
+);
+
+const instanceLockScriptSrc = fs.readFileSync(
+  path.join(__dirname, "..", "scripts", "instance-lock.sh"),
+  "utf8",
+);
+assert(
+  instanceLockScriptSrc.indexOf("flock -c") === -1 &&
+    instanceLockScriptSrc.indexOf("exec flock") === -1,
+  "instance-lock.sh does not use flock -c or flock FILE COMMAND (both fork)",
+);
+assert(
+  instanceLockScriptSrc.indexOf("exec 9>") !== -1 &&
+    instanceLockScriptSrc.indexOf("flock -n 9") !== -1 &&
+    instanceLockScriptSrc.indexOf('exec tail --pid="$parent"') !== -1,
+  "instance-lock.sh locks an fd on itself and execs tail --pid of the parent",
+);
+assert(
+  instanceLockScriptSrc.indexOf("id -u") !== -1 &&
+    instanceLockScriptSrc.indexOf("atmos-$uid.lock") !== -1 &&
+    instanceLockScriptSrc.indexOf("/tmp/atmos.lock") === -1,
+  "instance-lock.sh uses a UID-scoped lock path",
+);
+assert(
+  instanceLockScriptSrc.indexOf("ATMOS_INSTANCE_LOCK") !== -1,
+  "instance-lock.sh accepts ATMOS_INSTANCE_LOCK for tests",
+);
+assert(
+  omarchySrc.indexOf("instance-lock.sh") !== -1 &&
+    omarchySrc.indexOf("property bool lostInstanceLock") !== -1 &&
+    omarchySrc.indexOf("property Process instanceLock") !== -1,
+  "Omarchy holds the instance lock through instance-lock.sh",
+);
+assert(
+  omarchySrc.indexOf('flock", "-n"') === -1 && omarchySrc.indexOf("tail -f /dev/null") === -1,
+  "Omarchy does not park a grandchild tail via flock -c",
+);
+assert(
+  runCommandBody.indexOf("lostInstanceLock") !== -1,
+  "runCommand no-ops when the instance lock is lost",
+);
+assert(runJobBody.indexOf("lostInstanceLock") !== -1, "runJob no-ops when the instance lock is lost");
+const enqueueIoStart = omarchySrc.indexOf("function enqueueIo(");
+const enqueueIoEnd = omarchySrc.indexOf("function requestSudoMode(", enqueueIoStart);
+const enqueueIoBody = omarchySrc.slice(enqueueIoStart, enqueueIoEnd);
+assert(
+  enqueueIoBody.indexOf("lostInstanceLock") !== -1,
+  "enqueueIo no-ops when the instance lock is lost",
+);
+assert(shellSrc.indexOf("id: secondInstanceDialog") !== -1, "already-open dialog is a PrefsDialog");
+assert(
+  shellSrc.indexOf('title: "Atmos is already open"') !== -1,
+  "already-open dialog says Atmos is already open",
+);
+const lostLockAt = shellSrc.indexOf("onLostInstanceLockChanged");
+assert(lostLockAt !== -1, "shell watches lostInstanceLock");
+const lostLockWindow = shellSrc.slice(Math.max(0, lostLockAt - 500), lostLockAt + 400);
+assert(
+  lostLockWindow.indexOf("Component.onCompleted") !== -1 &&
+    lostLockWindow.indexOf("secondInstanceDialog.open()") !== -1,
+  "already-open dialog opens from onCompleted as well as the changed signal",
+);
+assert(
+  testsRun.indexOf("instance-lock.sh") !== -1 && testsRun.indexOf("ATMOS_INSTANCE_LOCK") !== -1,
+  "tests/run exercises the instance-lock.sh contract",
 );

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1527,9 +1527,9 @@ const instanceLockScriptSrc = fs.readFileSync(
   "utf8",
 );
 assert(
-  instanceLockScriptSrc.indexOf("flock -c") === -1 &&
-    instanceLockScriptSrc.indexOf("exec flock") === -1,
-  "instance-lock.sh does not use flock -c or flock FILE COMMAND (both fork)",
+  !/^\s*flock -c\b/m.test(instanceLockScriptSrc) &&
+    !/^\s*exec flock\b/m.test(instanceLockScriptSrc),
+  "instance-lock.sh does not invoke flock -c or flock FILE COMMAND (both fork)",
 );
 assert(
   instanceLockScriptSrc.indexOf("exec 9>") !== -1 &&

--- a/tests/run
+++ b/tests/run
@@ -1562,6 +1562,116 @@ else
   echo "ok - skipping bin/atmos symlink root"
 fi
 
+if [[ -x scripts/instance-lock.sh ]] && command -v flock >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+  lock_home=$(mktemp -d)
+  lock_file="$lock_home/atmos.lock"
+  lock_parent=""
+  lock_cleanup() {
+    if [[ -n ${lock_parent:-} ]] && kill -0 "$lock_parent" 2>/dev/null; then
+      kill -9 "$lock_parent" 2>/dev/null || true
+      wait "$lock_parent" 2>/dev/null || true
+    fi
+    rm -rf "$lock_home"
+  }
+  trap lock_cleanup EXIT
+
+  # A wrapper so the helper's $PPID is a process we can SIGKILL without
+  # killing this test script. The helper execs tail --pid=$parent.
+  cat >"$lock_home/wrapper.sh" <<'SH'
+#!/bin/bash
+set -euo pipefail
+ATMOS_INSTANCE_LOCK=$1 bash "$2" &
+wait
+SH
+  chmod +x "$lock_home/wrapper.sh"
+
+  wait_held() {
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+      if ! flock -n "$lock_file" true; then
+        return 0
+      fi
+      sleep 0.05
+    done
+    return 1
+  }
+
+  wait_released() {
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+      if flock -n "$lock_file" true; then
+        return 0
+      fi
+      sleep 0.1
+    done
+    return 1
+  }
+
+  "$lock_home/wrapper.sh" "$lock_file" "$ROOT/scripts/instance-lock.sh" &
+  lock_parent=$!
+  if ! wait_held; then
+    echo "not ok - instance-lock.sh did not acquire the lock"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+
+  set +e
+  timeout 1 env ATMOS_INSTANCE_LOCK="$lock_file" bash "$ROOT/scripts/instance-lock.sh"
+  second_status=$?
+  set -e
+  if [[ $second_status -ne 1 ]]; then
+    echo "not ok - second instance-lock.sh status $second_status, want 1"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+  echo "ok - instance-lock.sh exits 1 while held"
+
+  lock_child=$(ps -eo pid=,ppid= | awk -v p="$lock_parent" '$2 == p { print $1; exit }')
+  if [[ -z $lock_child ]]; then
+    echo "not ok - instance-lock.sh wrapper has no child"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+  kill -9 "$lock_child"
+  if ! wait_released; then
+    echo "not ok - lock survived killing the locker"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+  echo "ok - instance-lock.sh releases when the locker is killed"
+  kill -9 "$lock_parent" 2>/dev/null || true
+  wait "$lock_parent" 2>/dev/null || true
+  lock_parent=""
+
+  "$lock_home/wrapper.sh" "$lock_file" "$ROOT/scripts/instance-lock.sh" &
+  lock_parent=$!
+  if ! wait_held; then
+    echo "not ok - instance-lock.sh did not reacquire for parent-kill"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+  kill -9 "$lock_parent"
+  wait "$lock_parent" 2>/dev/null || true
+  lock_parent=""
+  if ! wait_released; then
+    echo "not ok - lock survived SIGKILL of the parent"
+    lock_cleanup
+    trap - EXIT
+    exit 1
+  fi
+  echo "ok - instance-lock.sh releases when the parent is SIGKILL'd"
+
+  lock_cleanup
+  trap - EXIT
+else
+  echo "ok - skipping instance-lock.sh (flock/timeout not available)"
+fi
+
 if [[ -f scripts/atmos-xdg.sh ]] && command -v python3 >/dev/null 2>&1; then
   menu_home=$(mktemp -d)
   mkdir -p "$menu_home/.config/omarchy/extensions"

--- a/tests/run
+++ b/tests/run
@@ -1581,7 +1581,8 @@ if [[ -x scripts/instance-lock.sh ]] && command -v flock >/dev/null 2>&1 && comm
 #!/bin/bash
 set -euo pipefail
 ATMOS_INSTANCE_LOCK=$1 bash "$2" &
-wait
+# exec so the wrapper pid stays the helper's parent and cleanup is one kill.
+exec sleep 60
 SH
   chmod +x "$lock_home/wrapper.sh"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Quickshell only refuses a second instance of the *same* `-p` path, so an install (`~/.local/share/atmos`) and a checkout can both write `~/.config`. That race is real; #28 identified it correctly.

This PR lands the same idea safely and **supersedes #28** (do not merge #28 as-is).

`scripts/instance-lock.sh` holds `$XDG_RUNTIME_DIR/atmos-$UID.lock` (or `/tmp/atmos-$UID.lock`) on **this** process, then `exec tail --pid=$parent`. That is the contract #28 missed: `flock -c "exec tail -f /dev/null"` forks, the lock fd lands on a grandchild `tail`, and killing Atmos (or QProcess killing `flock`) orphans the lock until logout.

A refused instance is not a live prefs app:

- `runCommand` / `runJob` / `enqueueIo` no-op when `lostInstanceLock` is true
- `startIoJob` drops queued mutations
- The “Atmos is already open” dialog opens from `Component.onCompleted` as well as `onLostInstanceLockChanged` (the property may already be true when Connections attaches)

`tests/run` exercises the helper: held → exit 1; kill the locker → reacquirable; SIGKILL of the parent → reacquirable. `tests/repo.test.js` pins the QML contract.

Related: #27 (dual-instance flock note), #28 (original PR; blockers called out in review).

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f30ccfad-fb13-4e16-bc51-16e5cbcbe5f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f30ccfad-fb13-4e16-bc51-16e5cbcbe5f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

