### PR TITLE
feat: keyboard-first sidebar navigation and a shortcut sheet

### DIFF
--- a/services/Layout.js
+++ b/services/Layout.js
@@ -183,3 +183,37 @@ function clusterByGroup(pages, grouped) {
   }
   return groups;
 }
+
+// Sidebar order as drawn: each cluster's pages, left to right, top to
+// bottom. Search uses one unlabeled cluster, so this is the filtered list.
+function flattenNavPages(groups) {
+  var out = [];
+  var list = Array.isArray(groups) ? groups : [];
+  var i, j;
+  for (i = 0; i < list.length; i++) {
+    var pages = list[i] && list[i].pages ? list[i].pages : [];
+    for (j = 0; j < pages.length; j++) {
+      if (pages[j] && pages[j].id) out.push(pages[j].id);
+    }
+  }
+  return out;
+}
+
+// Next index for j/k. Clamp at the ends; if the current hub is not in
+// the drawn list (filtered away), j lands on the first match and k on
+// the last.
+function stepNavIndex(list, current, delta) {
+  var ids = Array.isArray(list) ? list : [];
+  if (ids.length === 0) return -1;
+  var at = ids.indexOf(current);
+  var next = at < 0 ? (delta > 0 ? 0 : ids.length - 1) : at + Number(delta);
+  if (next < 0) next = 0;
+  if (next > ids.length - 1) next = ids.length - 1;
+  return next;
+}
+
+function jumpNavIndex(list, toEnd) {
+  var ids = Array.isArray(list) ? list : [];
+  if (ids.length === 0) return -1;
+  return toEnd ? ids.length - 1 : 0;
+}

--- a/shell.qml
+++ b/shell.qml
@@ -55,6 +55,61 @@ ShellRoot {
     return LayoutJs.clusterByGroup(matched, q.length === 0)
   }
 
