### PR TITLE
feat: light the whole settings row on hover and focus

### DIFF
--- a/components/PrefsMenu.qml
+++ b/components/PrefsMenu.qml
@@ -17,6 +17,9 @@ Item {
   height: implicitHeight
   opacity: Theme.controlOpacity(enabled)
 
+  // SettingRow keeps the row rail while this menu is open on Overlay.
+  readonly property bool overlayOpen: popup.opened
+
   Accessible.role: Accessible.Button
   Accessible.name: root.accessibleName
   Accessible.onPressAction: root.togglePopup()

--- a/components/PrefsSelect.qml
+++ b/components/PrefsSelect.qml
@@ -18,6 +18,9 @@ Item {
 
   readonly property bool useSearch: searchable || (options && options.length >= 8)
 
+  // SettingRow keeps the row rail while this list is open on Overlay.
+  readonly property bool overlayOpen: popup.opened
+
   signal changed(string value)
 
   implicitWidth: Theme.controlColumnWidth

--- a/components/SettingRow.qml
+++ b/components/SettingRow.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Window
 import "../services"
 import "../services/Favorites.js" as FavJs
 import "../services/Hubs.js" as HubsJs
@@ -75,6 +76,49 @@ Item {
 
   readonly property bool hovered: rowHover.hovered
 
+  // Fill when the pointer is over the row, or when anything inside it
+  // holds the keyboard. The rail is keyboard-only, so hover on A and Tab
+  // on B stay distinguishable.
+  //
+  // root.activeFocus is not enough on its own. A plain Item reports
+  // activeFocus only for itself, and focus actually lands on the control
+  // inside the row -- so a Tab into a field would light nothing, which is
+  // the case this exists for. Walk up from the window's focus item instead.
+  readonly property var focusItem: root.Window.activeFocusItem
+  readonly property bool focusInside: {
+    var item = root.focusItem
+    var guard = 0
+    while (item && guard < 40) {
+      if (item === root) return true
+      item = item.parent
+      guard += 1
+    }
+    return false
+  }
+
+  // Overlay popups reparent off the row and take focus with them. A
+  // descendant that exposes overlayOpen keeps the rail lit for the opener.
+  function childHoldsOverlay(item, depth) {
+    if (!item || depth > 8) return false
+    if (item.overlayOpen === true) return true
+    var kids = item.children
+    for (var i = 0; i < kids.length; i++) {
+      if (childHoldsOverlay(kids[i], depth + 1)) return true
+    }
+    return false
+  }
+
+  readonly property bool childOverlayOpen: {
+    var _n = root.controlCount
+    var _lead = leadingSlot.children.length
+    if (childHoldsOverlay(controlSlot, 0)) return true
+    if (childHoldsOverlay(leadingSlot, 0)) return true
+    return false
+  }
+
+  readonly property bool keyboardHere: root.focusInside || root.childOverlayOpen
+  readonly property bool lit: root.hovered || root.keyboardHere
+
   HoverHandler {
     id: rowHover
   }
@@ -136,6 +180,34 @@ Item {
   implicitWidth: width
   implicitHeight: visible ? body.implicitHeight + Theme.rowPad * 2 : 0
   height: implicitHeight
+
+  // Light the whole row, not a control inside it.
+  //
+  // A settings page is a wall of near-identical rows, and once you navigate
+  // by keyboard "where am I" has to be answerable at a glance. A thin ring
+  // around whichever control happens to hold focus does not answer it.
+  // Banding the row also makes it read as one thing rather than three that
+  // happen to sit near each other.
+  //
+  // Full-bleed and behind the splitter, so it reads as the row being lit
+  // rather than a box drawn on top of it. Instant on/off, like the rest of
+  // the chrome. Hover is fill only; the accent rail marks keyboard location.
+  Rectangle {
+    anchors.fill: parent
+    z: -2
+    visible: root.lit
+    color: Theme.fill(Theme.hoverFill)
+  }
+
+  Rectangle {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: Theme.railWidth
+    z: -1
+    visible: root.keyboardHere
+    color: Theme.accent
+  }
 
   Rectangle {
     width: parent.width

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -95,10 +95,7 @@ assert(
     selectSrc.indexOf("overlayOpen: popup.opened") !== -1,
   "PrefsSelect exposes overlayOpen so SettingRow can keep the row rail",
 );
-const menuSrc = fs.readFileSync(
-  path.join(__dirname, "..", "components", "PrefsMenu.qml"),
-  "utf8",
-);
+const menuSrc = fs.readFileSync(path.join(__dirname, "..", "components", "PrefsMenu.qml"), "utf8");
 assert(
   menuSrc.indexOf("readonly property bool overlayOpen:") !== -1 &&
     menuSrc.indexOf("overlayOpen: popup.opened") !== -1,

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -91,6 +91,20 @@ assert(
   "PrefsSelect reparents the list onto Overlay so the pane clip cannot crop it",
 );
 assert(
+  selectSrc.indexOf("readonly property bool overlayOpen:") !== -1 &&
+    selectSrc.indexOf("overlayOpen: popup.opened") !== -1,
+  "PrefsSelect exposes overlayOpen so SettingRow can keep the row rail",
+);
+const menuSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsMenu.qml"),
+  "utf8",
+);
+assert(
+  menuSrc.indexOf("readonly property bool overlayOpen:") !== -1 &&
+    menuSrc.indexOf("overlayOpen: popup.opened") !== -1,
+  "PrefsMenu exposes overlayOpen so SettingRow can keep the row rail",
+);
+assert(
   selectSrc.indexOf("parent: list") !== -1 &&
     selectSrc.indexOf("acceptedButtons: Qt.NoButton") !== -1,
   "PrefsSelect sizes a viewport wheel area on the options ListView",
@@ -502,6 +516,44 @@ assert(
   settingRowSrc.indexOf("property alias leading:") !== -1 &&
     settingRowSrc.indexOf("property bool interactive:") !== -1,
   "SettingRow can lead with a checkbox and toggle from the row",
+);
+assert(
+  settingRowSrc.indexOf("import QtQuick.Window") !== -1 &&
+    settingRowSrc.indexOf("root.Window.activeFocusItem") !== -1 &&
+    settingRowSrc.indexOf("readonly property bool focusInside:") !== -1 &&
+    settingRowSrc.indexOf("item === root") !== -1 &&
+    settingRowSrc.indexOf("item = item.parent") !== -1 &&
+    settingRowSrc.indexOf("guard < 40") !== -1,
+  "SettingRow walks Window.activeFocusItem ancestry, not root.activeFocus",
+);
+assert(
+  /readonly property bool (focusInside|keyboardHere|lit):[\s\S]{0,200}root\.activeFocus/.test(
+    settingRowSrc,
+  ) === false,
+  "SettingRow does not treat root.activeFocus as the row-lit test",
+);
+assert(
+  settingRowSrc.indexOf("visible: root.lit") !== -1 &&
+    settingRowSrc.indexOf("Theme.fill(Theme.hoverFill)") !== -1 &&
+    settingRowSrc.indexOf("z: -2") !== -1,
+  "SettingRow hover fills the whole row behind the splitter",
+);
+assert(
+  settingRowSrc.indexOf("visible: root.keyboardHere") !== -1 &&
+    settingRowSrc.indexOf("Theme.railWidth") !== -1 &&
+    settingRowSrc.indexOf("color: Theme.accent") !== -1 &&
+    settingRowSrc.indexOf("z: -1") !== -1,
+  "SettingRow paints the accent rail only when keyboard ancestry hits",
+);
+assert(
+  settingRowSrc.indexOf("Behavior on opacity") === -1 &&
+    settingRowSrc.indexOf("Theme.selectedFill") === -1,
+  "SettingRow row chrome is instant hoverFill, not a selected-fill fade",
+);
+assert(
+  settingRowSrc.indexOf("item.overlayOpen === true") !== -1 &&
+    settingRowSrc.indexOf("readonly property bool childOverlayOpen:") !== -1,
+  "SettingRow keeps the rail while a descendant overlay is open",
 );
 const collectionRowSrc = fs.readFileSync(
   path.join(__dirname, "..", "components", "CollectionRow.qml"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A settings page is a wall of near-identical rows. Keyboard (and pointer) location was answered only by the control’s own ring/fill — label and description stayed inert, so the row never read as one thing.

This bands the **entire** `SettingRow` on hover or when anything inside it holds focus, with a left accent rail for keyboard location. The band sits behind the content and behind the splitter.

The focus test walks ancestry from `Window.activeFocusItem` rather than `root.activeFocus`. A plain `Item` reports `activeFocus` only for itself, and focus lands on the control inside the row — so the obvious implementation would light nothing on Tab, which is the case this exists for.

`CollectionRow` inherits this. `PrefsRow` is already a `SettingRow` alias.

This is the #31 feature, rebased onto current `main` (#44/#45/#46) and polished. It does not depend on nixfred’s `feat/row-focus` branch.

Original work: [csfh/atmos#31](https://github.com/csfh/atmos/pull/31) by [@nixfred](https://github.com/nixfred).

## Polish vs #31

1. **Instant chrome.** Dropped the dead `Behavior on opacity` (rectangles toggle `visible`, so the animation never ran). Instant on/off matches the rest of Atmos chrome.
2. **Hover ≠ keyboard.** Hover is `Theme.hoverFill` only. The accent rail (and the “you are here” read) fires only when focus ancestry hits, or when a descendant overlay is open. Hover on A + Tab on B are distinguishable.
3. **Overlay popups.** `PrefsSelect` / `PrefsMenu` reparent onto `Overlay` and steal focus, which made the ancestry walk miss the row. They now expose `overlayOpen`; `SettingRow` keeps the rail while a descendant reports that, without naming each popup type.
4. **Regression test.** `repo.test.js` asserts the walk uses `Window.activeFocusItem` (not `root.activeFocus`), hover-vs-rail chrome, no opacity Behavior, and the `overlayOpen` contract.

## Leftover risks

- Overlay chrome that does **not** expose `overlayOpen` (section `PrefsHelp`, confirm/dialog modals) will still unlight the row. Those are not row controls.
- `Window.activeFocusItem` on `FloatingWindow` is not exercised here (no Quickshell in this environment). Low risk — `FloatingWindow` is a `QQuickWindow`.
- `j`/`k` hub movement (#30) still does not walk setting rows. Expected.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-508354fd-fb43-497c-91c4-f42852523946?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-508354fd-fb43-497c-91c4-f42852523946&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

