### PR TITLE
feat: glanceable live badges on sidebar hubs

### DIFF
--- a/services/NavStatus.js
+++ b/services/NavStatus.js
@@ -1,0 +1,134 @@
+// Derive a small live badge for each sidebar hub from snapshot state
+// Atmos already holds. Icons stay; this is additive at the row edge.
+//
+// Silence is the common case. A hub with nothing to say renders exactly
+// as it does today, and no badge ever shows a 0. Warn when something is
+// actually wrong. A healthy multi-monitor desk stays silent rather than
+// showing a count. Network and Bluetooth speak only on positive evidence,
+// because snapshotReady can be true while declared defaults (netKind
+// "disconnected", bluetooth false) are still in place.
+//
+// Disks stay silent: disk-inventory.py emits path/name/model/tran/size/
+// info/mounts, not health or SMART. Do not badge a field the snapshot
+// does not have.
+
+function arr(v) {
+  return Array.isArray(v) ? v : [];
+}
+
+function isFailedUnit(row, state) {
+  // Caller passes Systemd.isFailed (shell.qml / Node tests). Do not copy
+  // the failed-unit check; the Services page already owns that definition.
+  if (!state || typeof state.isFailed !== "function") return false;
+  return state.isFailed(row);
+}
+
+// tone: "warn" | "info". text is a glyph plus a small number, or a short
+// kind mark. The column is 220px and the label already owns most of it.
+function badge(text, tone, title) {
+  if (text === null || text === undefined || text === "") return null;
+  return { text: String(text), tone: tone || "info", title: title || "" };
+}
+
+function servicesBadge(state) {
+  var units = arr(state.systemdUnits);
+  var failed = 0;
+  var i;
+  for (i = 0; i < units.length; i++) {
+    if (isFailedUnit(units[i], state)) failed += 1;
+  }
+  if (failed > 0)
+    return badge("▲" + failed, "warn", failed + " failed unit" + (failed === 1 ? "" : "s"));
+  return null;
+}
+
+function bluetoothBadge(state) {
+  var devices = arr(state.bluetoothDevices);
+  var connected = 0;
+  var i;
+  for (i = 0; i < devices.length; i++) {
+    if (devices[i] && devices[i].connected === true) connected += 1;
+  }
+  if (connected > 0) return badge("●" + connected, "info", connected + " connected");
+  return null;
+}
+
+function displayBadge(state) {
+  var monitors = arr(state.monitors);
+  var total = 0;
+  var off = 0;
+  var i;
+  var row;
+  for (i = 0; i < monitors.length; i++) {
+    row = monitors[i];
+    if (!row || typeof row !== "object") continue;
+    total += 1;
+    // Snapshot monitors use enabled (snapshot.sh: enabled: (.disabled != true)).
+    // disabled lives on monitor rules, which this badge does not read.
+    if (row.enabled === false) off += 1;
+  }
+  if (total === 0 || off === 0) return null;
+  return badge(
+    total - off + "/" + total,
+    "warn",
+    off + " output" + (off === 1 ? "" : "s") + " disabled",
+  );
+}
+
+function networkBadge(state) {
+  var kind = String(state.netKind || "").toLowerCase();
+  if (kind === "ethernet") return badge("eth", "info", "Wired");
+  if (kind === "wifi") {
+    var ssid = String(state.netSsid || "");
+    return badge("●", "info", ssid ? "Connected to " + ssid : "Connected");
+  }
+  // disconnected, empty, and anything else stay silent. Positive evidence
+  // only: the singleton declares netKind "disconnected" before a snapshot
+  // runs, and snapshotReady is set even when applySnapshot was skipped.
+  return null;
+}
+
+function systemBadge(state) {
+  var parts = [];
+  if (state.updateAvailable === true) parts.push("Omarchy");
+  if (state.atmosUpdateAvailable === true) parts.push("Atmos");
+  if (parts.length === 0) return null;
+  return badge(
+    "↑" + parts.length,
+    "info",
+    parts.join(" and ") + " update" + (parts.length === 1 ? "" : "s") + " available",
+  );
+}
+
+function forHub(id, state) {
+  var s = state || {};
+  if (s.ready !== true) return null;
+  switch (String(id || "")) {
+    case "services":
+      return servicesBadge(s);
+    case "bluetooth":
+      return bluetoothBadge(s);
+    case "display":
+      return displayBadge(s);
+    case "network":
+      return networkBadge(s);
+    case "system":
+      return systemBadge(s);
+    default:
+      return null;
+  }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    arr: arr,
+    isFailedUnit: isFailedUnit,
+    badge: badge,
+    servicesBadge: servicesBadge,
+    bluetoothBadge: bluetoothBadge,
+    displayBadge: displayBadge,
+    networkBadge: networkBadge,
+    systemBadge: systemBadge,
+    forHub: forHub,
+  };
+}

