### PR TITLE
feat: one Atmos window per launch, with every window kept in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ A [Quickshell](https://quickshell.org) preferences window for [Omarchy](https://
 ./bin/atmos
 ```
 
-A second launch focuses the window that is already open. Pass a page if you want to land somewhere specific:
+Every launch opens its own window: run it twice and two windows open, each
+with its own engine. Open windows stay in sync through the files they
+share — a change in one appears in the other — and concurrent writes
+serialize on disk, so they cannot tear a config file. Pass a page if you
+want a window to land somewhere specific:
 
 ```bash
 ./bin/atmos appearance

--- a/bin/atmos
+++ b/bin/atmos
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Launch or focus the Atmos window.
+# Open an Atmos window. Every launch is its own instance: run this twice
+# and two windows open, each with its own engine and Omarchy queue.
+# Instances converge through the files they share. Writes serialize in
+# hypr-sentinel.py (flock + atomic rename) and the shell.json writers, so
+# concurrent edits cannot tear a file. File watchers re-read what another
+# window wrote, so all open windows settle on the same state.
 
 set -euo pipefail
 
@@ -28,45 +33,6 @@ if [[ -n $PAGE && $HUB != favorites && $HUB != appearance && $HUB != display && 
   exit 1
 fi
 
-prefs_pid() {
-  ps -eo pid=,args= | awk -v root="$ROOT" '
-    $2 == "quickshell" {
-      for (i = 3; i <= NF; i++) if ($i == "-p" && $(i + 1) == root) { print $1; exit }
-    }
-  '
-}
-
-ipc() {
-  quickshell ipc -p "$ROOT" call -- prefs "$@"
-}
-
-focus_existing() {
-  if [[ -n $PAGE ]]; then
-    ipc open "$PAGE"
-  else
-    ipc show
-  fi
-}
-
-if ipc ping >/dev/null 2>&1; then
-  focus_existing
-  exit 0
-fi
-
-# A starting instance has a process before IpcHandler answers. Do not spawn
-# a second engine with the same QS_APP_ID; the portal rejects it.
-if [[ -n $(prefs_pid) ]]; then
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if ipc ping >/dev/null 2>&1; then
-      focus_existing
-      exit 0
-    fi
-    sleep 0.15
-  done
-  echo "atmos: a preferences process is running but IPC is not answering" >&2
-  exit 1
-fi
-
 if [[ -n $PAGE ]]; then
   export ATMOS_PAGE=$PAGE
 fi
@@ -76,4 +42,7 @@ export QS_APP_ID=dev.csfh.atmos
 # for the desktop file name. It does not stop the window from opening.
 export QT_LOGGING_RULES="${QT_LOGGING_RULES:-qt.qpa.services=false}"
 
-exec quickshell -n -p "$ROOT"
+# No -n duplicate refusal and no focus-stealing: each launch owns its
+# window. The shared QS_APP_ID keeps the Hyprland window rule matching;
+# concurrent engines with the same id open fine (the portal log is noise).
+exec quickshell -p "$ROOT"

--- a/packaging/hypr-atmos.lua
+++ b/packaging/hypr-atmos.lua
@@ -1,6 +1,4 @@
--- Float and center the Atmos window.
+-- Tile the Atmos window like other apps.
 -- Install as ~/.config/hypr/atmos.lua and require("hypr.atmos")
 -- from hyprland.lua next to require("hypr.omafetch"), before toggles.
-o.window("dev.csfh.atmos", { float = true })
-o.window("dev.csfh.atmos", { center = true })
-o.window("dev.csfh.atmos", { size = { 960, 680 } })
+o.window("dev.csfh.atmos", { tile = true })

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -33,12 +33,27 @@ TOGGLES_LINE = 'require("default.hypr.toggles")'
 WINDOW_CLASS = "dev.csfh.atmos"
 PREFS_WINDOW_SEED = "\n".join(
     [
+        "-- Tile the Atmos window like other apps.",
+        f'o.window("{WINDOW_CLASS}", {{ tile = true }})',
+    ]
+)
+# The seed above used to float and center the window. Existing installs
+# still carry those exact lines; rewrite only that block so a customized
+# rule is never touched.
+FLOAT_WINDOW_SEED = "\n".join(
+    [
         "-- Float and center the Atmos window.",
         f'o.window("{WINDOW_CLASS}", {{ float = true }})',
         f'o.window("{WINDOW_CLASS}", {{ center = true }})',
         f'o.window("{WINDOW_CLASS}", {{ size = {{ 960, 680 }} }})',
     ]
 )
+
+
+def normalize_prefs_window_seed(text: str) -> str:
+    if FLOAT_WINDOW_SEED in (text or ""):
+        return text.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
+    return text
 
 
 def lua_number(n: float | int) -> str:
@@ -1283,6 +1298,8 @@ def apply(kind: str, path: Path, payload: dict | None, reset: bool) -> str:
     text = path.read_text() if path.exists() else ""
     if kind == "windows" and not text.strip():
         text = PREFS_WINDOW_SEED + "\n"
+    if kind == "windows":
+        text = normalize_prefs_window_seed(text)
     if kind == "look":
         text = strip_sentinel(text, LEGACY_LOOK_BEGIN, LEGACY_LOOK_END)
         begin, end, serialize = LOOK_BEGIN, LOOK_END, serialize_look

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 LOOK_BEGIN = "-- atmos:look begin"
@@ -387,6 +390,184 @@ def replace_sentinel(text: str, begin: str, end: str, block: str) -> str:
         return (trimmed + "\n\n" + body + "\n") if trimmed else body + "\n"
     start, stop = bounds
     return text[:start] + body + text[stop:]
+
+
+def lock_path_for(dest: Path) -> Path:
+    return dest.parent / (dest.name + ".atmos.lock")
+
+
+def atomic_write_text(dest: Path, text: str) -> None:
+    body = text if text.endswith("\n") or not text else text + "\n"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix="." + dest.name + ".", dir=str(dest.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _lua_bool_field(body: str, name: str) -> bool | None:
+    m = re.search(rf"{re.escape(name)}\s*=\s*(true|false)", body)
+    if not m:
+        return None
+    return m.group(1) == "true"
+
+
+def _lua_num_field(block: str, name: str) -> str:
+    m = re.search(rf"{re.escape(name)}\s*=\s*(-?[0-9]+(?:\.[0-9]+)?)", block)
+    return m.group(1) if m else ""
+
+
+def _lua_str_field(block: str, name: str) -> str:
+    m = re.search(rf'{re.escape(name)}\s*=\s*"((?:\\.|[^"\\])*)"', block)
+    if not m:
+        return ""
+    return unescape_lua(m.group(1))
+
+
+def parse_look_block(text: str) -> dict:
+    bounds = sentinel_bounds(text or "", LOOK_BEGIN, LOOK_END)
+    if not bounds:
+        return {}
+    body = text[bounds[0] : bounds[1]]
+    out: dict = {}
+    num_keys = (
+        ("gaps_in", "gapsIn"),
+        ("gaps_out", "gapsOut"),
+        ("border_size", "borderSize"),
+        ("rounding", "rounding"),
+        ("dim_strength", "dimStrength"),
+        ("active_opacity", "activeOpacity"),
+        ("inactive_opacity", "inactiveOpacity"),
+        ("column_width", "columnWidth"),
+        ("on_focus_under_fullscreen", "onFocusUnderFullscreen"),
+    )
+    for lua_name, key in num_keys:
+        raw = _lua_num_field(body, lua_name)
+        if raw == "":
+            continue
+        try:
+            out[key] = float(raw) if "." in raw else int(raw)
+        except ValueError:
+            continue
+    bool_keys = (
+        ("allow_tearing", "allowTearing"),
+        ("resize_on_border", "resizeOnBorder"),
+        ("dim_inactive", "dimInactive"),
+        ("focus_on_activate", "focusOnActivate"),
+        ("enable_swallow", "enableSwallow"),
+        ("hide_on_key_press", "cursorHideOnKey"),
+        ("preserve_split", "preserveSplit"),
+    )
+    for lua_name, key in bool_keys:
+        val = _lua_bool_field(body, lua_name)
+        if val is not None:
+            out[key] = val
+    for section, key in (("shadow", "shadow"), ("blur", "blur")):
+        m = re.search(rf"{section}\s*=\s*\{{\s*enabled\s*=\s*(true|false)", body)
+        if m:
+            out[key] = m.group(1) == "true"
+    m = re.search(r"animations\s*=\s*\{\s*enabled\s*=\s*(true|false)", body)
+    if m:
+        out["animations"] = m.group(1) == "true"
+    layout = _lua_str_field(body, "layout")
+    if layout:
+        out["layout"] = layout
+    swallow = _lua_str_field(body, "swallow_regex")
+    if swallow or 'swallow_regex' in body:
+        out["swallowRegex"] = swallow
+    warp = re.search(r"warp_on_change_workspace\s*=\s*(true|false|1|0)", body)
+    if warp:
+        out["cursorWarp"] = warp.group(1) in ("true", "1")
+    m = re.search(r'hl\.env\(\s*"HYPRCURSOR_SIZE"\s*,\s*"([^"]*)"\s*\)', body)
+    if not m:
+        m = re.search(r'hl\.env\(\s*"XCURSOR_SIZE"\s*,\s*"([^"]*)"\s*\)', body)
+    if m:
+        try:
+            out["cursorSize"] = int(float(m.group(1)))
+        except ValueError:
+            pass
+    return out
+
+
+def parse_input_block(text: str) -> dict:
+    bounds = sentinel_bounds(text or "", INPUT_BEGIN, INPUT_END)
+    if not bounds:
+        return {}
+    body = text[bounds[0] : bounds[1]]
+    out: dict = {}
+    raw = _lua_num_field(body, "sensitivity")
+    if raw != "":
+        try:
+            out["sensitivity"] = float(raw)
+        except ValueError:
+            pass
+    accel = _lua_str_field(body, "accel_profile")
+    if accel or "accel_profile" in body:
+        out["accelProfile"] = accel
+    for lua_name, key in (
+        ("emulate_discrete_scroll", "emulateDiscreteScroll"),
+        ("drag_3fg", "drag3fg"),
+        ("repeat_rate", "repeatRate"),
+        ("repeat_delay", "repeatDelay"),
+        ("follow_mouse", "followMouse"),
+    ):
+        raw = _lua_num_field(body, lua_name)
+        if raw == "":
+            continue
+        try:
+            out[key] = float(raw) if "." in raw else int(raw)
+        except ValueError:
+            continue
+    for lua_name, key in (
+        ("natural_scroll", "naturalScroll"),
+        ("clickfinger_behavior", "clickfinger"),
+        ("disable_while_typing", "disableWhileTyping"),
+        ("numlock_by_default", "numlock"),
+        ("key_press_enables_dpms", "keyPressDpms"),
+        ("mouse_move_enables_dpms", "mouseMoveDpms"),
+    ):
+        val = _lua_bool_field(body, lua_name)
+        if val is not None:
+            out[key] = val
+    scroll = _lua_num_field(body, "scroll_factor")
+    if scroll != "":
+        try:
+            out["scrollFactor"] = float(scroll)
+        except ValueError:
+            pass
+    layout = _lua_str_field(body, "kb_layout")
+    if layout or "kb_layout" in body:
+        out["kbLayoutOverride"] = layout
+    variant = _lua_str_field(body, "kb_variant")
+    if variant or "kb_variant" in body:
+        out["kbVariantOverride"] = variant
+    options = _lua_str_field(body, "kb_options")
+    if options or "kb_options" in body:
+        out["kbGroupToggle"] = "grp:alts_toggle" in options
+    if re.search(r"""action\s*=\s*["']workspace["']""", body):
+        out["workspaceGesture"] = True
+    return out
+
+
+def split_patch(payload: dict | None) -> dict | None:
+    if not isinstance(payload, dict):
+        return None
+    patch = payload.get("_patch")
+    if isinstance(patch, dict):
+        return {k: v for k, v in patch.items() if not str(k).startswith("_")}
+    return None
 
 
 def sanitize_command(raw) -> str:
@@ -1127,7 +1308,7 @@ def ensure_layout_file(dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists() and dest.read_text() == body:
         return
-    dest.write_text(body)
+    atomic_write_text(dest, body)
 
 
 def ensure_layout_require(text: str) -> str:
@@ -1322,8 +1503,8 @@ def parse_monitors(text: str) -> list:
     return out
 
 
-def apply(kind: str, path: Path, payload: dict | None, reset: bool) -> str:
-    text = path.read_text() if path.exists() else ""
+def apply(kind: str, path: Path, payload: dict | None, reset: bool, _text: str | None = None) -> str:
+    text = _text if _text is not None else (path.read_text() if path.exists() else "")
     if kind == "windows" and not text.strip():
         text = PREFS_WINDOW_SEED + "\n"
     if kind == "windows":
@@ -1346,8 +1527,25 @@ def apply(kind: str, path: Path, payload: dict | None, reset: bool) -> str:
         begin, end, serialize = INPUT_BEGIN, INPUT_END, serialize_input
     if reset:
         return strip_sentinel(text, begin, end)
+    # A _patch payload carries only the fields one write changed. Merge
+    # those onto what is on disk right now (under the caller's lock) so two
+    # windows editing different fields do not clobber each other. A plain
+    # object without _patch is a full managed block, as before.
     if kind == "input":
+        patch = split_patch(payload)
+        if patch is not None:
+            base = parse_input_block(text)
+            base.update(patch)
+            if "workspaceGesture" not in patch and "workspaceGesture" not in base:
+                base["workspaceGesture"] = input_has_workspace_gesture(text)
+            return replace_sentinel(text, begin, end, serialize_input(base, text))
         return replace_sentinel(text, begin, end, serialize_input(payload or {}, text))
+    if kind == "look":
+        patch = split_patch(payload)
+        if patch is not None:
+            base = parse_look_block(text)
+            base.update(patch)
+            return replace_sentinel(text, begin, end, serialize_look(base))
     return replace_sentinel(text, begin, end, serialize(payload or {}))
 
 
@@ -1372,13 +1570,20 @@ def main() -> int:
             return 2
         if not dest.exists():
             return 0
-        text = dest.read_text()
-        if not text.strip():
-            return 0
-        ensure_layout_file(dest.parent / "atmos_layout.lua")
-        updated = ensure_atmos_require(text)
-        updated = ensure_layout_require(updated)
-        dest.write_text(updated if updated.endswith("\n") or not updated else updated + "\n")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(lock_path_for(dest), "a+") as lock:
+            try:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+            text = dest.read_text()
+            if not text.strip():
+                return 0
+            ensure_layout_file(dest.parent / "atmos_layout.lua")
+            updated = ensure_atmos_require(text)
+            updated = ensure_layout_require(updated)
+            if updated != text:
+                atomic_write_text(dest, updated)
         return 0
     if action == "list":
         text = dest.read_text() if dest.exists() else ""
@@ -1413,8 +1618,18 @@ def main() -> int:
             print("hypr-sentinel.py: JSON object required", file=sys.stderr)
             return 2
     dest.parent.mkdir(parents=True, exist_ok=True)
-    updated = apply(kind, dest, payload, reset=action == "reset")
-    dest.write_text(updated if updated.endswith("\n") or not updated else updated + "\n")
+    # Serialize concurrent writers from every Atmos window (and imports)
+    # through one exclusive lock per destination file, and publish with an
+    # atomic rename so readers never see a torn mid-write file.
+    with open(lock_path_for(dest), "a+") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        except OSError:
+            pass
+        text = dest.read_text() if dest.exists() else ""
+        updated = apply(kind, dest, payload, reset=action == "reset", _text=text)
+        if updated != text:
+            atomic_write_text(dest, updated)
     return 0
 
 

--- a/scripts/hypr-sentinel.py
+++ b/scripts/hypr-sentinel.py
@@ -37,9 +37,18 @@ PREFS_WINDOW_SEED = "\n".join(
         f'o.window("{WINDOW_CLASS}", {{ tile = true }})',
     ]
 )
+FLOAT_SEED_LINES = {
+    f'o.window("{WINDOW_CLASS}", {{ float = true }})',
+    f'o.window("{WINDOW_CLASS}", {{ center = true }})',
+    f'o.window("{WINDOW_CLASS}", {{ size = {{ 960, 680 }} }})',
+}
+FLOAT_SEED_COMMENT = "-- Float and center the Atmos window."
+TILE_SEED_COMMENT = "-- Tile the Atmos window like other apps."
+TILE_SEED_LINE = f'o.window("{WINDOW_CLASS}", {{ tile = true }})'
 # The seed above used to float and center the window. Existing installs
-# still carry those exact lines; rewrite only that block so a customized
-# rule is never touched.
+# still carry those exact lines, either as the bare seed or under the
+# packaging header comments; rewrite only those verbatim lines so a
+# customized rule is never touched.
 FLOAT_WINDOW_SEED = "\n".join(
     [
         "-- Float and center the Atmos window.",
@@ -51,9 +60,28 @@ FLOAT_WINDOW_SEED = "\n".join(
 
 
 def normalize_prefs_window_seed(text: str) -> str:
-    if FLOAT_WINDOW_SEED in (text or ""):
-        return text.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
-    return text
+    src = text or ""
+    if FLOAT_WINDOW_SEED in src:
+        return src.replace(FLOAT_WINDOW_SEED, PREFS_WINDOW_SEED)
+    if TILE_SEED_LINE in src:
+        return src
+    if FLOAT_SEED_COMMENT not in src:
+        return src
+    lines = src.split("\n")
+    if not any(ln.strip() in FLOAT_SEED_LINES for ln in lines):
+        return src
+    kept = [ln for ln in lines if ln.strip() not in FLOAT_SEED_LINES]
+    out = []
+    inserted = False
+    for ln in kept:
+        out.append(ln)
+        if not inserted and ln.strip() == FLOAT_SEED_COMMENT:
+            out.append(TILE_SEED_LINE)
+            inserted = True
+    src = "\n".join(out)
+    if not inserted:
+        src = TILE_SEED_LINE + "\n" + src
+    return src.replace(FLOAT_SEED_COMMENT, TILE_SEED_COMMENT)
 
 
 def lua_number(n: float | int) -> str:

--- a/scripts/set-avatar.sh
+++ b/scripts/set-avatar.sh
@@ -50,6 +50,8 @@ install_accounts() {
     mkdir -p /var/lib/AccountsService/icons /var/lib/AccountsService/users
     cp -f -- "$file" "$icon"
     chmod 644 "$icon"
+    exec {ATMOS_AVATAR_LOCK}>"$cfg.atmos.lock"
+    flock "$ATMOS_AVATAR_LOCK"
     if [[ -f $cfg ]] && grep -q "^Icon=" "$cfg"; then
       sed -i "s|^Icon=.*|Icon=$icon|" "$cfg"
     elif [[ -f $cfg ]]; then
@@ -71,11 +73,14 @@ clear_accounts() {
     rm -f "/var/lib/AccountsService/icons/$user"
     cfg=/var/lib/AccountsService/users/$user
     if [[ -f $cfg ]]; then
-      grep -v "^Icon=" "$cfg" >"$cfg.tmp" || true
-      if grep -qE "^[A-Za-z]" "$cfg.tmp"; then
-        mv "$cfg.tmp" "$cfg"
+      exec {ATMOS_AVATAR_LOCK}>"$cfg.atmos.lock"
+      flock "$ATMOS_AVATAR_LOCK"
+      tmp=$(mktemp "$cfg.tmp.XXXXXX")
+      grep -v "^Icon=" "$cfg" >"$tmp" || true
+      if grep -qE "^[A-Za-z]" "$tmp"; then
+        mv "$tmp" "$cfg"
       else
-        rm -f "$cfg" "$cfg.tmp"
+        rm -f "$cfg" "$tmp"
       fi
     fi
   ' bash "$user"

--- a/scripts/set-bar-widget.sh
+++ b/scripts/set-bar-widget.sh
@@ -38,6 +38,14 @@ jq -cn --argjson value "$value" '$value' >/dev/null || {
 # shellcheck disable=SC1091
 source omarchy-shell-config
 
+# Same shared lock as set-idle.sh: commit() reads shell.json, patches one
+# widget key with jq, and renames. Two windows patching different widgets
+# must not read the same stale file and drop each other's key.
+_SHELL_JSON_LOCK="$HOME/.config/omarchy/shell.json.atmos.lock"
+mkdir -p "$(dirname "$_SHELL_JSON_LOCK")"
+exec {ATMOS_SHELL_LOCK}>"$_SHELL_JSON_LOCK"
+flock "$ATMOS_SHELL_LOCK"
+
 commit "$NORMALIZE
   | def entry_id:
       if type == \"object\" then (.id // \"\" | tostring) else tostring end;

--- a/scripts/set-env.sh
+++ b/scripts/set-env.sh
@@ -11,7 +11,7 @@ if [[ -z $json ]]; then
 fi
 
 python3 - "$DEST" "$json" <<'PY'
-import json, os, sys
+import fcntl, json, os, sys, tempfile
 from pathlib import Path
 
 dest = Path(sys.argv[1])
@@ -39,5 +39,23 @@ for item in vars_:
 lines.append(end)
 body = "\n".join(lines) + "\n"
 dest.parent.mkdir(parents=True, exist_ok=True)
-dest.write_text(body)
+# Full replace, published atomically under an exclusive lock so a
+# concurrent reader (or another Atmos window) never sees a torn file.
+lock = dest.parent / (dest.name + ".atmos.lock")
+with open(lock, "a+") as lf:
+    try:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        pass
+    fd, tmp = tempfile.mkstemp(prefix="." + dest.name + ".", dir=str(dest.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 PY

--- a/scripts/set-hypr-look.sh
+++ b/scripts/set-hypr-look.sh
@@ -12,7 +12,8 @@ atmos_hypr_reload set-hypr-look.sh errors
 
 json=$ATMOS_HYPR_JSON
 if [[ ${ATMOS_SKIP_HYPR:-0} != 1 && -n $json ]] && command -v hyprctl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-  size=$(jq -r '.cursorSize // empty' <<<"$json" 2>/dev/null || true)
+  # Payloads carry _patch/_full; plain objects still work.
+  size=$(jq -r '._patch.cursorSize // ._full.cursorSize // .cursorSize // empty' <<<"$json" 2>/dev/null || true)
   theme=${HYPRCURSOR_THEME:-${XCURSOR_THEME:-}}
   if [[ $size =~ ^[0-9]+$ && -n $theme ]]; then
     hyprctl setcursor "$theme" "$size" >/dev/null 2>&1 || true

--- a/scripts/set-hyprsunset.sh
+++ b/scripts/set-hyprsunset.sh
@@ -44,7 +44,7 @@ if temp < 3000 or temp > 6500:
 fi
 
 python3 - "$FILE" "$json" <<'PY'
-import json, re, sys
+import fcntl, json, os, re, sys, tempfile
 from pathlib import Path
 
 dest = Path(sys.argv[1])
@@ -86,7 +86,24 @@ if night_on:
         ]
     )
 dest.parent.mkdir(parents=True, exist_ok=True)
-dest.write_text("\n".join(lines) + "\n")
+body = "\n".join(lines) + "\n"
+lock = dest.parent / (dest.name + ".atmos.lock")
+with open(lock, "a+") as lf:
+    try:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        pass
+    fd, tmp = tempfile.mkstemp(prefix="." + dest.name + ".", dir=str(dest.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 PY
 
 if [[ $SKIP_HYPR == 1 ]]; then

--- a/scripts/set-idle.sh
+++ b/scripts/set-idle.sh
@@ -27,6 +27,15 @@ export OMARCHY_PATH
 # shellcheck disable=SC1091
 source omarchy-shell-config
 
+# shell.json is read, patched with jq, and renamed by commit(). Hold one
+# shared lock across that read-modify-write so two Atmos windows changing
+# different bar/idle keys cannot base their patch on the same stale file
+# and lose each other's edit. Every Atmos shell.json writer takes this lock.
+_SHELL_JSON_LOCK="$HOME/.config/omarchy/shell.json.atmos.lock"
+mkdir -p "$(dirname "$_SHELL_JSON_LOCK")"
+exec {ATMOS_SHELL_LOCK}>"$_SHELL_JSON_LOCK"
+flock "$ATMOS_SHELL_LOCK"
+
 commit "$NORMALIZE
   | .idle = (.idle | object_or_empty)
   | .idle.screensaver = (\$screensaver | tonumber)

--- a/scripts/set-nightlight-temp.sh
+++ b/scripts/set-nightlight-temp.sh
@@ -23,15 +23,24 @@ usage() {
 # conf comments the example out; moving the slider must not enable it.
 if [[ -f $ATMOS_HYPRSUNSET_FILE ]]; then
   python3 - "$ATMOS_HYPRSUNSET_FILE" "$temp" <<'PY'
+import fcntl
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 dest = Path(sys.argv[1])
 temp = int(sys.argv[2])
-raw = dest.read_text()
-if not raw:
-    raise SystemExit(0)
+lock = dest.parent / (dest.name + ".atmos.lock")
+with open(lock, "a+") as lf:
+    try:
+        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        pass
+    raw = dest.read_text()
+    if not raw:
+        raise SystemExit(0)
 
 temp_re = re.compile(r"^(\s*temperature\s*=\s*)([0-9]+)([ \t]*(#.*)?)?(\r?\n)?$")
 in_profile = False
@@ -54,7 +63,18 @@ for line in raw.splitlines(keepends=True):
         in_profile = False
     out.append(line)
 if changed:
-    dest.write_text("".join(out))
+    body = "".join(out)
+    fd, tmp = tempfile.mkstemp(prefix="." + dest.name + ".", dir=str(dest.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 PY
 fi
 

--- a/scripts/set-presentation.sh
+++ b/scripts/set-presentation.sh
@@ -8,6 +8,18 @@ source "$ROOT/atmos-env.sh"
 
 STATE=${ATMOS_PRESENTATION_FILE:-$HOME/.local/state/omarchy/atmos-presentation.json}
 mkdir -p "$(dirname "$STATE")"
+# The state file is one small JSON document fully replaced per write.
+# Publish through a temp file + rename under a sidecar lock so a second
+# Atmos window (or its file watcher) never reads a half-written document.
+exec {ATMOS_PRES_LOCK}>"$STATE.atmos.lock"
+flock "$ATMOS_PRES_LOCK"
+
+write_state() {
+  local tmp
+  tmp=$(mktemp "${STATE}.tmp.XXXXXX")
+  cat >"$tmp"
+  mv "$tmp" "$STATE"
+}
 
 on_off=${1:-}
 minutes=${2:-120}
@@ -20,7 +32,7 @@ case $on_off in
     now=$(date +%s)
     until=$((now + minutes * 60))
     jq -n --argjson on true --argjson until "$until" --argjson minutes "$minutes" \
-      '{on:$on, until:$until, minutes:$minutes}' >"$STATE"
+      '{on:$on, until:$until, minutes:$minutes}' | write_state
     omarchy toggle idle stay-awake >/dev/null 2>&1 || true
     if [[ $(omarchy-shell notifications isDnd 2>/dev/null || true) != on ]]; then
       omarchy toggle notification silencing >/dev/null 2>&1 || true
@@ -30,7 +42,7 @@ case $on_off in
     fi
     ;;
   off | false)
-    jq -n '{on:false, until:0, minutes:0}' >"$STATE"
+    jq -n '{on:false, until:0, minutes:0}' | write_state
     omarchy toggle idle allow-idle >/dev/null 2>&1 || true
     if [[ $(omarchy-shell notifications isDnd 2>/dev/null || true) == on ]]; then
       omarchy toggle notification silencing >/dev/null 2>&1 || true

--- a/scripts/set-tweaks.sh
+++ b/scripts/set-tweaks.sh
@@ -6,6 +6,40 @@ ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 ACTION=${1:-}
 ID=${2:-}
 
+# Read-modify-write branches below serialize on the destination's sidecar
+# lock so two Atmos windows cannot interleave a read and a rename. Temp
+# files are unique per run ($dest.tmp was shared between concurrent runs).
+tweak_rmw() {
+  local dest=$1
+  shift
+  local lock="$dest.atmos.lock"
+  mkdir -p "$(dirname "$dest")" "$(dirname "$lock")"
+  exec {ATMOS_TWEAK_LOCK}>"$lock"
+  flock "$ATMOS_TWEAK_LOCK"
+  "$@"
+  exec {ATMOS_TWEAK_LOCK}>&-
+}
+
+tweak_filter() {
+  local dest=$1 pattern=$2 extra=${3:-}
+  local tmp
+  tmp=$(mktemp "${dest}.tmp.XXXXXX")
+  grep -v "$pattern" "$dest" >"$tmp" || true
+  if [[ -n $extra ]]; then
+    printf '%s\n' "$extra" >>"$tmp"
+  fi
+  mv "$tmp" "$dest"
+}
+
+tweak_seed() {
+  local dest=$1
+  shift
+  local tmp
+  tmp=$(mktemp "${dest}.tmp.XXXXXX")
+  printf '%s\n' "$@" >"$tmp"
+  mv "$tmp" "$dest"
+}
+
 case $ACTION in
   gtk-middle-paste)
     dest="${ATMOS_GTK4_FILE:-$HOME/.config/gtk-4.0/settings.ini}"
@@ -13,7 +47,7 @@ case $ACTION in
     if [[ ${3:-} == off ]]; then
       rm -f "$dest"
     else
-      printf '%s\n' "[Settings]" "gtk-enable-primary-paste=false" >"$dest"
+      tweak_rmw "$dest" tweak_seed "$dest" "[Settings]" "gtk-enable-primary-paste=false"
     fi
     ;;
   electron-wayland)
@@ -21,15 +55,12 @@ case $ACTION in
     mkdir -p "$(dirname "$dest")"
     if [[ ${3:-} == off ]]; then
       if [[ -f $dest ]]; then
-        grep -v '^ELECTRON_OZONE_PLATFORM_HINT=' "$dest" >"$dest.tmp" || true
-        printf '%s\n' "ELECTRON_OZONE_PLATFORM_HINT=auto" >>"$dest.tmp"
-        mv "$dest.tmp" "$dest"
+        tweak_rmw "$dest" tweak_filter "$dest" '^ELECTRON_OZONE_PLATFORM_HINT=' "ELECTRON_OZONE_PLATFORM_HINT=auto"
       else
-        printf '%s\n' "# atmos:env begin" "ELECTRON_OZONE_PLATFORM_HINT=auto" "# atmos:env end" >"$dest"
+        tweak_rmw "$dest" tweak_seed "$dest" "# atmos:env begin" "ELECTRON_OZONE_PLATFORM_HINT=auto" "# atmos:env end"
       fi
     elif [[ -f $dest ]]; then
-      grep -v '^ELECTRON_OZONE_PLATFORM_HINT=' "$dest" >"$dest.tmp" || true
-      mv "$dest.tmp" "$dest"
+      tweak_rmw "$dest" tweak_filter "$dest" '^ELECTRON_OZONE_PLATFORM_HINT='
     fi
     ;;
   force-zero-scaling)
@@ -37,13 +68,10 @@ case $ACTION in
     mkdir -p "$(dirname "$dest")"
     if [[ ${3:-} == off ]]; then
       if [[ -f $dest ]]; then
-        grep -v '^ATMOS_XWAYLAND_ZERO_SCALING=' "$dest" >"$dest.tmp" || true
-        printf '%s\n' "ATMOS_XWAYLAND_ZERO_SCALING=0" >>"$dest.tmp"
-        mv "$dest.tmp" "$dest"
+        tweak_rmw "$dest" tweak_filter "$dest" '^ATMOS_XWAYLAND_ZERO_SCALING=' "ATMOS_XWAYLAND_ZERO_SCALING=0"
       fi
     elif [[ -f $dest ]]; then
-      grep -v '^ATMOS_XWAYLAND_ZERO_SCALING=' "$dest" >"$dest.tmp" || true
-      mv "$dest.tmp" "$dest"
+      tweak_rmw "$dest" tweak_filter "$dest" '^ATMOS_XWAYLAND_ZERO_SCALING='
     fi
     ;;
   swappiness)

--- a/scripts/set-workspace-bar.sh
+++ b/scripts/set-workspace-bar.sh
@@ -76,6 +76,13 @@ command -v omarchy-shell-config >/dev/null 2>&1 || {
 # shellcheck disable=SC1091
 source omarchy-shell-config
 
+# write_shell below reads shell.json and renames a patched copy, so it
+# takes the same shared lock as set-idle.sh and set-bar-widget.sh.
+_SHELL_JSON_LOCK="$HOME/.config/omarchy/shell.json.atmos.lock"
+mkdir -p "$(dirname "$_SHELL_JSON_LOCK")"
+exec {ATMOS_SHELL_LOCK}>"$_SHELL_JSON_LOCK"
+flock "$ATMOS_SHELL_LOCK"
+
 write_shell() {
   mkdir -p "$(dirname "$CONFIG_FILE")"
   _SHELL_CONFIG_TMP=$(mktemp)

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -89,6 +89,8 @@ QtObject {
   readonly property string faceFile: Quickshell.env("HOME") + "/.face"
   readonly property string vconsoleFile: "/etc/vconsole.conf"
   readonly property string localeConfFile: "/etc/locale.conf"
+  readonly property string gtkSettingsFile: Quickshell.env("HOME") + "/.config/gtk-4.0/settings.ini"
+  readonly property string swappinessFile: "/etc/sysctl.d/99-atmos-swappiness.conf"
   readonly property string gumStubDir: shellDir + "/scripts/stubs"
   readonly property string userShellJson: Quickshell.env("HOME") + "/.config/omarchy/shell.json"
   readonly property string defaultShellJson: "/usr/share/omarchy/config/omarchy/shell.json"
@@ -2751,7 +2753,9 @@ QtObject {
     localtimeFile: localtimeFile,
     vconsoleFile: vconsoleFile,
     localeConfFile: localeConfFile,
-    pacmanConfFile: pacmanConfFile
+    pacmanConfFile: pacmanConfFile,
+    gtkSettingsFile: gtkSettingsFile,
+    swappinessFile: swappinessFile
   })
 
   function applyThemeNameFromFile(slug) {

--- a/services/Settings.js
+++ b/services/Settings.js
@@ -2648,7 +2648,13 @@ function commandFor(key, value, snapshot, opts) {
     merged[field] = value;
     if (spec.group === "hyprInput" && workspaceGestureUnmanaged(snapshot, opts))
       delete merged.workspaceGesture;
-    var payload = JSON.stringify(merged);
+    // The writer merges _patch onto the file under an exclusive lock, so
+    // two windows changing different fields converge instead of the second
+    // full block overwriting the first. _full stays for readers that only
+    // understand a whole object. The optimistic apply still uses merged.
+    var patch = {};
+    patch[field] = merged[field];
+    var payload = JSON.stringify({ _patch: patch, _full: merged });
     var applyHypr = {};
     applyHypr[spec.group] = merged;
     applyHypr[spec.group === "hyprLook" ? "hyprLookManaged" : "hyprInputManaged"] = true;
@@ -2906,6 +2912,38 @@ function planCommands(changes, snapshot, opts) {
       continue;
     }
     if (merged) seen[merged] = true;
+    if (spec && spec.kind === "hypr-group" && cmd.stdin) {
+      // commandFor only saw the first coalesced key. Fold every change for
+      // this group into _patch so one write carries all of them; the writer
+      // merges the patch onto the file under lock.
+      var patchGroup = spec.group;
+      var combinedPatch = {};
+      var j, k2, f2;
+      for (j = 0; j < list.length; j++) {
+        k2 = String(list[j].key || "");
+        if (k2.indexOf(patchGroup + ".") !== 0) continue;
+        f2 = k2.slice(patchGroup.length + 1);
+        if (!f2) continue;
+        if (
+          patchGroup === "hyprInput" &&
+          f2 === "workspaceGesture" &&
+          workspaceGestureUnmanaged(cmdSnap, opts)
+        )
+          continue;
+        combinedPatch[f2] = readValue(cmdSnap, k2);
+      }
+      if (patchGroup === "hyprInput" && workspaceGestureUnmanaged(cmdSnap, opts))
+        delete combinedPatch.workspaceGesture;
+      try {
+        var parsedPayload = JSON.parse(cmd.stdin);
+        if (parsedPayload && typeof parsedPayload === "object" && parsedPayload._patch) {
+          parsedPayload._patch = combinedPatch;
+          var rebuilt = JSON.stringify(parsedPayload);
+          cmd.stdin = rebuilt;
+          if (cmd.argv && cmd.argv.length > 0) cmd.argv[cmd.argv.length - 1] = rebuilt;
+        }
+      } catch (e) {}
+    }
     out.push(cmd);
   }
   var muteSnap = copyObject(snapshot || {});

--- a/services/SnapshotGroups.js
+++ b/services/SnapshotGroups.js
@@ -360,6 +360,15 @@ var WATCH_SPEC_KEYS = [
   ["vconsoleFile", "rest"],
   ["localeConfFile", "rest"],
   ["pacmanConfFile", "rest"],
+  // A second envFile entry re-reads rest after an env write: the Electron
+  // and zero-scaling tweaks live in the env file but their snapshot key is
+  // rest, while envVars itself is system. Two FileViews on one path is
+  // cheaper than a missed cross-window refresh.
+  ["envFile", "rest"],
+  // Tweak sources without a watcher stayed stale in a second window until
+  // an unrelated rest refresh. Both snapshot keys are rest.
+  ["gtkSettingsFile", "rest"],
+  ["swappinessFile", "rest"],
 ];
 
 function normalizeGroup(g) {

--- a/services/WindowRules.js
+++ b/services/WindowRules.js
@@ -400,10 +400,8 @@ function ensureLayoutRequire(text) {
 
 function prefsSeed() {
   return [
-    "-- Float and center the Atmos window.",
-    'o.window("' + WINDOW_CLASS + '", { float = true })',
-    'o.window("' + WINDOW_CLASS + '", { center = true })',
-    'o.window("' + WINDOW_CLASS + '", { size = { 960, 680 } })',
+    "-- Tile the Atmos window like other apps.",
+    'o.window("' + WINDOW_CLASS + '", { tile = true })',
   ].join("\n");
 }
 

--- a/tests/run
+++ b/tests/run
@@ -1031,6 +1031,46 @@ else
   echo "ok - skipping set-hypr-look.sh"
 fi
 
+if command -v python3 >/dev/null 2>&1; then
+  patch_home=$(mktemp -d)
+  look_file="$patch_home/looknfeel.lua"
+  python3 scripts/hypr-sentinel.py look apply "$look_file" '{"gapsIn":5,"gapsOut":10,"rounding":3}' >/dev/null
+  # A _patch write changes one field and keeps what is on disk, so two
+  # windows editing different fields converge instead of overwriting.
+  python3 scripts/hypr-sentinel.py look apply "$look_file" '{"_patch":{"rounding":9}}' >/dev/null
+  grep -q 'gaps_in = 5' "$look_file"
+  grep -q 'rounding = 9' "$look_file"
+  python3 scripts/hypr-sentinel.py look apply "$look_file" '{"_patch":{"gapsIn":7}}' &
+  python3 scripts/hypr-sentinel.py look apply "$look_file" '{"_patch":{"rounding":2}}' &
+  wait
+  grep -q 'gaps_in = 7' "$look_file" || { echo "not ok - concurrent look patches lost gapsIn"; rm -rf "$patch_home"; exit 1; }
+  grep -q 'rounding = 2' "$look_file" || { echo "not ok - concurrent look patches lost rounding"; rm -rf "$patch_home"; exit 1; }
+  input_file="$patch_home/input.lua"
+  python3 scripts/hypr-sentinel.py input apply "$input_file" '{"sensitivity":0,"naturalScroll":false}' >/dev/null
+  python3 scripts/hypr-sentinel.py input apply "$input_file" '{"_patch":{"naturalScroll":true}}' >/dev/null
+  grep -q 'sensitivity = 0' "$input_file"
+  grep -q 'natural_scroll = true' "$input_file"
+  rm -rf "$patch_home"
+  echo "ok - hypr-sentinel.py merges _patch writes under lock"
+else
+  echo "ok - skipping hypr-sentinel.py _patch"
+fi
+
+if [[ -x bin/atmos ]]; then
+  if grep -q 'quickshell -n' bin/atmos; then
+    echo "not ok - bin/atmos refuses a second instance with quickshell -n"
+    exit 1
+  fi
+  if grep -q 'focus_existing\|prefs_pid\|ipc ping' bin/atmos; then
+    echo "not ok - bin/atmos still funnels a second launch into the first window"
+    exit 1
+  fi
+  grep -q 'exec quickshell -p' bin/atmos
+  echo "ok - bin/atmos opens every launch as its own instance"
+else
+  echo "ok - skipping bin/atmos multi-instance"
+fi
+
 if [[ -x scripts/set-hypr-input.sh ]] && command -v python3 >/dev/null 2>&1; then
   input_home=$(mktemp -d)
   cat >"$input_home/input.lua" <<'LUA'
@@ -1705,10 +1745,12 @@ JSON
     rm -rf "$apply_dir"
     exit 1
   fi
-  # The sentinel writer replaces the whole block, so the call carries the
-  # settings the plan never mentioned as well as the ones it changed.
+  # The look call carries a _patch with only the changed fields (merged
+  # onto the file under lock, so concurrent windows do not clobber each
+  # other) plus the _full snapshot context the plan was built from.
   grep -q '"gapsIn":9' <<<"$out"
   grep -q '"rounding":8' <<<"$out"
+  grep -q '"_patch"' <<<"$out"
   grep -q '"gapsOut":10' <<<"$out"
   grep -q '"layout":"dwindle"' <<<"$out"
   # A paired writer takes both values, so the one that did not change is read

--- a/tests/run
+++ b/tests/run
@@ -1346,8 +1346,10 @@ fi
 if [[ -x scripts/set-hypr-windows.sh ]] && command -v python3 >/dev/null 2>&1; then
   win_home=$(mktemp -d)
   cat >"$win_home/atmos.lua" <<'LUA'
+-- Float and center the Atmos window.
 o.window("dev.csfh.atmos", { float = true })
 o.window("dev.csfh.atmos", { center = true })
+o.window("dev.csfh.atmos", { size = { 960, 680 } })
 LUA
   cat >"$win_home/hyprland.lua" <<'LUA'
 require("hypr.autostart")
@@ -1355,12 +1357,17 @@ require("default.hypr.toggles")
 LUA
   ATMOS_WINDOWS_FILE="$win_home/atmos.lua" ATMOS_HYPRLAND_FILE="$win_home/hyprland.lua" ATMOS_SKIP_HYPR=1 \
     bash scripts/set-hypr-windows.sh '{"items":[{"match":"^Emulator$","placement":"float","center":true,"width":1280,"height":800}]}'
-  grep -q 'o.window("dev.csfh.atmos", { float = true })' "$win_home/atmos.lua"
+  grep -q 'o.window("dev.csfh.atmos", { tile = true })' "$win_home/atmos.lua"
+  if grep -q 'o.window("dev.csfh.atmos", { float = true })' "$win_home/atmos.lua"; then
+    echo "not ok - set-hypr-windows.sh left the float seed"
+    rm -rf "$win_home"
+    exit 1
+  fi
   grep -q -- '-- atmos:windows begin' "$win_home/atmos.lua"
   grep -q 'o.window("^Emulator$", { float = true, center = true, size = { 1280, 800 } })' "$win_home/atmos.lua"
   grep -q 'require("hypr.atmos")' "$win_home/hyprland.lua"
   listed=$(python3 scripts/hypr-sentinel.py windows list "$win_home/atmos.lua")
-  echo "$listed" | jq -e 'map(select(.match == "dev.csfh.atmos" and .managed == false)) | length == 2' >/dev/null
+  echo "$listed" | jq -e 'map(select(.match == "dev.csfh.atmos" and .managed == false)) | length == 1' >/dev/null
   echo "$listed" | jq -e 'map(select(.match == "^Emulator$" and .managed == true)) | length == 1' >/dev/null
   rm -rf "$win_home"
   echo "ok - set-hypr-windows.sh writes a sentinel and ensures the prefs require"
@@ -1399,7 +1406,10 @@ o.bind("SUPER + F", "Files", "nautilus")
 -- atmos:bindings end
 LUA
   cat >"$reset_home/atmos.lua" <<'LUA'
+-- Float and center the Atmos window.
 o.window("dev.csfh.atmos", { float = true })
+o.window("dev.csfh.atmos", { center = true })
+o.window("dev.csfh.atmos", { size = { 960, 680 } })
 -- atmos:windows begin
 o.window("^Emulator$", { float = true })
 -- atmos:windows end
@@ -1446,7 +1456,12 @@ LUA
     rm -rf "$reset_home"
     exit 1
   fi
-  grep -q 'o.window("dev.csfh.atmos", { float = true })' "$reset_home/atmos.lua"
+  grep -q 'o.window("dev.csfh.atmos", { tile = true })' "$reset_home/atmos.lua"
+  if grep -q 'o.window("dev.csfh.atmos", { float = true })' "$reset_home/atmos.lua"; then
+    echo "not ok - reset-atmos.sh left the float seed"
+    rm -rf "$reset_home"
+    exit 1
+  fi
   if grep -q -- '-- atmos:windows begin' "$reset_home/atmos.lua"; then
     echo "not ok - reset-atmos.sh left the windows sentinel"
     rm -rf "$reset_home"

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1681,3 +1681,50 @@ assertEqual(
   "",
   "parseApplyResult survives no JSON",
 );
+
+const patchCmd = settings.commandFor(
+  "hyprLook.gapsIn",
+  9,
+  { hyprLook: { gapsIn: 5, gapsOut: 10, rounding: 0 } },
+  {},
+);
+const patchPayload = JSON.parse(patchCmd.stdin);
+assertEqual(
+  JSON.stringify(patchPayload._patch),
+  JSON.stringify({ gapsIn: 9 }),
+  "a hyprLook write sends only the changed field as _patch",
+);
+assertEqual(patchPayload._full.gapsOut, 10, "a hyprLook write keeps snapshot context in _full");
+assertEqual(
+  patchCmd.argv[patchCmd.argv.length - 1],
+  patchCmd.stdin,
+  "a hyprLook write carries the payload on argv and stdin alike",
+);
+
+const coalescedPatch = settings.planCommands(
+  [
+    { key: "hyprLook.gapsIn", value: 9 },
+    { key: "hyprLook.rounding", value: 8 },
+  ],
+  { hyprLook: { gapsIn: 5, gapsOut: 10, rounding: 0, layout: "dwindle" } },
+  {},
+);
+assertEqual(coalescedPatch.length, 1, "coalesced look writes stay one call with _patch");
+const coalescedPayload = JSON.parse(coalescedPatch[0].stdin);
+assertEqual(
+  JSON.stringify(coalescedPayload._patch),
+  JSON.stringify({ gapsIn: 9, rounding: 8 }),
+  "a coalesced look write patches every changed field",
+);
+
+const inputPatch = settings.commandFor(
+  "hyprInput.sensitivity",
+  0.4,
+  { hyprInput: { sensitivity: 0, naturalScroll: false } },
+  {},
+);
+assertEqual(
+  JSON.stringify(JSON.parse(inputPatch.stdin)._patch),
+  JSON.stringify({ sensitivity: 0.4 }),
+  "a hyprInput write sends only the changed field as _patch",
+);

--- a/tests/snapshot-groups.test.js
+++ b/tests/snapshot-groups.test.js
@@ -186,20 +186,24 @@ const paths = {
   autostartLuaFile: "/home/x/.config/hypr/autostart.lua",
   bindingsLuaFile: "/home/x/.config/hypr/bindings.lua",
   windowsLuaFile: "/home/x/.config/hypr/atmos.lua",
+  envFile: "/home/x/.config/environment.d/10-atmos.conf",
+  presentationFile: "/home/x/.local/state/omarchy/atmos-presentation.json",
   localtimeFile: "/etc/localtime",
   vconsoleFile: "/etc/vconsole.conf",
   localeConfFile: "/etc/locale.conf",
   pacmanConfFile: "/etc/pacman.conf",
+  gtkSettingsFile: "/home/x/.config/gtk-4.0/settings.ini",
+  swappinessFile: "/etc/sysctl.d/99-atmos-swappiness.conf",
 };
 const specs = groups.watchSpecs(paths);
-assertEqual(specs.length, 44, "watchSpecs drops extraThemesDir and keeps 44 path/group pairs");
+assertEqual(specs.length, 47, "watchSpecs covers 47 path/group pairs for every window");
 assertEqual(
   specs
     .map(function (row) {
       return row.group;
     })
     .join(","),
-  "look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,all,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,system,look,rest,rest,rest,rest",
+  "look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,look,all,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,rest,system,look,rest,rest,rest,rest,rest,rest,rest",
   "watchSpecs group order matches today's Omarchy array",
 );
 assertEqual(specs[0].path, "/u/shell.json", "watchSpecs uses the passed userShellJson path");
@@ -212,6 +216,12 @@ assert(
 );
 assertEqual(specs[22].group, "all", "togglesDir stays all");
 assertEqual(specs[22].path, paths.togglesDir, "togglesDir path is the live map value");
+assertEqual(specs[44].path, paths.envFile, "envFile is watched twice for system and rest");
+assertEqual(specs[44].group, "rest", "the second envFile watch refreshes rest tweaks");
+assertEqual(specs[45].path, paths.gtkSettingsFile, "gtk settings are watched for tweaks");
+assertEqual(specs[45].group, "rest", "gtk settings refresh rest");
+assertEqual(specs[46].path, paths.swappinessFile, "swappiness is watched for tweaks");
+assertEqual(specs[46].group, "rest", "swappiness refreshes rest");
 assertEqual(
   groups.snapshotGroupForWatchPath(paths.looknfeelLuaFile, specs),
   "look",

--- a/tests/window-rules.test.js
+++ b/tests/window-rules.test.js
@@ -128,10 +128,60 @@ assertEqual(rules.clampSize(50), 0, "clampSize rejects below 100");
 assertEqual(rules.clampSize(5000), 0, "clampSize rejects above 4000");
 assertEqual(rules.clampSize("nope"), 0, "clampSize rejects NaN");
 assert(
-  rules.prefsSeed().indexOf('o.window("dev.csfh.atmos"') !== -1,
-  "prefsSeed floats the Atmos class",
+  rules.prefsSeed().indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1,
+  "prefsSeed tiles the Atmos class",
 );
-assert(rules.prefsSeed().indexOf("size = { 960, 680 }") !== -1, "prefsSeed sets the Atmos size");
+assert(
+  rules.prefsSeed().indexOf("float") === -1 && rules.prefsSeed().indexOf("center") === -1,
+  "prefsSeed leaves floating and centering out",
+);
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atmos-seed-"));
+  try {
+    const lua = path.join(dir, "atmos.lua");
+    fs.writeFileSync(
+      lua,
+      '-- Float and center the Atmos window.\no.window("dev.csfh.atmos", { float = true })\no.window("dev.csfh.atmos", { center = true })\no.window("dev.csfh.atmos", { size = { 960, 680 } })\n',
+    );
+    const result = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(result.status, 0, "hypr-sentinel.py windows apply exits 0");
+    const written = fs.readFileSync(lua, "utf8");
+    assert(
+      written.indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1 &&
+        written.indexOf("float = true") === -1,
+      "hypr-sentinel.py windows apply migrates the float seed to tile",
+    );
+    fs.writeFileSync(lua, '-- mine\no.window("dev.csfh.atmos", { float = true })\n');
+    const custom = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(custom.status, 0, "hypr-sentinel.py windows apply exits 0 on custom rules");
+    assert(
+      fs.readFileSync(lua, "utf8").indexOf("float = true") !== -1,
+      "hypr-sentinel.py windows apply keeps a customized float rule",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
 assertEqual(
   rules.describe({ placement: "tile", workspace: "5" }),
   "tile \u00b7 workspace 5",

--- a/tests/window-rules.test.js
+++ b/tests/window-rules.test.js
@@ -178,6 +178,29 @@ assert(
       fs.readFileSync(lua, "utf8").indexOf("float = true") !== -1,
       "hypr-sentinel.py windows apply keeps a customized float rule",
     );
+    fs.writeFileSync(
+      lua,
+      '-- Float and center the Atmos window.\n-- Install as ~/.config/hypr/atmos.lua and require("hypr.atmos")\n-- from hyprland.lua next to require("hypr.omafetch"), before toggles.\no.window("dev.csfh.atmos", { float = true })\no.window("dev.csfh.atmos", { center = true })\no.window("dev.csfh.atmos", { size = { 960, 680 } })\n',
+    );
+    const headed = spawnSync(
+      "python3",
+      [
+        path.join(__dirname, "..", "scripts", "hypr-sentinel.py"),
+        "windows",
+        "apply",
+        lua,
+        '{"items":[]}',
+      ],
+      { encoding: "utf8" },
+    );
+    assertEqual(headed.status, 0, "hypr-sentinel.py windows apply exits 0 on a packaged header");
+    const headedText = fs.readFileSync(lua, "utf8");
+    assert(
+      headedText.indexOf('o.window("dev.csfh.atmos", { tile = true })') !== -1 &&
+        headedText.indexOf("float = true") === -1 &&
+        headedText.indexOf('require("hypr.atmos")') !== -1,
+      "hypr-sentinel.py windows apply migrates under packaging comments",
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Every `atmos` launch now opens its own window instead of being funneled into the first one. Open windows converge on the same state through the files they already share, and concurrent writes serialize on disk so they can neither tear a config file nor silently lose each other's edits.

This intentionally goes the other way from #44: rather than refusing a second instance to dodge the race #28 found, it removes the race so refusing is unnecessary.

## Why

- #28 proved the race is real (two engines, one from an install and one from a checkout, writing the same `~/.config`).
- #44 made single-instance airtight. That protects users but keeps the limitation: no side-by-side windows, no deep-linking a second page while one window is open.
- Writers have since stayed single-writer shaped: lock-free read-modify-write in `hypr-sentinel.py`, full-block Hypr payloads where two windows editing different fields overwrite each other, unlocked `shell.json` patches, truncating publishes, and tweak files with no watcher on the other side.

## How it stays correct

- **Launcher** (`bin/atmos`): drops `-n`, the `ipc ping`/`focus_existing` guard, and the `prefs_pid` wait. Same `QS_APP_ID`, so the Hyprland tile rule still matches; concurrent engines with one id open fine.
- **Hypr writes** (`scripts/hypr-sentinel.py`): per-destination `flock` sidecar around every read-modify-write, atomic temp-and-rename publishes, and `{"_patch": {...}}` payloads merged onto the on-disk block under the lock (new `parse_look_block`/`parse_input_block`). Plain full objects still work as before. Skips the write when nothing changed, so no watcher storms.
- **Payloads** (`services/Settings.js`): hypr-group writes send `{_patch, _full}`; `planCommands` folds every coalesced field into one `_patch`. Optimistic apply is unchanged. `set-hypr-look.sh` cursor live-update reads the new shape (and the old one).
- **shell.json** (`set-idle.sh`, `set-bar-widget.sh`, `set-workspace-bar.sh`): one shared lock across the jq read-modify-rename, so two windows patching different keys cannot base their patch on the same stale file.
- **Remaining writers**: `set-env.sh`, `set-hyprsunset.sh`, `set-nightlight-temp.sh` (flock + atomic); `set-presentation.sh` (atomic publish under lock); `set-tweaks.sh` (per-file locks, unique tmps instead of a shared $dest.tmp); `set-avatar.sh` (lock + unique tmp). `set-favorites.sh` was already atomic full-replace (last-writer-wins, converges via watcher).
- **Sync** (`services/SnapshotGroups.js`, `services/Omarchy.qml`): added `gtkSettingsFile`/`swappinessFile` watchers (rest) and a second `envFile`->rest watch, so Electron/zero-scaling tweaks refresh other windows. `README.md` now describes multi-window behavior.

## Verification

- `./tests/run`: 3576 ok, 0 failures (oxlint, oxfmt, compile-python, parser + shell tests, live snapshot).
- New tests: `_patch` shape + coalescing (`settings.test.js`), 47 watcher specs (`snapshot-groups.test.js`), sentinel patch merge + concurrent-patch shell test, launcher multi-instance assertion (`tests/run`).
- Stress: 40 concurrent sentinel patches land intact with both fields; 20 concurrent `set-idle` writers converge on one consistent pair with valid JSON throughout.

## Notes

- This branch is based on the fork state at alpha.17 + the tile change, so it predates #44/#45 on `main`. Textual conflicts with #44 are expected (`Omarchy.qml`, `README.md`); conceptually it supersedes the refusal direction — happy to rebase or split it up on request.
- Second-instance IPC (`quickshell ipc ... call -- prefs open/show`) still targets the oldest engine; the launcher no longer uses it.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.