### PR TITLE
feat: say which config file a section writes

### DIFF
--- a/components/PrefsGroup.qml
+++ b/components/PrefsGroup.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import "../services"
 import "../services/Layout.js" as LayoutJs
+import "../services/WritesFile.js" as WritesFile
 
 Column {
   id: root
@@ -14,6 +15,15 @@ Column {
   // Boxes are for collections, objects, and special operations.
   // Ordinary settings are a heading plus rows.
   property bool framed: false
+  // Opt-in write target. writesMode is sentinel (Atmos block), file
+  // (Atmos owns the file), or command. Default sentinel so a copied
+  // Input section cannot claim whole-file ownership by omission.
+  property string writesFile: ""
+  property string writesMode: "sentinel"
+  property string writesNote: ""
+  readonly property string writesCaption: WritesFile.caption(root.writesFile, root.writesMode, {
+    note: root.writesNote
+  })
 
   width: parent ? parent.width : 640
   spacing: Theme.headingGap
@@ -102,7 +112,7 @@ Column {
   Item {
     id: headingHost
     width: parent.width
-    implicitHeight: root.title.length > 0 ? Math.max(titleLabel.implicitHeight, groupHelp.implicitHeight) : 0
+    implicitHeight: headingColumn.implicitHeight
     height: implicitHeight
     visible: root.title.length > 0
 
@@ -110,31 +120,56 @@ Column {
       id: headingHover
     }
 
-    PrefsText {
-      id: titleLabel
-      anchors.left: parent.left
-      anchors.leftMargin: root.titleInset
-      anchors.right: groupHelp.visible ? groupHelp.left : parent.right
-      anchors.rightMargin: groupHelp.visible ? Theme.space : root.titleInset
-      anchors.verticalCenter: parent.verticalCenter
-      text: root.title.toUpperCase()
-      color: Theme.muted
-      font.family: Theme.fontFamily
-      font.pixelSize: Theme.sectionSize
-      font.bold: true
-      font.letterSpacing: Theme.sectionTracking
-    }
+    Column {
+      id: headingColumn
+      width: parent.width
+      spacing: Theme.titleGap
 
-    PrefsHelp {
-      id: groupHelp
-      anchors.right: parent.right
-      anchors.rightMargin: root.titleInset
-      anchors.verticalCenter: parent.verticalCenter
-      title: root.title
-      reveal: headingHover.hovered
-      body: root.helpPayload && root.helpPayload.body ? root.helpPayload.body : ""
-      command: root.helpPayload && root.helpPayload.command ? root.helpPayload.command : ""
-      topics: root.showHelp && root.helpPayload ? root.helpPayload.topics : []
+      Item {
+        id: titleRow
+        width: parent.width
+        implicitHeight: Math.max(titleLabel.implicitHeight, groupHelp.implicitHeight)
+        height: implicitHeight
+
+        PrefsText {
+          id: titleLabel
+          anchors.left: parent.left
+          anchors.leftMargin: root.titleInset
+          anchors.right: groupHelp.visible ? groupHelp.left : parent.right
+          anchors.rightMargin: groupHelp.visible ? Theme.space : root.titleInset
+          anchors.verticalCenter: parent.verticalCenter
+          text: root.title.toUpperCase()
+          color: Theme.muted
+          font.family: Theme.fontFamily
+          font.pixelSize: Theme.sectionSize
+          font.bold: true
+          font.letterSpacing: Theme.sectionTracking
+        }
+
+        PrefsHelp {
+          id: groupHelp
+          anchors.right: parent.right
+          anchors.rightMargin: root.titleInset
+          anchors.verticalCenter: parent.verticalCenter
+          title: root.title
+          reveal: headingHover.hovered
+          body: root.helpPayload && root.helpPayload.body ? root.helpPayload.body : ""
+          command: root.helpPayload && root.helpPayload.command ? root.helpPayload.command : ""
+          topics: root.showHelp && root.helpPayload ? root.helpPayload.topics : []
+        }
+      }
+
+      PrefsText {
+        id: provenanceLabel
+        visible: root.writesCaption.length > 0
+        x: root.titleInset
+        width: parent.width - root.titleInset * 2
+        text: root.writesCaption
+        color: Theme.muted
+        opacity: Theme.metaOpacity
+        font.family: Theme.fontFamily
+        font.pixelSize: Theme.metaSize
+      }
     }
   }
 

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -36,6 +36,7 @@ PrefsPage {
   PrefsGroup {
     title: "Pointer"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Sensitivity and acceleration for the mouse and trackpad. These write a managed block in ~/.config/hypr/input.lua."
 
     SettingRow {
@@ -108,6 +109,7 @@ PrefsPage {
   PrefsGroup {
     title: "Touchpad"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Feel for the trackpad. The on/off switch for the device itself is on Displays."
 
     SettingRow {
@@ -189,6 +191,7 @@ PrefsPage {
   PrefsGroup {
     title: "Keyboard"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
     detail: "Repeat and numlock for Hyprland. The console and login layout stay on System."
 
     SettingRow {
@@ -269,6 +272,8 @@ PrefsPage {
   PrefsGroup {
     title: "Advanced"
     query: root.query
+    writesFile: "~/.config/hypr/input.lua"
+    writesNote: Omarchy.hyprWorkspaceGestureUnmanaged ? "your gesture stays" : ""
     detail: "Follow mouse, waking the screen, an optional Hyprland layout list, and a three-finger workspace swipe."
 
     SettingRow {

--- a/services/WritesFile.js
+++ b/services/WritesFile.js
@@ -1,0 +1,39 @@
+// Caption for which config file a PrefsGroup section writes.
+// Sentinel is the default: Atmos replaces `-- atmos:…` and leaves the rest
+// of the user's file. File mode is whole-file ownership. Command mode is
+// an omarchy/script write that is not a config path we edit in place.
+
+var MODE_SENTINEL = "sentinel";
+var MODE_FILE = "file";
+var MODE_COMMAND = "command";
+
+function trim(s) {
+  return String(s || "").replace(/^\s+|\s+$/g, "");
+}
+
+function normalizeMode(mode) {
+  var m = trim(mode);
+  if (m === MODE_FILE || m === MODE_COMMAND) return m;
+  return MODE_SENTINEL;
+}
+
+function ownsWholeFile(mode) {
+  return normalizeMode(mode) === MODE_FILE;
+}
+
+function statusLabel(mode) {
+  var m = normalizeMode(mode);
+  if (m === MODE_FILE) return "Atmos file";
+  if (m === MODE_COMMAND) return "via command";
+  return "Atmos block";
+}
+
+function caption(file, mode, extras) {
+  var path = trim(file);
+  if (!path) return "";
+  extras = extras || {};
+  var note = trim(extras.note);
+  var out = path + "  ·  " + statusLabel(mode);
+  if (note) out += "  ·  " + note;
+  return out;
+}

--- a/tests/writes-file.test.js
+++ b/tests/writes-file.test.js
@@ -1,0 +1,159 @@
+const fs = require("fs");
+const path = require("path");
+const { load, assert, assertEqual } = require("./harness");
+
+const writes = load("services/WritesFile.js");
+
+function claimsWholeFile(text) {
+  const s = String(text || "").toLowerCase();
+  return (
+    s.indexOf("managed by atmos") !== -1 ||
+    s.indexOf("atmos file") !== -1 ||
+    s.indexOf("owns") !== -1 ||
+    s.indexOf("edits in place") !== -1
+  );
+}
+
+assertEqual(writes.normalizeMode(""), "sentinel", "empty mode is sentinel");
+assertEqual(writes.normalizeMode("managed"), "sentinel", "unknown mode is sentinel");
+assertEqual(writes.normalizeMode("true"), "sentinel", "bool-shaped mode is sentinel");
+assertEqual(writes.normalizeMode("file"), "file", "file mode stays file");
+assertEqual(writes.normalizeMode("command"), "command", "command mode stays command");
+assertEqual(writes.ownsWholeFile(""), false, "default mode does not own the file");
+assertEqual(writes.ownsWholeFile("sentinel"), false, "sentinel does not own the file");
+assertEqual(writes.ownsWholeFile("command"), false, "command does not own the file");
+assertEqual(writes.ownsWholeFile("file"), true, "file mode owns the file");
+
+const inputCaption = writes.caption("~/.config/hypr/input.lua");
+assertEqual(
+  inputCaption,
+  "~/.config/hypr/input.lua  ·  Atmos block",
+  "default input caption is the Atmos block, not whole-file ownership",
+);
+assert(!claimsWholeFile(inputCaption), "sentinel caption does not claim whole-file ownership");
+assert(
+  !claimsWholeFile(writes.caption("~/.config/hypr/input.lua", "sentinel")),
+  "explicit sentinel caption does not claim whole-file ownership",
+);
+assert(
+  !claimsWholeFile(writes.caption("~/.config/hypr/input.lua", "")),
+  "omitted mode cannot claim whole-file ownership",
+);
+assertEqual(
+  writes.caption("~/.config/hypr/input.lua", "file"),
+  "~/.config/hypr/input.lua  ·  Atmos file",
+  "file mode can say Atmos owns the file",
+);
+assertEqual(
+  writes.caption("omarchy font set", "command"),
+  "omarchy font set  ·  via command",
+  "command mode names a command write",
+);
+assertEqual(writes.caption(""), "", "empty path has no caption");
+assertEqual(writes.caption("   "), "", "whitespace path has no caption");
+assertEqual(
+  writes.caption("~/.config/hypr/input.lua", "sentinel", {
+    note: "your gesture stays",
+  }),
+  "~/.config/hypr/input.lua  ·  Atmos block  ·  your gesture stays",
+  "optional note appends after the sentinel status",
+);
+assert(
+  !claimsWholeFile(
+    writes.caption("~/.config/hypr/input.lua", "sentinel", { note: "your gesture stays" }),
+  ),
+  "unmanaged-gesture note still does not claim the whole file",
+);
+
+const prefsGroupSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsGroup.qml"),
+  "utf8",
+);
+assert(
+  prefsGroupSrc.indexOf('property string writesMode: "sentinel"') !== -1,
+  "PrefsGroup defaults writesMode to sentinel",
+);
+assert(
+  prefsGroupSrc.indexOf("property bool writesManaged") === -1,
+  "PrefsGroup has no writesManaged bool that can default to ownership",
+);
+assert(
+  prefsGroupSrc.indexOf('import "../services/WritesFile.js" as WritesFile') !== -1 &&
+    prefsGroupSrc.indexOf("WritesFile.caption(") !== -1,
+  "PrefsGroup builds the caption from WritesFile.js",
+);
+
+const headingAt = prefsGroupSrc.indexOf("id: headingHost");
+assert(headingAt !== -1, "PrefsGroup has headingHost");
+const rowsAt = prefsGroupSrc.indexOf("id: rowsWrap");
+const headingHost = prefsGroupSrc.slice(headingAt, rowsAt);
+const beforeHeading = prefsGroupSrc.slice(0, headingAt);
+assert(
+  beforeHeading.indexOf("provenanceLabel") === -1 &&
+    beforeHeading.indexOf("writesFile") !== -1 &&
+    beforeHeading.indexOf("id: headingHost") === -1,
+  "writesFile properties live on the group; the caption is not a Column sibling above the heading",
+);
+assert(
+  headingHost.indexOf("id: titleLabel") !== -1 &&
+    headingHost.indexOf("id: provenanceLabel") !== -1 &&
+    headingHost.indexOf("id: titleLabel") < headingHost.indexOf("id: provenanceLabel"),
+  "provenance caption is inside headingHost after the section title",
+);
+assert(
+  headingHost.indexOf("PrefsText") !== -1 &&
+    headingHost.indexOf("id: provenanceLabel") !== -1 &&
+    headingHost.slice(0, headingHost.indexOf("id: provenanceLabel")).lastIndexOf("PrefsText") !==
+      -1,
+  "provenance caption is a PrefsText like SettingRow captions",
+);
+assert(
+  headingHost.indexOf("Theme.metaSize") !== -1 &&
+    headingHost.indexOf("Theme.metaOpacity") !== -1 &&
+    headingHost.indexOf("Theme.muted") !== -1,
+  "provenance caption uses SettingRow caption tokens",
+);
+assert(
+  headingHost.indexOf("spacing: Theme.titleGap") !== -1,
+  "title and caption sit on titleGap inside the heading block",
+);
+assert(
+  /\n  spacing: Theme.headingGap\n/.test(prefsGroupSrc),
+  "Theme.headingGap still sits between the heading block and the first row",
+);
+assert(
+  headingHost.indexOf("implicitHeight: headingColumn.implicitHeight") !== -1 ||
+    prefsGroupSrc.indexOf("implicitHeight: headingColumn.implicitHeight") !== -1,
+  "headingHost grows with the title-plus-caption column",
+);
+assert(
+  headingHost.indexOf("reveal: headingHover.hovered") !== -1,
+  "section help hover stays on the heading block",
+);
+
+const inputSrc = fs.readFileSync(path.join(__dirname, "..", "pages", "InputPage.qml"), "utf8");
+["Pointer", "Touchpad", "Keyboard", "Advanced"].forEach(function (title) {
+  const needle = 'title: "' + title + '"';
+  const start = inputSrc.indexOf(needle);
+  assert(start !== -1, "Input has a " + title + " section");
+  const next = inputSrc.indexOf('title: "', start + needle.length);
+  const block = inputSrc.slice(start, next === -1 ? inputSrc.length : next);
+  assert(
+    block.indexOf('writesFile: "~/.config/hypr/input.lua"') !== -1 ||
+      block.indexOf("writesFile: root.inputWritesFile") !== -1,
+    title + " labels ~/.config/hypr/input.lua",
+  );
+  assert(
+    block.indexOf('writesMode: "file"') === -1 && block.indexOf("writesManaged: true") === -1,
+    title + " does not claim whole-file ownership of input.lua",
+  );
+});
+assert(
+  /title: "Advanced"[\s\S]*writesFile:/.test(inputSrc),
+  "Advanced carries the same write-target caption; unmanaged gesture deferral lives there",
+);
+assert(
+  inputSrc.indexOf("hyprWorkspaceGestureUnmanaged") !== -1 &&
+    /title: "Advanced"[\s\S]*writesNote:/.test(inputSrc),
+  "Advanced wires the unmanaged-gesture note to real state",
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Muted caption under a PrefsGroup section heading showing which config file the section touches, so the write target is visible without opening help. Opt-in via `writesFile`. Demonstrated on Input.

This is nixfred's idea from #33, rebased onto current `main` (#44–#49) and fixed so the caption is true and sits under the heading. Not a push to nixfred's fork.

A section declares `writesFile` and an optional `writesMode` (`sentinel` / `file` / `command`). Default is `sentinel`. The caption is built by `WritesFile.js` so a copied Input section cannot claim Atmos owns the file by omission.

Input's Pointer, Touchpad, Keyboard, and Advanced all label `~/.config/hypr/input.lua`. The caption is `~/.config/hypr/input.lua · Atmos block`, matching the page's own language (managed block / Reset removes the block / the rest of the file stays). Advanced also binds `hyprWorkspaceGestureUnmanaged` and adds `your gesture stays` when that line is outside the sentinel.

`hyprInputManaged` is not bound on the heading. That flag is "block present now" (Reset enablement), not "how this section writes". Binding it would change the caption after Reset without changing the write target.

## What changed vs #33

| | #33 | This |
|---|---|---|
| Placement | Caption is a `Column` sibling *above* `headingHost` | Caption is `PrefsText` inside `headingHost` after the title; `Theme.headingGap` still sits between the heading block and the first row |
| Default | `writesManaged: true` → "managed by Atmos" | `writesMode: "sentinel"` → "Atmos block" |
| Copy | "managed by Atmos" / "your file, Atmos edits in place" | Sentinel = Atmos block; file = Atmos file; command = via command |
| Advanced | Unlabeled | Same file; unmanaged gesture note when Atmos defers |
| Tests | None | Caption cannot claim whole-file ownership for sentinel writes; placement contract; Input labels all four sections |

No writers, no parsers, no private store.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5094fe7-3557-4148-a9f3-a7f3e297b8c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5094fe7-3557-4148-a9f3-a7f3e297b8c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