+  // The nav in the order it is drawn, so j/k walk what the eye sees rather
+  // than the unfiltered catalogue. Follows the live search filter.
+  readonly property var flatNavPages: LayoutJs.flattenNavPages(root.groupedPages)
+
+  // True while a text field owns the keyboard, so a plain letter types
+  // instead of navigating. WindowShortcut still fires when a PrefsField,
+  // PrefsPassword, PrefsSelect filter, or the sudo box has focus — so this
+  // watches the real focus item, not only the sidebar search field.
+  readonly property bool typing: {
+    var item = window.activeFocusItem
+    return !!(item && (item instanceof TextInput || item instanceof TextEdit))
+  }
+
+  // Page-level PrefsDialogs (add binding, LUKS, …) never appear as ids here.
+  // Walk the focus parent chain so a j cannot change hub under a modal or
+  // while a key-grab is listening.
+  function focusIsUnderPopup(item) {
+    var p = item
+    while (p) {
+      if (p instanceof Popup) return true
+      p = p.parent
+    }
+    return false
+  }
+
+  readonly property bool modalOpen: errorDialog.visible
+    || sudoModeDialog.visible
+    || keysDialog.visible
+    || secondInstanceDialog.visible
+    || focusIsUnderPopup(window.activeFocusItem)
+
+  readonly property bool navBusy: typing || modalOpen
+
+  function moveNav(delta) {
+    var list = root.flatNavPages
+    var next = LayoutJs.stepNavIndex(list, root.currentPage, delta)
+    if (next < 0) return
+    var id = list[next]
+    if (id === root.currentPage) return
+    root.currentPage = id
+    if (searchField.text.length > 0) searchField.text = ""
+    else root.loadHub(id)
+  }
+
+  function jumpNav(toEnd) {
+    var list = root.flatNavPages
+    var next = LayoutJs.jumpNavIndex(list, toEnd)
+    if (next < 0) return
+    var id = list[next]
+    if (id === root.currentPage) return
+    root.currentPage = id
+    if (searchField.text.length > 0) searchField.text = ""
+    else root.loadHub(id)
+  }
+
   function pageMatches(page, q) {
     var nq = String(q || "").toLowerCase()
     if (!nq) return true
@@ -99,6 +154,24 @@ ShellRoot {
     navHighlight.y = pos.y
     navHighlight.visible = true
     if (!slide) highlightSlide.enabled = true
+    root.revealNavItem(item)
+  }
+
+  // G and a held j select rows below the fold. Keep the current hub in
+  // the nav viewport; the rail is useless if you cannot see it.
+  function revealNavItem(item) {
+    if (!item || !navFlick) return
+    var pos = item.mapToItem(navContent, 0, 0)
+    if (pos.y !== pos.y) return
+    var top = pos.y
+    var bottom = top + item.height
+    var viewH = navFlick.height
+    var maxY = Math.max(0, navFlick.contentHeight - viewH)
+    var y = navFlick.contentY
+    if (top < y)
+      navFlick.contentY = Math.max(0, Math.min(maxY, top))
+    else if (bottom > y + viewH)
+      navFlick.contentY = Math.max(0, Math.min(maxY, bottom - viewH))
   }
 
   function openPage(id) {
@@ -452,8 +525,11 @@ ShellRoot {
               root.query = text
               root.syncSearchPane()
             }
-            Keys.onEscapePressed: {
-              if (text.length > 0) text = ""
+            Keys.onEscapePressed: function(event) {
+              // Blur first so the filter stays and j/k can walk it. The
+              // window Escape shortcut clears on the next press.
+              searchField.focus = false
+              event.accepted = true
             }
 
             Text {
@@ -844,6 +920,61 @@ ShellRoot {
       }
     }
 
+    // A keyboard-first app has to teach its own keys rather than send you
+    // to a README.
+    PrefsDialog {
+      id: keysDialog
+      title: "Keyboard"
+      closePolicy: Popup.CloseOnEscape
+
+      Repeater {
+        model: [
+          { keys: "j  /  k", what: "Move down and up the sidebar" },
+          { keys: "g  /  G", what: "Jump to the first or last hub" },
+          { keys: "/  /  Ctrl+F", what: "Search settings" },
+          { keys: "Enter", what: "Open or toggle what is focused" },
+          { keys: "Tab", what: "Move through controls on the page" },
+          { keys: "Escape", what: "Go back, leave search, or clear the filter" },
+          { keys: "?", what: "This sheet" }
+        ]
+        delegate: Item {
+          required property var modelData
+          width: parent ? parent.width : 0
+          height: Theme.rowHeight
+
+          PrefsText {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            width: Theme.spinWidth + Theme.spaceMd
+            text: modelData.keys
+            color: Theme.accent
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.labelSize
+            font.bold: true
+          }
+          PrefsText {
+            anchors.left: parent.left
+            anchors.leftMargin: Theme.spinWidth + Theme.spaceLg
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: modelData.what
+            color: Theme.foreground
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.labelSize
+          }
+        }
+      }
+
+      Row {
+        anchors.right: parent.right
+        PrefsButton {
+          text: "Close"
+          primary: true
+          onClicked: keysDialog.close()
+        }
+      }
+    }
+
     PrefsDialog {
       id: sudoModeDialog
       title: "Administrator password"
@@ -925,7 +1056,37 @@ ShellRoot {
 
     Shortcut {
       sequences: ["Ctrl+F", "/"]
+      enabled: !root.modalOpen
       onActivated: searchField.forceActiveFocus()
+    }
+
+    // Atmos's audience runs a tiling window manager and lives on the
+    // keyboard. Every binding is disabled while a text field or modal has
+    // focus, so typing a j into a field types a j.
+    Shortcut {
+      sequences: ["J"]
+      enabled: !root.navBusy
+      onActivated: root.moveNav(1)
+    }
+    Shortcut {
+      sequences: ["K"]
+      enabled: !root.navBusy
+      onActivated: root.moveNav(-1)
+    }
+    Shortcut {
+      sequences: ["G"]
+      enabled: !root.navBusy
+      onActivated: root.jumpNav(false)
+    }
+    Shortcut {
+      sequences: ["Shift+G"]
+      enabled: !root.navBusy
+      onActivated: root.jumpNav(true)
+    }
+    Shortcut {
+      sequences: ["?"]
+      enabled: !root.navBusy
+      onActivated: keysDialog.open()
     }
 
     Shortcut {

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -182,3 +182,37 @@ const searched = layout.clusterByGroup(
 assertEqual(searched.length, 1, "clusterByGroup is one list while searching");
 assertEqual(searched[0].title, "", "clusterByGroup drops labels while searching");
 assertEqual(searched[0].pages.length, 2, "clusterByGroup keeps every search hit");
+assertEqual(
+  layout.flattenNavPages(clustered).join(","),
+  "appearance,display,input,system",
+  "flattenNavPages walks clustered pages in drawn order",
+);
+assertEqual(
+  layout.flattenNavPages(searched).join(","),
+  "appearance,system",
+  "flattenNavPages follows the filtered cluster, not the catalogue",
+);
+assertEqual(layout.flattenNavPages(null).length, 0, "flattenNavPages ignores a non-array");
+assertEqual(
+  layout.flattenNavPages([{ title: "Desktop" }]).length,
+  0,
+  "flattenNavPages skips a cluster with no pages",
+);
+assertEqual(layout.stepNavIndex(["a", "b", "c"], "a", 1), 1, "stepNavIndex j moves down");
+assertEqual(layout.stepNavIndex(["a", "b", "c"], "b", -1), 0, "stepNavIndex k moves up");
+assertEqual(layout.stepNavIndex(["a", "b", "c"], "a", -1), 0, "stepNavIndex k clamps at the top");
+assertEqual(layout.stepNavIndex(["a", "b", "c"], "c", 1), 2, "stepNavIndex j clamps at the bottom");
+assertEqual(
+  layout.stepNavIndex(["a", "c"], "b", 1),
+  0,
+  "stepNavIndex j lands on the first match when the current hub is filtered away",
+);
+assertEqual(
+  layout.stepNavIndex(["a", "c"], "b", -1),
+  1,
+  "stepNavIndex k lands on the last match when the current hub is filtered away",
+);
+assertEqual(layout.stepNavIndex([], "a", 1), -1, "stepNavIndex no-ops on an empty list");
+assertEqual(layout.jumpNavIndex(["a", "b", "c"], false), 0, "jumpNavIndex g is the first hub");
+assertEqual(layout.jumpNavIndex(["a", "b", "c"], true), 2, "jumpNavIndex G is the last hub");
+assertEqual(layout.jumpNavIndex([], true), -1, "jumpNavIndex no-ops on an empty list");

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -962,6 +962,61 @@ assert(
     navItemSrc.indexOf("Keys.onReturnPressed") !== -1,
   "sidebar hubs are keyboard-activable buttons",
 );
+assert(
+  shellSrc.indexOf("readonly property var flatNavPages:") !== -1 &&
+    shellSrc.indexOf("LayoutJs.flattenNavPages(root.groupedPages)") !== -1,
+  "flatNavPages walks groupedPages, not the unfiltered catalogue",
+);
+assert(
+  shellSrc.indexOf("typing: searchField.activeFocus") === -1,
+  "typing is not searchField.activeFocus alone",
+);
+assert(
+  shellSrc.indexOf("item instanceof TextInput") !== -1 &&
+    shellSrc.indexOf("item instanceof TextEdit") !== -1,
+  "typing watches the real focus item for text fields",
+);
+assert(
+  shellSrc.indexOf("p instanceof Popup") !== -1 &&
+    shellSrc.indexOf("keysDialog.visible") !== -1 &&
+    shellSrc.indexOf("sudoModeDialog.visible") !== -1 &&
+    shellSrc.indexOf("errorDialog.visible") !== -1 &&
+    shellSrc.indexOf("secondInstanceDialog.visible") !== -1,
+  "nav shortcuts stay off while a shell dialog or page-level popup is open",
+);
+assert(
+  shellSrc.indexOf("enabled: !root.navBusy") !== -1 &&
+    shellSrc.indexOf("readonly property bool navBusy:") !== -1,
+  "j/k/g/G/? are gated on navBusy, not search focus alone",
+);
+assert(
+  shellSrc.indexOf("function revealNavItem(") !== -1 &&
+    shellSrc.indexOf("navFlick.contentY") !== -1,
+  "placeNavHighlight scrolls the selected hub into the nav viewport",
+);
+const searchFieldSrc = shellSrc.slice(
+  shellSrc.indexOf("id: searchField"),
+  shellSrc.indexOf("id: navFlick"),
+);
+assert(
+  searchFieldSrc.indexOf("Keys.onEscapePressed") !== -1 &&
+    searchFieldSrc.indexOf("focus = false") !== -1 &&
+    searchFieldSrc.indexOf('text = ""') === -1,
+  "Escape on search blurs first so j/k can walk the filter",
+);
+const keysDialogSrc = shellSrc.slice(
+  shellSrc.indexOf("id: keysDialog"),
+  shellSrc.indexOf("id: sudoModeDialog"),
+);
+assert(keysDialogSrc.indexOf("id: keysDialog") !== -1, "shortcut sheet is a PrefsDialog");
+assert(
+  keysDialogSrc.indexOf("Ctrl+F") !== -1 && keysDialogSrc.indexOf("/") !== -1,
+  "shortcut sheet lists Ctrl+F alongside /",
+);
+assert(
+  keysDialogSrc.indexOf("PrefsText") !== -1,
+  "shortcut sheet uses PrefsText like the other dialogs",
+);
 assert(shellSrc.indexOf("id: errorDialog") !== -1, "error dialog is a PrefsDialog");
 assert(shellSrc.indexOf("Omarchy.copyLastError()") !== -1, "error dialog copies lastError");
 assert(shellSrc.indexOf("Omarchy.clearLastError()") !== -1, "error dialog dismisses lastError");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Takes [nixfred’s #30](https://github.com/csfh/atmos/pull/30) onto current `main` (including #44 / #45 / #46) and fixes the review blockers. This is a new PR from `csfh` — nothing was pushed to nixfred’s fork.

Atmos users live on tiling WMs and the keyboard. The sidebar was mouse/Tab only. This keeps that intent:

| Key | Does |
|---|---|
| `j` / `k` | move down and up the sidebar |
| `g` / `G` | jump to the first or last hub |
| `?` | shortcut sheet |
| `/` and `Ctrl+F` | search (already existed; the sheet now lists both) |

**Preserved from #30**

- `flatNavPages` walks drawn / search-filtered order from `groupedPages`, not the unfiltered catalogue
- Clamp at the ends (no wrap)
- Mouse `activate()`, hover, and the sliding rail are untouched
- `moveNav` / `jumpNav` still reuse the existing activate path (clear search → `syncSearchPane()` → `loadHub`)

**Blockers fixed**

1. **Rebase** — `keysDialog` and `#44`’s `secondInstanceDialog` both live after the error-dialog `Connections`.
2. **Focus / modal guard** — `typing` is no longer `searchField.activeFocus`. It watches `window.activeFocusItem` for `TextInput` / `TextEdit`, walks the parent chain for a `Popup`, and also treats `errorDialog` / `sudoModeDialog` / `keysDialog` / `secondInstanceDialog` as not-navigable. A `j` in the sudo box, a `PrefsField`, a `PrefsSelect` filter, or a binding key-grab cannot change hub.
3. **Selected row is visible** — `placeNavHighlight` now scrolls `navFlick` so `G` / a held `j` keep the current hub on screen.

**Should-fix**

- **Escape vs filtered `j`/`k`:** Escape on the search field **blurs first and keeps the filter**. The window Escape shortcut still clears on the next press. That is the keyboard path onto the filtered list (Tab-away is no longer required). The first `j` after blur still picks a visible match and clears, same as clicking a row.
- Shortcut sheet lists `Ctrl+F` alongside `/`, and uses `PrefsText` + Theme tokens.
- `/` and `Ctrl+F` are disabled while a modal is open so they cannot steal from sudo / key-grab.
- `flattenNavPages` / `stepNavIndex` / `jumpNavIndex` live in `Layout.js` with Node tests; `repo.test.js` contracts the QML guard, scroll, Escape blur, and sheet.

Do not merge #30. Leave this open for Christoffer.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77bd10cf-6d39-4b67-9a8d-198f555c382e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77bd10cf-6d39-4b67-9a8d-198f555c382e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

