### PR TITLE
feat: hover a theme and see it on this window

### DIFF
--- a/components/PrefsSelect.qml
+++ b/components/PrefsSelect.qml
@@ -23,6 +23,28 @@ Item {
 
   signal changed(string value)
 
+  // Opt-in live preview. Emitted as the pointer (or highlight) moves over
+  // options, and with "" when it leaves the list or the popup closes.
+  // Callers that do not subscribe are unaffected.
+  signal previewed(string value)
+
+  // Last value handed out, so a repeat of the same option does not re-apply
+  // on every mouse move across one row.
+  property string hoveredOption: ""
+
+  function hoverOption(value) {
+    var next = String(value || "")
+    if (next === root.hoveredOption) return
+    root.hoveredOption = next
+    root.previewed(next)
+  }
+
+  // Pick already committed through changed(). Clearing without emitting
+  // "" means the subscriber must not restore over that paint.
+  function clearHover() {
+    root.hoveredOption = ""
+  }
+
   implicitWidth: Theme.controlColumnWidth
   implicitHeight: Theme.controlHeight
   width: implicitWidth
@@ -85,6 +107,7 @@ Item {
     changed(next)
     if (value === next) _holding = false
     refreshDisplayLabel()
+    root.clearHover()
     popup.close()
   }
 
@@ -199,7 +222,12 @@ Item {
       else list.forceActiveFocus()
       Qt.callLater(root.placePopup)
     }
-    onClosed: root.filter = ""
+    onClosed: {
+      root.filter = ""
+      // Dismiss by Escape or click-away puts the live value back. pickValue
+      // already cleared hoveredOption, so this is a no-op after a click.
+      root.hoverOption("")
+    }
 
     background: Rectangle {
       color: Theme.background
@@ -210,6 +238,13 @@ Item {
 
     contentItem: Column {
       width: popup.width
+
+      // One revert site, so there is no race between a row losing the
+      // pointer and its neighbour gaining it.
+      HoverHandler {
+        id: listHover
+        onHoveredChanged: if (!hovered) root.hoverOption("")
+      }
 
       Rectangle {
         visible: root.useSearch
@@ -261,6 +296,11 @@ Item {
         highlightFollowsCurrentItem: true
         Keys.onReturnPressed: root.pickCurrent()
         Keys.onSpacePressed: root.pickCurrent()
+        onCurrentIndexChanged: {
+          if (!popup.opened || currentIndex < 0) return
+          if (currentIndex >= (root.shownOptions || []).length) return
+          root.hoverOption(root.optionValue(root.shownOptions[currentIndex]))
+        }
 
         // Same viewport wheel handler as PrefsFlickable. Delegate MouseAreas
         // swallow the wheel, and a WheelHandler on this ListView never fires.
@@ -310,6 +350,12 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
+            // Enter only. The matching revert is on the list and on the
+            // popup, never on the row -- moving between two adjacent rows
+            // can fire the old row's onExited after the new row's onEntered,
+            // which undoes the preview the instant it is set and makes the
+            // whole feature look like it does nothing.
+            onEntered: root.hoverOption(root.optionValue(modelData))
             onClicked: root.pickValue(root.optionValue(modelData))
           }
         }

--- a/pages/AppearancePage.qml
+++ b/pages/AppearancePage.qml
@@ -146,7 +146,7 @@ PrefsPage {
 
     SettingRow {
       label: "Current theme"
-      description: "The palette in use right now. The shell and themed apps follow this."
+      description: "The palette in use right now. The shell and themed apps follow this. Hover a name to preview its colors on this window."
       hint: "omarchy theme set"
       query: root.query
       keywords: ["appearance", "color", "style", "palette"]
@@ -155,7 +155,24 @@ PrefsPage {
         value: Omarchy.theme
         options: Omarchy.themes
         enabled: Omarchy.themes.length > 0
-        onChanged: function(value) { if (value !== Omarchy.theme) Omarchy.setTheme(value) }
+        onChanged: function(value) {
+          if (value !== Omarchy.theme) Omarchy.setTheme(value)
+          else Theme.restorePreview()
+        }
+
+        // Hover paints this window from the named theme's colors.toml.
+        // Wallpaper, bar, terminals, and Hyprland stay put. Preview never
+        // runs omarchy theme set. Leave the list or close the popup to put
+        // the live chrome back (the in-memory snapshot from current/, not
+        // the named theme directory). Click commits through setTheme;
+        // pickValue clears hover without emitting previewed("") so that
+        // paint is not undone while Omarchy.theme is still the old name.
+        onPreviewed: function(value) {
+          if (value.length > 0 && value !== Omarchy.theme)
+            Theme.previewNamedTheme(value)
+          else
+            Theme.restorePreview()
+        }
       }
     }
 

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -761,6 +761,9 @@ QtObject {
   function setTheme(name) {
     name = String(name || "")
     if (!name || name === theme) return
+    // A hover snapshot is stale once we commit. Drop it so a later
+    // restorePreview cannot paint the pre-click chrome back over this.
+    Theme.discardPreview()
     Theme.applyNamedTheme(name)
     var cmd = SettingsJs.commandFor("theme", name, snapshotData, scriptOpts())
     if (!cmd || cmd.skip) return

--- a/services/Theme.js
+++ b/services/Theme.js
@@ -119,6 +119,59 @@ function mergeShell(themeValues, userValues) {
   return merged;
 }
 
+function copyMap(values) {
+  var out = {};
+  var key;
+  var src = values || {};
+  for (key in src) out[key] = src[key];
+  return out;
+}
+
+// Live chrome comes from current/theme/{colors,shell}.toml plus the user
+// shell.toml, already loaded into Theme properties. Hover preview must
+// snapshot those values -- not reread a named theme directory on the way
+// back, or in-place edits vanish.
+function snapshotLiveTheme(colors, themeShellValues) {
+  var c = colors || {};
+  return {
+    source: "live",
+    colors: {
+      foreground: c.foreground,
+      background: c.background,
+      accent: c.accent,
+      muted: c.muted,
+      urgent: c.urgent,
+    },
+    themeShellValues: copyMap(themeShellValues),
+  };
+}
+
+function restoreLiveTheme(snapshot) {
+  if (!snapshot || snapshot.source !== "live" || !snapshot.colors) return null;
+  return {
+    source: "live",
+    colors: {
+      foreground: snapshot.colors.foreground,
+      background: snapshot.colors.background,
+      accent: snapshot.colors.accent,
+      muted: snapshot.colors.muted,
+      urgent: snapshot.colors.urgent,
+    },
+    themeShellValues: copyMap(snapshot.themeShellValues),
+  };
+}
+
+function firstThemeFile(name, rel, home, readFn, omarchyPath) {
+  var paths = themeFileCandidates(name, rel, home, omarchyPath);
+  var i;
+  var raw;
+  for (i = 0; i < paths.length; i++) {
+    raw = readFn ? readFn(paths[i]) : "";
+    if (raw) return raw;
+  }
+  return "";
+}
+
 function numberToken(values, key, fallback) {
   var n = Number(values && values[key]);
   return isFinite(n) ? n : fallback;

--- a/services/Theme.qml
+++ b/services/Theme.qml
@@ -23,6 +23,12 @@ QtObject {
   property var userShellValues: ({})
   property var shellValues: ({})
 
+  // In-memory copy of the live FileView chrome. Hover preview paints over
+  // Theme colors, then restorePreview puts these back. source: "live" --
+  // never a named theme directory.
+  property var livePreviewSnapshot: null
+  property bool livePreviewing: false
+
   // Visual language. Monospace, grayscale chrome, 1px hairlines, radius 0,
   // dense native controls, a capped content column, a persistent sidebar.
   // Tokens record the live look. Do not round cards, add shadows, or grow
@@ -185,12 +191,54 @@ QtObject {
     raw = ""
     for (i = 0; i < paths.length; i++) {
       raw = root.readPath(paths[i])
-      if (raw) {
-        root.themeShellValues = ThemeJs.parseShell(raw)
-        root.mergeShell()
-        break
-      }
+      if (raw) break
     }
+    // Always replace. A theme with no shell.toml must not keep the previous
+    // theme's font.base-size / fills, or the chrome (and an open popup) jump
+    // to leftover tokens.
+    root.themeShellValues = raw ? ThemeJs.parseShell(raw) : ({})
+    root.mergeShell()
+  }
+
+  function discardPreview() {
+    root.livePreviewSnapshot = null
+    root.livePreviewing = false
+  }
+
+  function captureLivePreview() {
+    if (root.livePreviewing) return
+    root.livePreviewSnapshot = ThemeJs.snapshotLiveTheme({
+      foreground: String(root.foreground),
+      background: String(root.background),
+      accent: String(root.accent),
+      muted: String(root.muted),
+      urgent: String(root.urgent)
+    }, root.themeShellValues)
+    root.livePreviewing = true
+  }
+
+  function restorePreview() {
+    if (!root.livePreviewing) return
+    var restored = ThemeJs.restoreLiveTheme(root.livePreviewSnapshot)
+    root.discardPreview()
+    if (!restored) return
+    root.foreground = restored.colors.foreground
+    root.background = restored.colors.background
+    root.accent = restored.colors.accent
+    root.muted = restored.colors.muted
+    root.urgent = restored.colors.urgent
+    root.themeShellValues = restored.themeShellValues
+    root.mergeShell()
+  }
+
+  // Hover path. Colors.toml only -- no shell.toml, no omarchy theme set --
+  // so fontSize / rowHeight stay put and the open popup does not reflow.
+  function previewNamedTheme(name) {
+    root.captureLivePreview()
+    var raw = ThemeJs.firstThemeFile(name, "colors.toml", root.home, function(path) {
+      return root.readPath(path)
+    })
+    if (raw) root.applyColors(raw)
   }
 
   // omarchy-theme-set rm -rf's current/theme then mv's a new directory in.

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -212,3 +212,181 @@ assert(
     bgOmarchySrc.indexOf("function runInteractive(") !== -1,
   "native background pickers do not hold the mut queue",
 );
+
+function qmlFunctionBody(src, name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) return "";
+  const brace = src.indexOf("{", start);
+  if (brace < 0) return "";
+  let depth = 0;
+  for (let i = brace; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return "";
+}
+
+const liveColors = {
+  foreground: "#aaa111",
+  background: "#111111",
+  accent: "#222222",
+  muted: "#333333",
+  urgent: "#444444",
+};
+const liveShell = { "font.base-size": "16", "controls.normal-fill-alpha": "0.2" };
+const snap = theme.snapshotLiveTheme(liveColors, liveShell);
+assertEqual(snap.source, "live", "snapshotLiveTheme tags the restore source as live");
+assertEqual(snap.colors.foreground, "#aaa111", "snapshotLiveTheme copies live foreground");
+assertEqual(
+  snap.themeShellValues["font.base-size"],
+  "16",
+  "snapshotLiveTheme copies live themeShellValues",
+);
+liveShell["font.base-size"] = "99";
+assertEqual(
+  snap.themeShellValues["font.base-size"],
+  "16",
+  "snapshotLiveTheme copies themeShellValues, it does not alias them",
+);
+const restored = theme.restoreLiveTheme(snap);
+assertEqual(restored.source, "live", "restoreLiveTheme keeps the live source tag");
+assertEqual(restored.colors.background, "#111111", "restoreLiveTheme returns snapshotted colors");
+assertEqual(
+  restored.themeShellValues["font.base-size"],
+  "16",
+  "restoreLiveTheme returns snapshotted shell tokens",
+);
+assertEqual(theme.restoreLiveTheme(null), null, "restoreLiveTheme rejects a missing snapshot");
+assertEqual(
+  theme.restoreLiveTheme({ source: "named", colors: liveColors, themeShellValues: {} }),
+  null,
+  "restoreLiveTheme rejects a named-directory snapshot",
+);
+
+const files = {
+  "/home/u/.config/omarchy/themes/miasma/colors.toml": 'foreground = "#aabbcc"\n',
+  "/usr/share/omarchy/themes/miasma/shell.toml": "[font]\nbase-size = 18\n",
+};
+const readFn = function (p) {
+  return files[p] || "";
+};
+assertEqual(
+  theme.firstThemeFile("Miasma", "colors.toml", "/home/u", readFn, "/usr/share/omarchy"),
+  'foreground = "#aabbcc"\n',
+  "firstThemeFile reads a named theme colors.toml for preview",
+);
+assertEqual(
+  theme.firstThemeFile("Miasma", "shell.toml", "/home/u", readFn, "/usr/share/omarchy"),
+  "[font]\nbase-size = 18\n",
+  "firstThemeFile can read shell.toml when asked",
+);
+assert(
+  theme.themeFileCandidates("Miasma", "colors.toml", "/home/u").indexOf("/home/u/.local/state") ===
+    -1,
+  "named theme candidates never include current/theme",
+);
+
+const previewFn = qmlFunctionBody(themeQml, "previewNamedTheme");
+assert(
+  previewFn.indexOf("captureLivePreview") !== -1,
+  "previewNamedTheme snapshots live chrome first",
+);
+assert(
+  previewFn.indexOf("colors.toml") !== -1 && previewFn.indexOf("shell.toml") === -1,
+  "previewNamedTheme reads colors.toml only, not shell.toml",
+);
+assert(
+  previewFn.indexOf("applyNamedTheme") === -1 &&
+    previewFn.indexOf("setTheme") === -1 &&
+    previewFn.indexOf("omarchy") === -1,
+  "previewNamedTheme does not commit a theme",
+);
+
+const restoreFn = qmlFunctionBody(themeQml, "restorePreview");
+assert(
+  restoreFn.indexOf("restoreLiveTheme") !== -1 && restoreFn.indexOf("applyNamedTheme") === -1,
+  "restorePreview reapplies the live snapshot, not applyNamedTheme",
+);
+assert(
+  restoreFn.indexOf("themeFileCandidates") === -1 && restoreFn.indexOf("currentThemePath") === -1,
+  "restorePreview does not reread named dirs or current/ files",
+);
+
+const applyFn = qmlFunctionBody(themeQml, "applyNamedTheme");
+assert(
+  applyFn.indexOf("themeShellValues = raw ? ThemeJs.parseShell(raw) : ({})") !== -1,
+  "applyNamedTheme resets themeShellValues when a theme has no shell.toml",
+);
+
+const setThemeFn = qmlFunctionBody(bgOmarchySrc, "setTheme");
+assert(
+  setThemeFn.indexOf("Theme.discardPreview()") !== -1 &&
+    setThemeFn.indexOf("Theme.restorePreview()") === -1,
+  "setTheme drops a hover snapshot instead of restoring it",
+);
+
+const selectSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsSelect.qml"),
+  "utf8",
+);
+assert(selectSrc.indexOf("signal previewed(string value)") !== -1, "PrefsSelect emits previewed");
+assert(
+  selectSrc.indexOf("onEntered: root.hoverOption(root.optionValue(modelData))") !== -1 &&
+    selectSrc.indexOf("onExited:") === -1,
+  "PrefsSelect previews on enter only, never per-row onExited",
+);
+assert(
+  selectSrc.indexOf("HoverHandler") !== -1 && selectSrc.indexOf('root.hoverOption("")') !== -1,
+  "PrefsSelect reverts from the list HoverHandler and popup close",
+);
+const pickFn = qmlFunctionBody(selectSrc, "pickValue");
+assert(
+  pickFn.indexOf("root.clearHover()") !== -1 && pickFn.indexOf("hoverOption") === -1,
+  'pickValue clears hover state without emitting previewed("")',
+);
+const clearFn = qmlFunctionBody(selectSrc, "clearHover");
+assert(
+  clearFn.indexOf("hoveredOption") !== -1 && clearFn.indexOf("previewed") === -1,
+  "clearHover does not emit previewed",
+);
+assert(
+  selectSrc.indexOf("onCurrentIndexChanged:") !== -1,
+  "PrefsSelect previews keyboard highlight moves",
+);
+
+const appearanceSrc = fs.readFileSync(
+  path.join(__dirname, "..", "pages", "AppearancePage.qml"),
+  "utf8",
+);
+const themeSelectStart = appearanceSrc.indexOf('label: "Current theme"');
+const themeSelectEnd = appearanceSrc.indexOf('label: "Theme files"', themeSelectStart);
+const themeSelect = appearanceSrc.slice(themeSelectStart, themeSelectEnd);
+assert(
+  themeSelect.indexOf("onPreviewed:") !== -1 &&
+    themeSelect.indexOf("Theme.previewNamedTheme") !== -1,
+  "Current theme hover calls previewNamedTheme",
+);
+assert(
+  themeSelect.indexOf("Theme.restorePreview()") !== -1 &&
+    themeSelect.indexOf("applyNamedTheme") === -1,
+  "Current theme restore uses restorePreview, not applyNamedTheme",
+);
+assert(
+  themeSelect.indexOf("Omarchy.setTheme") !== -1 &&
+    /onPreviewed:[\s\S]*setTheme/.test(themeSelect) === false,
+  "Current theme hover does not call setTheme",
+);
+assert(
+  themeSelect.indexOf("onChanged:") !== -1 && themeSelect.indexOf("Omarchy.setTheme(value)") !== -1,
+  "Current theme click still commits through Omarchy.setTheme",
+);
+
+const extraSelectStart = appearanceSrc.indexOf('label: "Installed themes"');
+const extraBlock = appearanceSrc.slice(extraSelectStart, extraSelectStart + 1800);
+assert(
+  extraBlock.indexOf("onPreviewed") === -1,
+  "Additional themes picker does not subscribe to previewed",
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hover a theme in Appearance → Current theme and Atmos chrome repaints in that palette. Leave the list or close the popup and the live colors come back. Click still commits through `Omarchy.setTheme`. Preview never runs `omarchy theme set`.

This is nixfred's idea from #32, rebased onto current `main` (#44–#48) and fixed so it can merge. Product pick is live chrome repaint, not #39's sample swatches. Do not land this alongside #39 without an explicit choice.

`PrefsSelect` still emits `previewed` on option hover (enter only) and `""` from one revert site (list leave + popup close). `pickValue` clears hover **without** emitting `previewed("")`, so `setTheme`'s paint is not undone while `Omarchy.theme` is still the old name.

Restore is an in-memory snapshot of the live FileView chrome (`current/theme/{colors,shell}.toml` + user `shell.toml`), not `applyNamedTheme(Omarchy.theme)` which reads named theme dirs and drops in-place edits. Hover applies **colors.toml only**, so `fontSize` / `rowHeight` do not jump under the open popup. `applyNamedTheme` now resets `themeShellValues` when a theme has no `shell.toml`, so leftover tokens cannot stick on a commit either.

Keyboard highlight moves also emit `previewed` (same repeat filter). Additional-themes picker does not subscribe.

## What changed vs #32

| | #32 | This |
|---|---|---|
| Pick | `hoverOption("")` after `changed()` flaps back to the old theme | `clearHover()` — no `previewed("")` |
| Restore | `applyNamedTheme(Omarchy.theme)` (named dirs) | in-memory live snapshot |
| Hover I/O | colors + shell, blocking, layout tokens jump | colors only |
| Missing `shell.toml` | previous row's shell sticks | reset on commit; preview never applies shell |
| Tests | none | hover does not `setTheme`; pick does not restore via `previewed("")`; restore source is `live` |
| Copy | claimed Atmos is the shell | preview is this window; wallpaper/bar/terminals stay put |

Does not absorb #39 (no swatches, no thumbnail, no `setTheme` / mut-queue rewrite).

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a92d469-4781-49e2-86e1-d599511a0af6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a92d469-4781-49e2-86e1-d599511a0af6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

