### PR TITLE
fix: run blocking pickers off the mut queue

### DIFF
--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -247,6 +247,9 @@ QtObject {
   property string jobStdoutBuf: ""
   property var jobStdoutLineCb: null
   property var jobFinishedCb: null
+  property var interactiveApply: null
+  property string interactiveRefresh: "none"
+  property string interactiveKind: ""
   property var wifiQrRows: []
   property int wifiQrSize: 0
   property string wifiQrSsid: ""
@@ -704,6 +707,25 @@ QtObject {
     jobProc.running = false
   }
 
+  // Blocking pickers and region tools (file select, slurp, theme switcher)
+  // stay off ioQueue. mutProc is a single lock; holding it while a dialog
+  // waits stalls every other setting. The wrapper is the Process so a
+  // SIGTERM can kill file-select / slurp children instead of orphaning them.
+  function runInteractive(argv, opts) {
+    if (!(argv instanceof Array) || argv.length === 0) return
+    opts = opts || {}
+    lastError = ""
+    interactiveKind = String(opts.kind || "")
+    interactiveApply = opts.apply && typeof opts.apply === "object" ? opts.apply : null
+    interactiveRefresh = snapshotRefreshGroup(opts.refresh)
+    var cmd = ["bash", "-c", "trap 'trap - INT TERM; kill 0 2>/dev/null; exit 143' INT TERM; \"$@\"", "prefs-interactive"]
+    var i
+    for (i = 0; i < argv.length; i++) cmd.push(argv[i])
+    interactiveProc.running = false
+    interactiveProc.command = cmd
+    interactiveProc.running = true
+  }
+
   function commandFailureText(err, out) {
     var e = String(err || "").replace(/^\s+|\s+$/g, "")
     var o = String(out || "").replace(/^\s+|\s+$/g, "")
@@ -749,8 +771,8 @@ QtObject {
     })
   }
   function openThemeSwitcher() {
-    runCommand(["bash", "-c", "theme=$(omarchy theme switcher || true); [[ -n $theme ]] && omarchy theme set \"$theme\" >/dev/null 2>&1 &"], {
-      key: "theme",
+    runInteractive(["bash", "-c", "theme=$(omarchy theme switcher || true); [[ -n $theme ]] && omarchy theme set \"$theme\" >/dev/null 2>&1 &"], {
+      kind: "theme-switcher",
       refresh: "none"
     })
   }
@@ -800,18 +822,18 @@ QtObject {
     })
   }
   function openBackgroundSwitcher() {
-    runCommand(["omarchy", "theme", "bg-switcher"], {
-      key: "background",
+    runInteractive(["omarchy", "theme", "bg-switcher"], {
+      kind: "background-switcher",
       refresh: "all"
     })
   }
   function setBackgroundFromFile() {
-    runCommand(["bash", "-c", "path=$(omarchy file select --title \"Set background\" --extensions \"jpg jpeg png gif webp bmp\" || true); [[ -n $path ]] && omarchy theme bg set \"$path\""], {
-      key: "background",
+    runInteractive(["bash", "-c", "path=$(omarchy file select --title \"Set background\" --extensions \"jpg jpeg png gif webp bmp\" || true); [[ -n $path ]] && omarchy theme bg set \"$path\""], {
+      kind: "background-file",
       refresh: "all"
     })
   }
-  function openBackgroundFolder() { runCommand(["omarchy", "theme", "bg", "install"]) }
+  function openBackgroundFolder() { launchDetached(["omarchy", "theme", "bg", "install"]) }
   function cacheBackgrounds() { runCommand(["omarchy", "theme", "bg", "cache"]) }
   function setFont(name) {
     name = String(name || "")
@@ -1151,7 +1173,7 @@ QtObject {
     if (!servers) return
     runJob(["bash", setDnsCustomScript, servers], "", "dns-custom")
   }
-  function openAether() { runCommand(["aether"]) }
+  function openAether() { launchDetached(["aether"]) }
 
   function setIdle(screensaver, lock) {
     var saver = Math.round(Number(screensaver)) || 0
@@ -1189,8 +1211,8 @@ QtObject {
       })
       return
     }
-    runCommand(["omarchy", "branding", "screensaver", action], {
-      key: "screensaverBranding",
+    runInteractive(["omarchy", "branding", "screensaver", action], {
+      kind: "screensaver-branding",
       refresh: "all"
     })
   }
@@ -1206,8 +1228,8 @@ QtObject {
       })
       return
     }
-    runCommand(["omarchy", "branding", "about", action], {
-      key: "aboutBranding",
+    runInteractive(["omarchy", "branding", "about", action], {
+      kind: "about-branding",
       refresh: "all"
     })
   }
@@ -2220,7 +2242,7 @@ QtObject {
     dest = String(dest || "slurp")
     if (mode !== "smart" && mode !== "region" && mode !== "windows" && mode !== "fullscreen") return
     if (dest !== "slurp" && dest !== "copy" && dest !== "save") return
-    runCommand(["omarchy", "capture", "screenshot", mode, dest])
+    runInteractive(["omarchy", "capture", "screenshot", mode, dest], { kind: "screenshot" })
   }
   function startScreenrecording(desktopAudio, microphone, webcam, webcamSize, fullscreen) {
     var argv = ["omarchy", "capture", "screenrecording"]
@@ -2231,13 +2253,15 @@ QtObject {
     var size = String(webcamSize || "medium")
     if (size !== "small" && size !== "medium" && size !== "large") size = "medium"
     if (webcam) argv.push("--webcam-size=" + size)
-    runCommand(argv, {
-      key: "recordingActive",
+    runInteractive(argv, {
+      kind: "recording",
       apply: { recordingActive: true, webcamOverlay: webcam === true },
       refresh: "none"
     })
   }
   function stopScreenrecording() {
+    if (interactiveKind === "recording" && interactiveProc.running)
+      interactiveProc.running = false
     runCommand(["omarchy", "capture", "screenrecording", "--stop-recording"], {
       key: "recordingActive",
       apply: { recordingActive: false },
@@ -2245,10 +2269,10 @@ QtObject {
     })
   }
   function captureText() {
-    runCommand(["omarchy", "capture", "text"])
+    runInteractive(["omarchy", "capture", "text"], { kind: "capture-text" })
   }
   function captureQr() {
-    runCommand(["omarchy", "capture", "qr"])
+    runInteractive(["omarchy", "capture", "qr"], { kind: "capture-qr" })
   }
   function resizeWebcam(action) {
     action = String(action || "")
@@ -2275,13 +2299,13 @@ QtObject {
     path = String(path || "")
     if (path.length > 0) {
       if (path.charAt(0) !== "/" || path.indexOf("..") !== -1) return
-      runCommand(["omarchy", "tailscale", "send", machine, path])
+      runInteractive(["omarchy", "tailscale", "send", machine, path], { kind: "tailscale-send" })
       return
     }
-    runCommand(["omarchy", "tailscale", "send", machine])
+    runInteractive(["omarchy", "tailscale", "send", machine], { kind: "tailscale-send" })
   }
   function tailscaleReceive() {
-    runCommand(["omarchy", "tailscale", "receive", "--once"])
+    runInteractive(["omarchy", "tailscale", "receive", "--once"], { kind: "tailscale-receive" })
   }
 
   function runSoftware(argv, kind) {
@@ -2420,7 +2444,7 @@ QtObject {
 
   function launchHerdr() {
     if (!(extras && extras.herdr === true)) return
-    runCommand(["omarchy", "launch", "terminal", "herdr"])
+    launchDetached(["omarchy", "launch", "terminal", "herdr"])
   }
 
   function setNightlightSchedule(day, night, nightOn) {
@@ -2857,6 +2881,38 @@ QtObject {
     onLoaded: root.loadFavorites(text())
     onLoadFailed: root.favoriteItems = []
     onFileChanged: reload()
+  }
+
+  property Process interactiveProc: Process {
+    command: ["true"]
+    stdout: StdioCollector {
+      id: interactiveOut
+      waitForEnd: true
+    }
+    stderr: StdioCollector {
+      id: interactiveErr
+      waitForEnd: true
+    }
+    onExited: function(exitCode) {
+      var apply = root.interactiveApply
+      var refresh = root.interactiveRefresh
+      root.interactiveKind = ""
+      root.interactiveApply = null
+      root.interactiveRefresh = "none"
+      if (exitCode === 143) return
+      if (exitCode !== 0) {
+        var msg = root.commandFailureText(interactiveErr.text, interactiveOut.text)
+        if (!msg) return
+        if (root.stderrLooksLikeFailure(msg))
+          root.lastError = msg
+        else
+          root.lastError = ""
+        return
+      }
+      if (apply) root.applyWritePatch({ apply: apply, key: "" })
+      if (refresh && refresh !== "none")
+        root.scheduleRefresh(refresh)
+    }
   }
 
   property Process mutProc: Process {

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -990,6 +990,57 @@ assert(
 );
 assert(omarchySrc.indexOf("id: mutOut") !== -1, "mutProc keeps stdout for failure text");
 assert(
+  omarchySrc.indexOf("function runInteractive(") !== -1 &&
+    omarchySrc.indexOf("property Process interactiveProc: Process") !== -1 &&
+    omarchySrc.indexOf("prefs-interactive") !== -1 &&
+    omarchySrc.indexOf("kill 0") !== -1,
+  "interactive tools use their own Process and kill the process group on cancel",
+);
+const runInteractiveStart = omarchySrc.indexOf("function runInteractive(");
+const runInteractiveEnd = omarchySrc.indexOf("function commandFailureText(", runInteractiveStart);
+const runInteractiveBody = omarchySrc.slice(runInteractiveStart, runInteractiveEnd);
+assert(
+  runInteractiveBody.indexOf("enqueueIo") === -1 && runInteractiveBody.indexOf("mutProc") === -1,
+  "runInteractive does not hold the mut queue",
+);
+const brandingStart = omarchySrc.indexOf("function setScreensaverBranding(");
+const brandingEnd = omarchySrc.indexOf("function setTimezone(", brandingStart);
+const brandingBody = omarchySrc.slice(brandingStart, brandingEnd);
+assert(
+  brandingBody.indexOf('runInteractive(["omarchy", "branding", "screensaver"') !== -1 &&
+    brandingBody.indexOf('runInteractive(["omarchy", "branding", "about"') !== -1 &&
+    brandingBody.indexOf('runCommand(["omarchy", "branding", "screensaver", "reset"]') !== -1 &&
+    brandingBody.indexOf('runCommand(["omarchy", "branding", "about", "reset"]') !== -1,
+  "branding Choose/Edit stay off the mut queue; reset stays on it",
+);
+const captureStart = omarchySrc.indexOf("function captureScreenshot(");
+const captureEnd = omarchySrc.indexOf("function resizeWebcam(", captureStart);
+const captureBody = omarchySrc.slice(captureStart, captureEnd);
+assert(
+  captureBody.indexOf("runInteractive") !== -1 &&
+    captureBody.indexOf('kind: "screenshot"') !== -1 &&
+    captureBody.indexOf('kind: "recording"') !== -1 &&
+    captureBody.indexOf('kind: "capture-text"') !== -1 &&
+    captureBody.indexOf('kind: "capture-qr"') !== -1 &&
+    captureBody.indexOf("interactiveProc.running = false") !== -1,
+  "capture pickers stay off the mut queue; stop cancels a pending start",
+);
+assert(
+  omarchySrc.indexOf(
+    'function openBackgroundFolder() { launchDetached(["omarchy", "theme", "bg", "install"]) }',
+  ) !== -1 &&
+    omarchySrc.indexOf('function openAether() { launchDetached(["aether"]) }') !== -1 &&
+    omarchySrc.indexOf('launchDetached(["omarchy", "launch", "terminal", "herdr"])') !== -1,
+  "folder and GUI launches detach instead of holding mutProc",
+);
+assert(
+  omarchySrc.indexOf('runInteractive(["omarchy", "theme", "bg-switcher"]') !== -1 &&
+    omarchySrc.indexOf("omarchy file select") !== -1 &&
+    omarchySrc.indexOf('kind: "background-file"') !== -1 &&
+    omarchySrc.indexOf('kind: "theme-switcher"') !== -1,
+  "unused switcher helpers stay off the mut queue if a later UI wires them",
+);
+assert(
   omarchySrc.indexOf("presentationMode = on") !== -1 &&
     omarchySrc.indexOf("WorkQueue.hasQueuedKey(ioQueue, job.key)") !== -1,
   "Presentation Mode updates immediately and a later write skips a stale apply",

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -186,3 +186,29 @@ assert(
   !shell.haystackMatches("network", shell.joinSearchHaystack(["Theme", "font"])),
   "haystackMatches rejects unrelated rows",
 );
+
+const bgPageSrc = fs.readFileSync(
+  path.join(__dirname, "..", "pages", "appearance", "BackgroundPage.qml"),
+  "utf8",
+);
+assert(
+  bgPageSrc.indexOf("FileDialog") !== -1 &&
+    bgPageSrc.indexOf("Omarchy.setBackgroundPath") !== -1 &&
+    bgPageSrc.indexOf("setBackgroundFromFile") === -1 &&
+    bgPageSrc.indexOf("openBackgroundSwitcher") === -1,
+  "Background Choose… is a Qt FileDialog, not the native switcher helpers",
+);
+const bgOmarchySrc = fs.readFileSync(path.join(__dirname, "..", "services", "Omarchy.qml"), "utf8");
+const bgChooseStart = bgOmarchySrc.indexOf("function setBackgroundPath(");
+const bgChooseEnd = bgOmarchySrc.indexOf("function cacheBackgrounds(", bgChooseStart);
+const bgChooseBody = bgOmarchySrc.slice(bgChooseStart, bgChooseEnd);
+assert(
+  bgChooseBody.indexOf("dispatchSetting") !== -1,
+  "setBackgroundPath still applies a picked path through dispatchSetting",
+);
+assert(
+  bgOmarchySrc.indexOf('runInteractive(["omarchy", "theme", "bg-switcher"]') !== -1 &&
+    bgOmarchySrc.indexOf('kind: "background-file"') !== -1 &&
+    bgOmarchySrc.indexOf("function runInteractive(") !== -1,
+  "native background pickers do not hold the mut queue",
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`runCommand` → `enqueueIo` → `mutProc` is a single lock. A tool that waits for the user held that lock and stalled every other setting.

[#40](https://github.com/csfh/atmos/pull/40) moved the unused `openBackgroundSwitcher` / `setBackgroundFromFile` helpers onto their own process. Background → Choose… on main is a Qt `FileDialog` then `setBackgroundPath`, so that PR does not fix a stall users can hit today.

This PR fixes the paths that *are* wired:

- **Idle / System branding Choose…** — `omarchy branding screensaver|about image` runs `omarchy-file-select` (desktop portal, up to 600s)
- **Capture screenshot / text / QR / start recording** — slurp / region pickers
- **Background → Open folder** — `omarchy theme bg install` runs nautilus in the foreground
- **Aether / Herdr** — long-lived GUIs
- **Tailscale send/receive** — transfer or `--once` wait

Those go through `runInteractive` on `interactiveProc` (not the mut queue). Reopening replaces the previous picker. The bash wrapper is the Process so SIGTERM can `kill 0` the file-select / slurp children. Failed commands still set `lastError`; a cancel with no output stays silent. Branding file watchers still refresh `look`. Stop recording cancels a pending start so stop is not queued behind the picker.

Unused switcher helpers (`openThemeSwitcher`, `openBackgroundSwitcher`, `setBackgroundFromFile`) use the same helper so a later UI (e.g. deferred #39) cannot put them back on `mutProc`. No extra dead `bgPickerProc` just to mirror #40.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e1cc329-08b1-4b1e-894a-4af7c4212528?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e1cc329-08b1-4b1e-894a-4af7c4212528&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

