### PR TITLE
feat: fold Advanced sections in Simple without hiding them from search

### DIFF
--- a/components/PrefsGroup.qml
+++ b/components/PrefsGroup.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import "../services"
+import "../services/Disclosure.js" as DisclosureJs
 import "../services/Layout.js" as LayoutJs
 import "../services/WritesFile.js" as WritesFile
 
@@ -15,6 +16,9 @@ Column {
   // Boxes are for collections, objects, and special operations.
   // Ordinary settings are a heading plus rows.
   property bool framed: false
+  // Same fold as SettingRow.advanced. Existing Advanced sections opt in
+  // so Simple talks to the heading already on the page, not a second model.
+  property bool advanced: false
   // Opt-in write target. writesMode is sentinel (Atmos block), file
   // (Atmos owns the file), or command. Default sentinel so a copied
   // Input section cannot claim whole-file ownership by omission.
@@ -27,10 +31,42 @@ Column {
 
   width: parent ? parent.width : 640
   spacing: Theme.headingGap
+
+  readonly property string resolvedHubId: {
+    var p = parent
+    while (p) {
+      if (p.hubId !== undefined && String(p.hubId).length) return String(p.hubId)
+      p = p.parent
+    }
+    return ""
+  }
+
+  readonly property var disclosureLabels: {
+    var _n = root.childCount(rowsColumn)
+    var rows = root.collectPrefsRows({ includeFolded: true })
+    var out = []
+    var i
+    for (i = 0; i < rows.length; i++) out.push(rows[i].label || "")
+    return out
+  }
+
+  readonly property bool folded: DisclosureJs.groupFolded({
+    advanced: root.advanced,
+    query: root.query,
+    hub: root.resolvedHubId,
+    labels: root.disclosureLabels
+  }, {
+    simple: Disclosure.simple,
+    revealedHub: Disclosure.revealedHub,
+    revealedLabel: Disclosure.revealedLabel
+  })
+
   // The section stays in the layout even when it has no matching rows.
   // Hiding it with visible:false, or collapsing it to height 0 with clip,
   // skips the row layout pass and every group stays a heading with no controls.
-  visible: query.length === 0 || rowsColumn.implicitHeight > 0
+  // Simple may hide an opted-in Advanced section as a unit; children stay
+  // instantiated so a search pin can bring the heading back.
+  visible: !root.folded && (query.length === 0 || rowsColumn.implicitHeight > 0)
 
   function childCount(node) {
     var n = 0
@@ -45,7 +81,8 @@ Column {
     return n
   }
 
-  function collectPrefsRows() {
+  function collectPrefsRows(opts) {
+    var includeFolded = !!(opts && opts.includeFolded)
     var out = []
     function walk(node) {
       var kids = node && node.children
@@ -55,9 +92,9 @@ Column {
         var kid = kids[i]
         if (!kid) continue
         if (kid.prefsRow === true) {
-          if (kid.visible === false) continue
           if (kid.available === false) continue
           if (kid.matches === false) continue
+          if (kid.visible === false && !(includeFolded && kid.folded === true)) continue
           out.push(kid)
         } else if (kid.children && kid.children.length > 0) {
           walk(kid)
@@ -69,7 +106,7 @@ Column {
   }
 
   function collectHelpRows() {
-    var rows = root.collectPrefsRows()
+    var rows = root.collectPrefsRows({ includeFolded: true })
     var out = []
     var i
     for (i = 0; i < rows.length; i++) {
@@ -89,6 +126,7 @@ Column {
     var _q = root.query
     var _n = root.childCount(rowsColumn)
     var _s = root.splitPass
+    var _simple = Disclosure.simple
     return LayoutJs.sectionHelpPayload(root.detail, root.hint, root.collectHelpRows())
   }
 

--- a/components/PrefsPage.qml
+++ b/components/PrefsPage.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import "../services"
+import "../services/Disclosure.js" as DisclosureJs
 
 Item {
   id: root
@@ -12,6 +13,28 @@ Item {
   default property alias extra: sections.data
   readonly property alias prefsOverlay: overlayLayer
   readonly property bool hasSections: sections.implicitHeight > 0
+
+  function treeHasAdvanced(node, depth) {
+    if (!node || depth > 24) return false
+    if (node.advanced === true) return true
+    var kids = node.children
+    if (!kids) return false
+    var i
+    for (i = 0; i < kids.length; i++) {
+      if (treeHasAdvanced(kids[i], depth + 1)) return true
+    }
+    return false
+  }
+
+  readonly property bool hasAdvanced: {
+    var _n = sections.children.length
+    return treeHasAdvanced(sections, 0)
+  }
+
+  readonly property bool showDisclosure: DisclosureJs.showModeToggle(root.hasAdvanced, {
+    embed: root.embed,
+    query: root.query
+  })
 
   width: parent ? parent.width : 640
   implicitWidth: width
@@ -58,6 +81,28 @@ Item {
           color: Theme.muted
           font.family: Theme.fontFamily
           font.pixelSize: Theme.pageDescriptionSize
+        }
+
+        Row {
+          spacing: Theme.space
+          visible: root.showDisclosure
+          topPadding: Theme.titleGap
+
+          PrefsButton {
+            text: Disclosure.simple ? "Simple" : "Everything"
+            onClicked: Disclosure.simple = !Disclosure.simple
+          }
+
+          PrefsText {
+            anchors.verticalCenter: parent.verticalCenter
+            text: Disclosure.simple
+              ? "advanced rows folded — search still finds them"
+              : "showing every option"
+            color: Theme.muted
+            opacity: Theme.metaOpacity
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.captionSize
+          }
         }
       }
 

--- a/components/SettingRow.qml
+++ b/components/SettingRow.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Window
 import "../services"
+import "../services/Disclosure.js" as DisclosureJs
 import "../services/Favorites.js" as FavJs
 import "../services/Hubs.js" as HubsJs
 import "../services/ShellConfig.js" as ShellConfigJs
@@ -22,6 +23,9 @@ Item {
   property string valueText: ""
   property bool stretchControl: false
   property bool available: true
+  // Opt-in fold. Simple hides the row; search and section help still
+  // reach it. Untagged rows never fold, so untriaged pages stay as they are.
+  property bool advanced: false
   // List rows (wifi SSIDs, devices) stay out of the section modal.
   property bool sectionHelp: true
   // Find a setting indexes SettingRow blocks unless this is false.
@@ -47,7 +51,17 @@ Item {
   }
 
   readonly property bool matches: ShellConfigJs.haystackMatches(query, searchHaystack)
-  readonly property bool shown: available && matches
+  readonly property bool folded: DisclosureJs.rowFolded({
+    advanced: root.advanced,
+    query: root.query,
+    label: root.label,
+    hub: root.resolvedHubId
+  }, {
+    simple: Disclosure.simple,
+    revealedHub: Disclosure.revealedHub,
+    revealedLabel: Disclosure.revealedLabel
+  })
+  readonly property bool shown: available && matches && !folded
 
   property string favoriteHub: ""
   readonly property string resolvedHubId: {

--- a/pages/AppearancePage.qml
+++ b/pages/AppearancePage.qml
@@ -373,6 +373,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Warmth is Kelvin. 6500 is daylight. Lower numbers go amber. This talks to hyprsunset the same way the toggle does."
 

--- a/pages/ApplicationsPage.qml
+++ b/pages/ApplicationsPage.qml
@@ -242,6 +242,7 @@ PrefsPage {
   PrefsGroup {
     framed: true
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Autostart writes a managed block at the end of ~/.config/hypr/autostart.lua. Lines you typed yourself stay. Remove only deletes a line Atmos added."
     hint: "~/.config/hypr/autostart.lua"

--- a/pages/BarPage.qml
+++ b/pages/BarPage.qml
@@ -641,6 +641,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Shell plugins Omarchy discovered. The bar itself cannot be disabled. Other widgets and services can."
 

--- a/pages/DefaultsPage.qml
+++ b/pages/DefaultsPage.qml
@@ -141,6 +141,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "XDG defaults for PDFs, images, and video. Browser, terminal, and editor stay in the group above."
 

--- a/pages/DisksPage.qml
+++ b/pages/DisksPage.qml
@@ -526,6 +526,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "How many Snapper snapshots to keep, whether hourly snapshots run, and weekly SSD TRIM."
 

--- a/pages/IdlePage.qml
+++ b/pages/IdlePage.qml
@@ -145,6 +145,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: Omarchy.isLaptop ? root.query : "."
     detail: "Lid close already locks when the machine is undocked. Omarchy runs that from logind, not from Atmos."
 

--- a/pages/InputPage.qml
+++ b/pages/InputPage.qml
@@ -271,6 +271,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     writesFile: "~/.config/hypr/input.lua"
     writesNote: Omarchy.hyprWorkspaceGestureUnmanaged ? "your gesture stays" : ""

--- a/pages/NetworkPage.qml
+++ b/pages/NetworkPage.qml
@@ -363,6 +363,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Tailscale is a mesh VPN Omarchy can install. LocalSend and Taildrop are actions, not extra config."
 

--- a/pages/SearchPage.qml
+++ b/pages/SearchPage.qml
@@ -130,8 +130,10 @@ Item {
           valueText: modelData.hubTitle || modelData.hub || ""
           onClicked: {
             // hub is a hub id or a hub/subpage path such as windows/bindings.
+            // Pass the label so Simple can pin the landing row after chrome
+            // search clears the query.
             if (root.navigator && root.navigator.go)
-              root.navigator.go(modelData.hub)
+              root.navigator.go(modelData.hub, modelData.label)
           }
         }
       }

--- a/pages/SecurityPage.qml
+++ b/pages/SecurityPage.qml
@@ -237,6 +237,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Passwordless sudo is timed. Sudoless Docker puts this account in the docker group."
 

--- a/pages/SoundPage.qml
+++ b/pages/SoundPage.qml
@@ -202,6 +202,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Voxtype is Omarchy's dictation tool. Install pulls the package and a model. Hold F9 after it is ready."
 

--- a/pages/SystemPage.qml
+++ b/pages/SystemPage.qml
@@ -434,6 +434,7 @@ PrefsPage {
   PrefsGroup {
     framed: true
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Leftover packages, the pacman download cache, and restore for Hyprland Lua or shell.json. Firmware updates are on Drivers."
 

--- a/pages/WindowsPage.qml
+++ b/pages/WindowsPage.qml
@@ -348,6 +348,7 @@ PrefsPage {
 
   PrefsGroup {
     title: "Advanced"
+    advanced: true
     query: root.query
     detail: "Dim, animations, cursor, and tearing. These go in the same looknfeel.lua block as the sliders above."
 

--- a/services/Disclosure.js
+++ b/services/Disclosure.js
@@ -1,0 +1,129 @@
+// Simple / Everything fold math.
+//
+// A row or section can opt in with advanced:true. Simple folds those
+// without removing them: a non-empty query skips the fold, and a search
+// hit pins the landing row (and its section) until the user leaves the hub.
+// Mode is session state. Nothing here is persisted.
+
+function normalizeHub(hub) {
+  var raw = String(hub || "");
+  var slash = raw.indexOf("/");
+  return slash === -1 ? raw : raw.substring(0, slash);
+}
+
+function emptyState() {
+  return {
+    simple: false,
+    revealedHub: "",
+    revealedLabel: "",
+    pending: false,
+  };
+}
+
+function copyState(state) {
+  var s = state || emptyState();
+  return {
+    simple: !!s.simple,
+    revealedHub: String(s.revealedHub || ""),
+    revealedLabel: String(s.revealedLabel || ""),
+    pending: !!s.pending,
+  };
+}
+
+function revealFromSearch(state, hub, label) {
+  var next = copyState(state);
+  next.revealedHub = normalizeHub(hub);
+  next.revealedLabel = String(label || "");
+  next.pending = next.revealedLabel.length > 0;
+  if (!next.pending) {
+    next.revealedHub = "";
+    next.revealedLabel = "";
+  }
+  return next;
+}
+
+// Sidebar / loadHub. A search click clears the find field first, which
+// reloads the previous hub before openPage lands on the hit. Pending
+// keeps that intermediate load from dropping the pin.
+function leaveHub(state, hub) {
+  var next = copyState(state);
+  if (next.pending) return next;
+  var id = normalizeHub(hub);
+  if (next.revealedHub && id !== next.revealedHub) {
+    next.revealedHub = "";
+    next.revealedLabel = "";
+  }
+  return next;
+}
+
+function finishReveal(state, hub) {
+  var next = copyState(state);
+  var id = normalizeHub(hub);
+  var keep = next.revealedHub && next.revealedLabel && id === next.revealedHub;
+  next.pending = false;
+  if (!keep) {
+    next.revealedHub = "";
+    next.revealedLabel = "";
+  }
+  return next;
+}
+
+function isRevealed(row, state) {
+  var s = state || emptyState();
+  if (!s.revealedLabel) return false;
+  if (String((row && row.label) || "") !== s.revealedLabel) return false;
+  var rowHub = normalizeHub(row && row.hub);
+  if (rowHub && s.revealedHub && rowHub !== s.revealedHub) return false;
+  return true;
+}
+
+function groupRevealed(group, state) {
+  var s = state || emptyState();
+  if (!s.revealedLabel) return false;
+  var hub = normalizeHub(group && group.hub);
+  if (hub && s.revealedHub && hub !== s.revealedHub) return false;
+  var labels = (group && group.labels) || [];
+  var i;
+  for (i = 0; i < labels.length; i++) {
+    if (String(labels[i] || "") === s.revealedLabel) return true;
+  }
+  return false;
+}
+
+function rowFolded(row, state) {
+  if (!row || !row.advanced) return false;
+  var s = state || emptyState();
+  if (!s.simple) return false;
+  if (String(row.query || "").length > 0) return false;
+  if (isRevealed(row, s)) return false;
+  return true;
+}
+
+function groupFolded(group, state) {
+  if (!group || !group.advanced) return false;
+  var s = state || emptyState();
+  if (!s.simple) return false;
+  if (String(group.query || "").length > 0) return false;
+  if (groupRevealed(group, s)) return false;
+  return true;
+}
+
+function showModeToggle(hasAdvanced, opts) {
+  var o = opts || {};
+  if (!hasAdvanced) return false;
+  if (o.embed) return false;
+  if (String(o.query || "").length > 0) return false;
+  return true;
+}
+
+// Section "?" walks rows even when Simple folded them. Other hides
+// (no match, unavailable) stay omitted.
+function helpCollectsRow(row, opts) {
+  var o = opts || {};
+  if (!row) return false;
+  if (row.available === false) return false;
+  if (row.matches === false) return false;
+  if (row.sectionHelp === false) return false;
+  if (row.visible === false && !(o.includeFolded && row.folded === true)) return false;
+  return true;
+}

--- a/services/Disclosure.qml
+++ b/services/Disclosure.qml
@@ -1,0 +1,41 @@
+pragma Singleton
+import QtQuick
+import "Disclosure.js" as DisclosureJs
+
+// Simple / Everything. Session-only; see Disclosure.js for the rules.
+QtObject {
+  id: root
+
+  property bool simple: false
+  property string revealedHub: ""
+  property string revealedLabel: ""
+  property bool pending: false
+
+  function snapshot() {
+    return {
+      simple: root.simple,
+      revealedHub: root.revealedHub,
+      revealedLabel: root.revealedLabel,
+      pending: root.pending
+    }
+  }
+
+  function apply(next) {
+    root.simple = next.simple
+    root.revealedHub = next.revealedHub
+    root.revealedLabel = next.revealedLabel
+    root.pending = next.pending
+  }
+
+  function revealFromSearch(hub, label) {
+    apply(DisclosureJs.revealFromSearch(snapshot(), hub, label))
+  }
+
+  function leaveHub(hub) {
+    apply(DisclosureJs.leaveHub(snapshot(), hub))
+  }
+
+  function finishReveal(hub) {
+    apply(DisclosureJs.finishReveal(snapshot(), hub))
+  }
+}

--- a/services/qmldir
+++ b/services/qmldir
@@ -1,3 +1,4 @@
 singleton Theme 1.0 Theme.qml
 singleton AccountsStore 1.0 AccountsStore.qml
 singleton Omarchy 1.0 Omarchy.qml
+singleton Disclosure 1.0 Disclosure.qml

--- a/shell.qml
+++ b/shell.qml
@@ -135,6 +135,7 @@ ShellRoot {
   }
 
   function loadHub(id) {
+    Disclosure.leaveHub(hubId(id))
     currentPage = id
     if (pageStack.depth > 0)
       pageStack.clear(StackView.Immediate)
@@ -181,6 +182,7 @@ ShellRoot {
     var sub = subId(id)
     for (var i = 0; i < pages.length; i++) {
       if (pages[i].id === hub) {
+        Disclosure.finishReveal(hub)
         loadHub(hub)
         window.visible = true
         window.minimized = false
@@ -193,6 +195,7 @@ ShellRoot {
         return "ok"
       }
     }
+    Disclosure.finishReveal("")
     return "unknown"
   }
 
@@ -209,7 +212,9 @@ ShellRoot {
 
   QtObject {
     id: prefsNavigator
-    function go(path) {
+    function go(path, label) {
+      if (label)
+        Disclosure.revealFromSearch(path, label)
       searchField.text = ""
       Qt.callLater(function() { root.openPage(path) })
     }

--- a/tests/disclosure.test.js
+++ b/tests/disclosure.test.js
@@ -1,0 +1,238 @@
+const fs = require("fs");
+const path = require("path");
+const { load, assert, assertEqual } = require("./harness");
+
+const d = load("services/Disclosure.js");
+
+assertEqual(d.normalizeHub("input"), "input", "normalizeHub keeps a hub id");
+assertEqual(d.normalizeHub("windows/bindings"), "windows", "normalizeHub strips a subpage");
+assertEqual(d.normalizeHub(""), "", "normalizeHub empty stays empty");
+
+const idle = d.emptyState();
+assertEqual(idle.simple, false, "default mode is Everything");
+assertEqual(idle.revealedLabel, "", "default has no search pin");
+assertEqual(idle.pending, false, "default is not pending a search land");
+
+const accel = { advanced: true, query: "", label: "Acceleration", hub: "input" };
+assertEqual(d.rowFolded(accel, idle), false, "Everything does not fold an advanced row");
+assertEqual(
+  d.rowFolded(accel, { simple: true }),
+  true,
+  "Simple folds an advanced row when the query is empty",
+);
+assertEqual(
+  d.rowFolded({ advanced: true, query: "accel", label: "Acceleration" }, { simple: true }),
+  false,
+  "a non-empty query unfolds an advanced row",
+);
+assertEqual(
+  d.rowFolded({ advanced: false, query: "", label: "Sensitivity" }, { simple: true }),
+  false,
+  "Simple leaves an untagged row alone",
+);
+assertEqual(
+  d.rowFolded({ query: "" }, { simple: true }),
+  false,
+  "a row without advanced never folds",
+);
+
+let state = d.emptyState();
+state.simple = true;
+assert(d.rowFolded(accel, state), "Simple + empty query folds Acceleration");
+
+state = d.revealFromSearch(state, "input", "Follow mouse");
+assertEqual(state.pending, true, "search navigation marks the pin pending");
+assertEqual(state.revealedHub, "input", "search pin stores the hub");
+assertEqual(state.revealedLabel, "Follow mouse", "search pin stores the row label");
+assertEqual(
+  d.rowFolded({ advanced: true, query: "", label: "Follow mouse", hub: "input" }, state),
+  false,
+  "the landing row is not folded after a search hit",
+);
+assertEqual(
+  d.rowFolded({ advanced: true, query: "", label: "Wake on key", hub: "input" }, state),
+  true,
+  "a different advanced row stays folded",
+);
+
+const mid = d.leaveHub(state, "appearance");
+assertEqual(
+  mid.revealedLabel,
+  "Follow mouse",
+  "pending pin survives the hub reload that clears search",
+);
+assertEqual(mid.pending, true, "leaveHub does not consume a pending search pin");
+
+state = d.finishReveal(mid, "input");
+assertEqual(state.pending, false, "landing the search hit consumes pending");
+assertEqual(state.revealedLabel, "Follow mouse", "pin stays after the page opens");
+assertEqual(
+  d.rowFolded({ advanced: true, query: "", label: "Follow mouse", hub: "input" }, state),
+  false,
+  "the landing row stays revealed until the user leaves",
+);
+
+state = d.leaveHub(state, "appearance");
+assertEqual(state.revealedLabel, "", "leaving the hub drops the pin");
+assertEqual(
+  d.rowFolded({ advanced: true, query: "", label: "Follow mouse", hub: "input" }, state),
+  true,
+  "the row folds again after leave",
+);
+
+const noLabel = d.revealFromSearch(d.emptyState(), "input", "");
+assertEqual(noLabel.pending, false, "go without a label does not pin");
+assertEqual(noLabel.revealedHub, "", "go without a label does not keep a hub");
+
+const miss = d.finishReveal(
+  d.revealFromSearch({ simple: true }, "input", "Follow mouse"),
+  "accounts",
+);
+assertEqual(miss.revealedLabel, "", "landing on another hub drops the pin");
+assertEqual(miss.pending, false, "a missed land is not left pending");
+
+const group = {
+  advanced: true,
+  query: "",
+  hub: "input",
+  labels: ["Follow mouse", "Wake on key", "Three-finger swipe"],
+};
+assertEqual(d.groupFolded(group, idle), false, "Everything leaves an Advanced section up");
+assertEqual(
+  d.groupFolded(group, { simple: true }),
+  true,
+  "Simple folds an opted-in Advanced section",
+);
+assertEqual(
+  d.groupFolded(group, { simple: true, revealedHub: "input", revealedLabel: "Follow mouse" }),
+  false,
+  "a search hit inside the section unfolds the whole section",
+);
+assertEqual(
+  d.groupFolded(group, { simple: true, revealedHub: "input", revealedLabel: "Sensitivity" }),
+  true,
+  "a search hit on another row does not unfold the section",
+);
+assertEqual(
+  d.groupFolded({ advanced: true, query: "follow", labels: ["Follow mouse"] }, { simple: true }),
+  false,
+  "a non-empty query unfolds an Advanced section",
+);
+assertEqual(
+  d.groupFolded({ advanced: false, query: "", labels: ["Follow mouse"] }, { simple: true }),
+  false,
+  "an untagged section never folds",
+);
+
+assertEqual(d.showModeToggle(false, {}), false, "no toggle when the page has no advanced rows");
+assertEqual(d.showModeToggle(true, {}), true, "toggle when the page opted in");
+assertEqual(
+  d.showModeToggle(true, { embed: true }),
+  false,
+  "embedded pages do not show the toggle",
+);
+assertEqual(d.showModeToggle(true, { query: "mouse" }), false, "in-page query hides the toggle");
+assertEqual(
+  d.showModeToggle(false, { query: "" }),
+  false,
+  "empty query is not enough without advanced rows",
+);
+
+assertEqual(
+  d.helpCollectsRow({ available: true, matches: true, visible: true, folded: false }),
+  true,
+  "help keeps a visible matching row",
+);
+assertEqual(
+  d.helpCollectsRow({ available: true, matches: true, visible: false, folded: true }),
+  false,
+  "help skips a folded row unless asked",
+);
+assertEqual(
+  d.helpCollectsRow(
+    { available: true, matches: true, visible: false, folded: true },
+    { includeFolded: true },
+  ),
+  true,
+  "section help includes a folded row",
+);
+assertEqual(
+  d.helpCollectsRow(
+    { available: true, matches: false, visible: false, folded: true },
+    { includeFolded: true },
+  ),
+  false,
+  "help still omits a row the query missed",
+);
+assertEqual(
+  d.helpCollectsRow(
+    { available: false, matches: true, visible: false, folded: true },
+    { includeFolded: true },
+  ),
+  false,
+  "help still omits an unavailable row",
+);
+assertEqual(
+  d.helpCollectsRow(
+    { available: true, matches: true, visible: false, folded: true, sectionHelp: false },
+    { includeFolded: true },
+  ),
+  false,
+  "list rows stay out of section help",
+);
+
+function walkQml(dir, acc) {
+  acc = acc || [];
+  fs.readdirSync(dir, { withFileTypes: true }).forEach(function (ent) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) walkQml(full, acc);
+    else if (ent.name.endsWith(".qml")) acc.push(full);
+  });
+  return acc;
+}
+
+const pagesDir = path.join(__dirname, "..", "pages");
+const advancedBlocks = [];
+const untriagedHits = [];
+walkQml(pagesDir).forEach(function (file) {
+  const src = fs.readFileSync(file, "utf8");
+  const rel = path.relative(path.join(__dirname, ".."), file);
+  const re = /title:\s*"Advanced"/g;
+  let m;
+  while ((m = re.exec(src))) {
+    const window = src.slice(Math.max(0, m.index - 40), m.index + 80);
+    advancedBlocks.push({ rel: rel, window: window });
+  }
+  if (/DiagnosticsPage|AccountsPage|FavoritesPage/.test(rel) && /advanced:\s*true/.test(src)) {
+    untriagedHits.push(rel);
+  }
+});
+
+assert(advancedBlocks.length >= 12, "existing Advanced sections are still in the tree");
+advancedBlocks.forEach(function (block) {
+  assert(
+    /title:\s*"Advanced"[\s\S]{0,80}advanced:\s*true/.test(block.window) ||
+      /advanced:\s*true[\s\S]{0,80}title:\s*"Advanced"/.test(block.window),
+    block.rel + " Advanced section opts into Disclosure",
+  );
+});
+assertEqual(untriagedHits.length, 0, "Diagnostics, Accounts, and Favorites stay untriaged");
+
+const inputSrc = fs.readFileSync(path.join(pagesDir, "InputPage.qml"), "utf8");
+assert(
+  /title:\s*"Advanced"[\s\S]{0,80}advanced:\s*true/.test(inputSrc),
+  "Input folds its existing Advanced section",
+);
+assert(
+  !/label:\s*"Acceleration"[\s\S]{0,80}advanced:\s*true/.test(inputSrc) &&
+    !/advanced:\s*true[\s\S]{0,40}label:\s*"Acceleration"/.test(inputSrc),
+  "Input does not mark Acceleration as the Simple demo",
+);
+assert(
+  !/label:\s*"Scroll inertia"[\s\S]{0,80}advanced:\s*true/.test(inputSrc),
+  "Input does not mark Scroll inertia as the Simple demo",
+);
+assert(
+  !/label:\s*"Three-finger drag"[\s\S]{0,80}advanced:\s*true/.test(inputSrc),
+  "Input does not mark Three-finger drag as the Simple demo",
+);

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -20,6 +20,10 @@ assert(
   searchPageSrc.indexOf('SearchIndex.js", "query"') === -1,
   "SearchPage does not spawn a query process per keystroke",
 );
+assert(
+  searchPageSrc.indexOf("root.navigator.go(modelData.hub, modelData.label)") !== -1,
+  "SearchPage passes the hit label so Simple can pin the landing row",
+);
 const omarchyQml = fs.readFileSync(path.join(__dirname, "..", "services", "Omarchy.qml"), "utf8");
 assert(
   omarchyQml.indexOf('enqueueRead(ioQueue, "rest")') !== -1,
@@ -411,6 +415,42 @@ assert(
     prefsPageSrc.indexOf("Theme.copyInset") !== -1,
   "PrefsPage uses Theme page title, description, margin, section spacing, and copy inset",
 );
+assert(
+  prefsPageSrc.indexOf("readonly property bool showDisclosure:") !== -1 &&
+    prefsPageSrc.indexOf("DisclosureJs.showModeToggle(root.hasAdvanced") !== -1,
+  "PrefsPage shows Simple/Everything only on pages that opted in",
+);
+assert(
+  prefsPageSrc.indexOf(
+    "visible: root.query.length === 0 && !root.embed && root.title.length > 0",
+  ) === -1,
+  "PrefsPage does not paint the mode toggle on every titled hub",
+);
+
+const disclosureQml = fs.readFileSync(
+  path.join(__dirname, "..", "services", "Disclosure.qml"),
+  "utf8",
+);
+assert(
+  disclosureQml.indexOf("pragma Singleton") !== -1 &&
+    disclosureQml.indexOf("property bool simple: false") !== -1 &&
+    disclosureQml.indexOf("Settings") === -1 &&
+    disclosureQml.indexOf("store") === -1,
+  "Disclosure is a session singleton and is not persisted",
+);
+const qmldir = fs.readFileSync(path.join(__dirname, "..", "services", "qmldir"), "utf8");
+assert(
+  qmldir.indexOf("singleton Disclosure 1.0 Disclosure.qml") !== -1,
+  "qmldir registers the Disclosure singleton",
+);
+const chromeSrc = fs.readFileSync(path.join(__dirname, "..", "shell.qml"), "utf8");
+assert(
+  chromeSrc.indexOf("function go(path, label)") !== -1 &&
+    chromeSrc.indexOf("Disclosure.revealFromSearch(path, label)") !== -1 &&
+    chromeSrc.indexOf("Disclosure.finishReveal(hub)") !== -1 &&
+    chromeSrc.indexOf("Disclosure.leaveHub(hubId(id))") !== -1,
+  "chrome search pins the landing row and drops the pin when leaving the hub",
+);
 
 const settingRowSrc = fs.readFileSync(
   path.join(__dirname, "..", "components", "SettingRow.qml"),
@@ -421,6 +461,18 @@ assert(
     settingRowSrc.indexOf("Theme.iconStar") !== -1 &&
     settingRowSrc.indexOf("Omarchy.toggleFavorite") !== -1,
   "SettingRow stars a row through Omarchy.toggleFavorite",
+);
+assert(
+  settingRowSrc.indexOf("property bool advanced: false") !== -1 &&
+    settingRowSrc.indexOf("DisclosureJs.rowFolded") !== -1 &&
+    settingRowSrc.indexOf("shown: available && matches && !folded") !== -1,
+  "SettingRow folds through Disclosure.js so search can pin the landing row",
+);
+assert(
+  prefsGroupSrcEarly.indexOf("property bool advanced: false") !== -1 &&
+    prefsGroupSrcEarly.indexOf("DisclosureJs.groupFolded") !== -1 &&
+    prefsGroupSrcEarly.indexOf("collectPrefsRows({ includeFolded: true })") !== -1,
+  "PrefsGroup folds Advanced sections with the same Disclosure model and keeps them in section help",
 );
 assert(
   settingRowSrc.indexOf("readonly property int favoriteGutter:") !== -1 &&
@@ -957,7 +1009,7 @@ assert(
   "the first row in a framed card has no hairline under the card edge",
 );
 assert(
-  prefsGroupSrc.indexOf("function collectPrefsRows()") !== -1 &&
+  prefsGroupSrc.indexOf("function collectPrefsRows(") !== -1 &&
     prefsGroupSrc.indexOf("kid.available === false") !== -1 &&
     prefsGroupSrc.indexOf("walk(kid)") !== -1,
   "framed split walks Repeater delegates and skips a hidden empty row",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Simple/Everything fold, based on nixfred's #34, rebased onto current `main` (through #50) and fixed so the fold is disclosure rather than a hide.

A row or `PrefsGroup` opts in with `advanced: true`. Simple folds those. Everything is unchanged. Mode is a session singleton and is not persisted.

### Against #34

1. **Search hit reveals the row.** Chrome find still swaps in SearchPage and clears the query on click. `navigator.go(hub, label)` now pins that label until you leave the hub, so Simple cannot fold the landing row (or its Advanced section) again. The in-page empty-query fold rule is unchanged.
2. **Toggle only where it matters.** The Simple/Everything control is on `PrefsPage` only when the page has at least one `advanced` row or section. Diagnostics, Accounts, Favorites, and other untriaged hubs render as they do today.
3. **One disclosure story.** Existing Advanced `PrefsGroup`s opt into the same model. Input no longer tags Acceleration / Scroll inertia / Three-finger drag. Simple folds the Advanced block (Follow mouse, wake, layouts, swipe) and leaves Pointer as the primary settings. Section `?` help still lists folded rows.

### Tests

- Search navigation pins the landing row through the chrome clear-query path
- Toggle absent when the page has no advanced rows
- Fold math for empty vs non-empty query, plus section help including folded rows

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-207c4101-352c-4b8b-a94f-059362eaba30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207c4101-352c-4b8b-a94f-059362eaba30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