--- a/services/Theme.qml
+++ b/services/Theme.qml
@@ -49,6 +49,9 @@ QtObject {
   readonly property string iconStar: "star-line"
   readonly property string iconStarOn: "star-fill"
   readonly property int radius: 0
+  // Sidebar status badges. A step above caption so the glyph reads at a
+  // glance. Status ink is Theme.urgent / Theme.muted, not a private green.
+  readonly property int badgeSize: Math.max(12, fontSize + 1)
   readonly property real normalFill: ThemeJs.numberToken(root.shellValues, "controls.normal-fill-alpha", 0.04)
   readonly property real hoverFill: ThemeJs.numberToken(root.shellValues, "controls.hover-cursor-fill-alpha", 0.08)
   readonly property real selectedFill: ThemeJs.numberToken(root.shellValues, "controls.selected-fill-alpha", 0.18)

--- a/shell.qml
+++ b/shell.qml
@@ -8,7 +8,9 @@ import "services"
 import "services/Accounts.js" as AccountsJs
 import "services/Hubs.js" as HubsJs
 import "services/Layout.js" as LayoutJs
+import "services/NavStatus.js" as NavStatusJs
 import "services/RichUi.js" as RichUi
+import "services/Systemd.js" as SystemdJs
 import "components"
 import "pages"
 import "pages/windows" as Win
@@ -26,6 +28,21 @@ ShellRoot {
   readonly property string profileHost: AccountsJs.profileHost(Omarchy.currentUser, Omarchy.hostname)
 
   readonly property var pages: HubsJs.navPages()
+
+  // Fields the sidebar badges read, boxed so the binding list lives in
+  // one place. A change still re-runs forHub on every row; that is cheap
+  // at this size.
+  readonly property var navState: ({
+    ready: Omarchy.snapshotReady,
+    systemdUnits: Omarchy.systemdUnits,
+    bluetoothDevices: Omarchy.bluetoothDevices,
+    monitors: Omarchy.monitors,
+    netKind: Omarchy.netKind,
+    netSsid: Omarchy.netSsid,
+    updateAvailable: Omarchy.updateAvailable,
+    atmosUpdateAvailable: Omarchy.atmosUpdateAvailable,
+    isFailed: SystemdJs.isFailed
+  })
 
   readonly property var groupedPages: {
     var q = root.query
@@ -564,16 +581,34 @@ ShellRoot {
 
                     Text {
                       anchors.left: navIcon.right
-                      anchors.right: parent.right
+                      anchors.right: navBadge.visible ? navBadge.left : parent.right
                       anchors.verticalCenter: parent.verticalCenter
                       anchors.leftMargin: Theme.space
-                      anchors.rightMargin: Theme.pad
+                      anchors.rightMargin: navBadge.visible ? Theme.space : Theme.pad
                       text: modelData.title
                       color: Theme.foreground
                       font.family: Theme.fontFamily
                       font.pixelSize: Theme.labelSize
                       font.bold: navItem.selected
                       elide: Text.ElideRight
+                    }
+
+                    // Live state at the row edge. Silent when there is
+                    // nothing to say, which is the common case.
+                    Text {
+                      id: navBadge
+                      anchors.right: parent.right
+                      anchors.rightMargin: Theme.pad
+                      anchors.verticalCenter: parent.verticalCenter
+                      readonly property var badge: NavStatusJs.forHub(
+                        modelData ? modelData.id : "", root.navState)
+                      visible: !!badge
+                      text: badge ? badge.text : ""
+                      color: badge && badge.tone === "warn" ? Theme.urgent : Theme.muted
+                      font.family: Theme.fontFamily
+                      font.pixelSize: Theme.badgeSize
+                      Accessible.role: Accessible.StaticText
+                      Accessible.name: badge ? badge.title : ""
                     }
 
                     MouseArea {

--- a/tests/nav-status.test.js
+++ b/tests/nav-status.test.js
@@ -1,0 +1,308 @@
+const fs = require("fs");
+const path = require("path");
+const { load, assert, assertEqual } = require("./harness");
+
+const systemd = load("services/Systemd.js");
+const nav = load("services/NavStatus.js");
+
+function ready(extra) {
+  const state = { ready: true, isFailed: systemd.isFailed };
+  if (extra && typeof extra === "object") Object.assign(state, extra);
+  return state;
+}
+
+function expectNull(id, state, description) {
+  assertEqual(nav.forHub(id, state), null, description);
+}
+
+function expectBadge(id, state, text, tone, title, description) {
+  const badge = nav.forHub(id, state);
+  assert(badge && typeof badge === "object", description);
+  assertEqual(badge.text, text, description + " text");
+  assertEqual(badge.tone, tone, description + " tone");
+  if (title !== undefined) assertEqual(badge.title, title, description + " title");
+}
+
+expectNull("services", null, "null state is silent");
+expectNull("services", undefined, "undefined state is silent");
+expectNull("services", "nope", "string state is silent");
+expectNull("services", 0, "number state is silent");
+expectNull("services", [], "array state is silent");
+expectNull("services", {}, "missing ready is silent");
+expectNull(
+  "services",
+  { ready: false, systemdUnits: [{ active: "failed" }] },
+  "ready false is silent",
+);
+expectNull(
+  "services",
+  { ready: "true", systemdUnits: [{ active: "failed" }] },
+  "ready string true is silent",
+);
+expectNull(
+  "network",
+  { ready: true, netKind: "disconnected" },
+  "ready disconnected network is silent",
+);
+expectNull("network", { netKind: "wifi" }, "wifi before ready is silent");
+expectNull("display", { monitors: [{ enabled: false }] }, "disabled output before ready is silent");
+
+expectNull("constructor", ready(), "constructor hub id is silent");
+expectNull("__proto__", ready(), "__proto__ hub id is silent");
+expectNull("toString", ready(), "toString hub id is silent");
+expectNull("", ready(), "empty hub id is silent");
+expectNull(null, ready({ systemdUnits: [{ active: "failed" }] }), "null hub id is silent");
+
+expectNull("services", ready({ systemdUnits: null }), "null systemdUnits is silent");
+expectNull("services", ready({ systemdUnits: "failed" }), "string systemdUnits is silent");
+expectNull(
+  "services",
+  ready({ systemdUnits: { active: "failed" } }),
+  "object systemdUnits is silent",
+);
+expectNull(
+  "services",
+  ready({ systemdUnits: [null, undefined, 0, "x"] }),
+  "junk unit rows are silent",
+);
+expectNull(
+  "services",
+  ready({ systemdUnits: [{ active: "active", sub: "running" }] }),
+  "healthy units are silent",
+);
+
+expectBadge(
+  "services",
+  ready({ systemdUnits: [{ active: "failed", sub: "failed" }] }),
+  "▲1",
+  "warn",
+  "1 failed unit",
+  "one failed unit",
+);
+expectBadge(
+  "services",
+  ready({
+    systemdUnits: [
+      null,
+      { active: "active", sub: "running" },
+      { active: "failed" },
+      { active: "inactive", sub: "failed" },
+    ],
+  }),
+  "▲2",
+  "warn",
+  "2 failed units",
+  "failed units skip nulls and count active or sub",
+);
+assert(systemd.isFailed({ active: "failed" }) === true, "Systemd.isFailed sees active=failed");
+assert(
+  nav.isFailedUnit({ active: "failed" }, ready()) === true,
+  "NavStatus delegates failed units to Systemd.isFailed",
+);
+assert(
+  nav.isFailedUnit({ active: "failed" }, { ready: true }) === false,
+  "NavStatus does not invent a failed-unit check without Systemd.isFailed",
+);
+
+expectNull("display", ready({ monitors: null }), "null monitors are silent");
+expectNull("display", ready({ monitors: {} }), "object monitors are silent");
+expectNull("display", ready({ monitors: [] }), "empty monitors are silent");
+expectNull(
+  "display",
+  ready({ monitors: [{ name: "eDP-1", enabled: true }] }),
+  "one enabled output is silent",
+);
+expectNull(
+  "display",
+  ready({
+    monitors: [
+      { name: "eDP-1", enabled: true },
+      { name: "HDMI-A-1", enabled: true },
+    ],
+  }),
+  "all-enabled multi-monitor is silent",
+);
+expectNull(
+  "display",
+  ready({ monitors: [{ name: "eDP-1", disabled: true }] }),
+  "monitor-rule disabled field is not a snapshot enabled flag",
+);
+
+expectBadge(
+  "display",
+  ready({
+    monitors: [
+      { name: "eDP-1", enabled: true },
+      { name: "HDMI-A-1", enabled: false },
+    ],
+  }),
+  "1/2",
+  "warn",
+  "1 output disabled",
+  "disabled snapshot output uses enabled === false",
+);
+expectBadge(
+  "display",
+  ready({
+    monitors: [
+      null,
+      { name: "eDP-1", enabled: false },
+      { name: "DP-1", enabled: false },
+      { name: "HDMI-A-1", enabled: true },
+    ],
+  }),
+  "1/3",
+  "warn",
+  "2 outputs disabled",
+  "display count skips null rows and still uses enabled",
+);
+
+expectNull("network", ready({ netKind: null }), "null netKind is silent");
+expectNull("network", ready({ netKind: "" }), "empty netKind is silent");
+expectNull("network", ready({ netKind: "disconnected" }), "disconnected is silent");
+expectNull("network", ready({ netKind: "DISCONNECTED" }), "uppercase disconnected is silent");
+expectNull("network", ready({ bluetooth: false }), "bluetooth default is not network evidence");
+expectBadge(
+  "network",
+  ready({ netKind: "ethernet" }),
+  "eth",
+  "info",
+  "Wired",
+  "ethernet is positive evidence",
+);
+expectBadge(
+  "network",
+  ready({ netKind: "Ethernet" }),
+  "eth",
+  "info",
+  "Wired",
+  "ethernet kind is case-insensitive",
+);
+expectBadge(
+  "network",
+  ready({ netKind: "wifi", netSsid: "home" }),
+  "●",
+  "info",
+  "Connected to home",
+  "wifi is positive evidence",
+);
+expectBadge(
+  "network",
+  ready({ netKind: "wifi", netSsid: "" }),
+  "●",
+  "info",
+  "Connected",
+  "wifi without ssid still counts as connected",
+);
+
+expectNull("bluetooth", ready({ bluetoothDevices: null }), "null bluetooth devices are silent");
+expectNull(
+  "bluetooth",
+  ready({ bluetoothDevices: [{ name: "buds" }] }),
+  "unconnected device is silent",
+);
+expectNull(
+  "bluetooth",
+  ready({ bluetoothDevices: [{ connected: false }] }),
+  "connected false is not evidence",
+);
+expectBadge(
+  "bluetooth",
+  ready({
+    bluetoothDevices: [null, { connected: true }, { connected: true, name: "keyboard" }],
+  }),
+  "●2",
+  "info",
+  "2 connected",
+  "connected true is positive evidence",
+);
+
+expectNull(
+  "software",
+  ready({ updateAvailable: true, atmosUpdateAvailable: true }),
+  "updates do not hang on Software",
+);
+expectNull(
+  "system",
+  ready({ updateAvailable: false, atmosUpdateAvailable: false }),
+  "no updates is silent",
+);
+expectBadge(
+  "system",
+  ready({ updateAvailable: true }),
+  "↑1",
+  "info",
+  "Omarchy update available",
+  "Omarchy update hangs on System",
+);
+expectBadge(
+  "system",
+  ready({ atmosUpdateAvailable: true }),
+  "↑1",
+  "info",
+  "Atmos update available",
+  "Atmos update hangs on System",
+);
+expectBadge(
+  "system",
+  ready({ updateAvailable: true, atmosUpdateAvailable: true }),
+  "↑2",
+  "info",
+  "Omarchy and Atmos updates available",
+  "both updates name the sources",
+);
+
+expectNull(
+  "disks",
+  ready({
+    disks: [
+      {
+        path: "/dev/nvme0n1",
+        name: "nvme0n1",
+        model: "SSD",
+        tran: "nvme",
+        size: 512,
+        info: "/dev/nvme0n1",
+        mounts: [{ target: "/", source: "/dev/nvme0n1p2" }],
+        smart: "FAILING",
+        health: "FAILING",
+      },
+    ],
+  }),
+  "disks stay silent even when a fabricated smart field is present",
+);
+
+const themeQml = fs.readFileSync(path.join(__dirname, "..", "services", "Theme.qml"), "utf8");
+assert(themeQml.indexOf("#6f8f6f") === -1, "Theme.qml has no hardcoded ok green");
+assert(themeQml.indexOf("#b5904f") === -1, "Theme.qml has no hardcoded warn amber");
+assert(themeQml.indexOf("property color ok:") === -1, "Theme.qml does not add a private ok ink");
+assert(
+  themeQml.indexOf("property color warn:") === -1,
+  "Theme.qml does not add a private warn ink",
+);
+assert(themeQml.indexOf("readonly property int badgeSize:") !== -1, "Theme names badgeSize");
+assert(themeQml.indexOf("urgent") !== -1, "Theme still carries urgent from colors.toml");
+
+const shellSrc = fs.readFileSync(path.join(__dirname, "..", "shell.qml"), "utf8");
+assert(shellSrc.indexOf("NavStatus.js") !== -1, "shell binds NavStatus.js");
+assert(shellSrc.indexOf("id: navBadge") !== -1, "sidebar rows have a navBadge");
+assert(shellSrc.indexOf("Theme.urgent") !== -1, "warn badges use Theme.urgent");
+assert(shellSrc.indexOf("Theme.ok") === -1, "shell does not read a private Theme.ok");
+assert(shellSrc.indexOf("Theme.warn") === -1, "shell does not read a private Theme.warn");
+assert(shellSrc.indexOf("Theme.sidebarWidth") !== -1, "sidebar width token is unchanged");
+
+const navStatusSrc = fs.readFileSync(
+  path.join(__dirname, "..", "services", "NavStatus.js"),
+  "utf8",
+);
+assert(
+  navStatusSrc.indexOf("state.isFailed") !== -1,
+  "NavStatus calls the Systemd.isFailed the caller passed",
+);
+assert(
+  shellSrc.indexOf("SystemdJs.isFailed") !== -1,
+  "shell passes Systemd.isFailed into navState",
+);
+assert(navStatusSrc.indexOf("enabled === false") !== -1, "Displays reads enabled, not disabled");
+assert(navStatusSrc.indexOf('case "disks"') === -1, "Disks is not a badged hub");
+assert(navStatusSrc.indexOf('case "software"') === -1, "Software is not a badged hub");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sidebar hub icons currently look the same whether Services is healthy or units failed. This adds glanceable live badges from snapshot state Atmos already has — no new processes, polling, or fields. Icons stay; silence is the common case.

This supersedes [csfh/atmos#29](https://github.com/csfh/atmos/pull/29) (nixfred) after the review blockers. Built on current `main` (post #44/#45). Does not push to nixfred's fork.

| Hub | Shows | When |
|---|---|---|
| Services | `▲2` | units have failed (`Systemd.isFailed`) |
| Displays | `1/2` | an output has `enabled === false` |
| Network | `●` / `eth` | connected (positive evidence only) |
| Bluetooth | `●2` | devices connected |
| System | `↑2` | Omarchy and/or Atmos updates waiting |

### vs #29

- **Displays** read snapshot `enabled`, not the monitor-rule `disabled` field. A disabled output now warns `n/m` instead of looking like a healthy multi-monitor count.
- **Disks** stay silent. `disk-inventory.py` has no `health`/`smart`; a dead SMART badge is not shipped.
- **Theme** — no hardcoded `#6f8f6f` / `#b5904f`. Warn uses `Theme.urgent` (colors.toml); info uses `Theme.muted`. New token is only `badgeSize`.
- **Updates** hang on **System**, not Software, and the title names Omarchy / Atmos.
- **Quieter chrome** — no always-on display count on a healthy multi-monitor desk. Network/Bluetooth stay muted and speak only on positive evidence (the `snapshotReady` hole #29 flagged).
- **`tests/nav-status.test.js`** covers null/wrong-type/defensive reads, Displays `enabled`, Services failed units, network positive-evidence-only, and the ready gate.

Column stays 220px. No rounding, shadows, or new processes.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bec56eba-5a1c-41f3-8672-c33d642b0b6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bec56eba-5a1c-41f3-8672-c33d642b0b6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

