### PR TITLE
feat: chamfer PrefsButton with an Omarchy-style cut corner

### DIFF
--- a/components/Chamfer.qml
+++ b/components/Chamfer.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtQuick.Window
+import "../services"
+import "../services/Chamfer.js" as ChamferJs
+
+// A chamfered panel: corners cut at 45 degrees rather than rounded.
+//
+// Theme.qml is explicit that cards must not be rounded. This respects that
+// and is not a workaround for it -- the chamfer is the shape language
+// Omarchy already uses in its own brand marks, so it reads as house style
+// rather than as decoration. Hairline border, no shadow, no gradient.
+//
+// Canvas rather than QtQuick.Shapes so there is no extra module dependency,
+// and it repaints only when geometry or colour actually changes, never per
+// frame.
+
+Item {
+  id: root
+
+  property color fillColor: "transparent"
+  property color strokeColor: "transparent"
+  property int strokeWidth: Theme.borderWidth
+  // Which corners to cut. Top-left and bottom-right by default: a diagonal
+  // pair reads as deliberate, all four reads as an octagon.
+  property bool cutTopLeft: true
+  property bool cutTopRight: false
+  property bool cutBottomRight: true
+  property bool cutBottomLeft: false
+  property int cut: Theme.chamfer
+
+  onFillColorChanged: canvas.requestPaint()
+  onStrokeColorChanged: canvas.requestPaint()
+  onStrokeWidthChanged: canvas.requestPaint()
+  onCutChanged: canvas.requestPaint()
+  onCutTopLeftChanged: canvas.requestPaint()
+  onCutTopRightChanged: canvas.requestPaint()
+  onCutBottomRightChanged: canvas.requestPaint()
+  onCutBottomLeftChanged: canvas.requestPaint()
+
+  Canvas {
+    id: canvas
+    anchors.fill: parent
+    antialiasing: true
+    readonly property real dpr: {
+      var win = Window.window
+      if (win && win.devicePixelRatio > 0) return win.devicePixelRatio
+      if (typeof Screen !== "undefined" && Screen.devicePixelRatio > 0) return Screen.devicePixelRatio
+      return 1
+    }
+    onWidthChanged: requestPaint()
+    onHeightChanged: requestPaint()
+    onDprChanged: requestPaint()
+
+    onPaint: {
+      var ctx = getContext("2d")
+      ctx.reset()
+      var w = width
+      var h = height
+      var pts = ChamferJs.pathPoints(w, h, root.cut, {
+        cutTopLeft: root.cutTopLeft,
+        cutTopRight: root.cutTopRight,
+        cutBottomRight: root.cutBottomRight,
+        cutBottomLeft: root.cutBottomLeft
+      }, root.strokeWidth, dpr)
+      if (pts.length === 0) return
+
+      ctx.beginPath()
+      ctx.moveTo(pts[0][0], pts[0][1])
+      var i
+      for (i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1])
+      ctx.closePath()
+      ctx.lineJoin = "miter"
+      ctx.miterLimit = 2
+
+      if (ChamferJs.shouldPaint(root.fillColor)) {
+        ctx.fillStyle = ChamferJs.cssColor(root.fillColor)
+        ctx.fill()
+      }
+      var metrics = ChamferJs.strokeMetrics(root.strokeWidth, dpr)
+      if (metrics.width > 0 && ChamferJs.shouldPaint(root.strokeColor)) {
+        ctx.lineWidth = metrics.width
+        ctx.strokeStyle = ChamferJs.cssColor(root.strokeColor)
+        ctx.stroke()
+      }
+    }
+  }
+}

--- a/components/PrefsButton.qml
+++ b/components/PrefsButton.qml
@@ -25,31 +25,47 @@ Rectangle {
   radius: Theme.radius
   opacity: Theme.controlOpacity(enabled)
   activeFocusOnTab: enabled
-  color: {
+
+  // The root stays a Rectangle so every existing anchor, size and caller is
+  // untouched; it simply stops painting itself and lets Chamfer draw the
+  // same fill and the same hairline in a different silhouette.
+  // Writable so Behavior can tween hover and focus the way color / border
+  // did on the square rect.
+  property color bodyColor: {
     if ((mouse.containsMouse || root.activeFocus) && enabled) return Theme.fill(Theme.hoverFill)
     if (primary) return Theme.accentFill(Theme.primaryFill)
     return Theme.fill(Theme.normalFill)
   }
-  border.width: Theme.borderWidth
-  border.color: {
+  property color edgeColor: {
     if (danger) return Theme.urgent
     if (primary || ((mouse.containsMouse || root.activeFocus) && enabled)) return Theme.accent
     return Theme.borderColor()
   }
 
+  color: "transparent"
+  border.width: 0
+  border.color: "transparent"
+
   Keys.onReturnPressed: if (enabled) root.clicked()
   Keys.onSpacePressed: if (enabled) root.clicked()
 
-  Behavior on color {
+  Behavior on bodyColor {
     ColorAnimation { duration: Theme.motionFast }
   }
-  Behavior on border.color {
+  Behavior on edgeColor {
     ColorAnimation { duration: Theme.motionFast }
   }
 
   Accessible.role: Accessible.Button
   Accessible.name: text
   Accessible.onPressAction: if (enabled) root.clicked()
+
+  Chamfer {
+    anchors.fill: parent
+    fillColor: root.bodyColor
+    strokeColor: root.edgeColor
+    cut: Theme.chamferSm
+  }
 
   Text {
     id: label

--- a/services/Chamfer.js
+++ b/services/Chamfer.js
@@ -1,0 +1,141 @@
+// Geometry for the 45° cut-corner path. QML paints it; Node tests the math.
+
+function devicePixelRatio(dpr) {
+  var n = Number(dpr);
+  return isFinite(n) && n > 0 ? n : 1;
+}
+
+function snap(value, dpr) {
+  dpr = devicePixelRatio(dpr);
+  return Math.round(Number(value) * dpr) / dpr;
+}
+
+function strokeMetrics(strokeWidth, dpr) {
+  dpr = devicePixelRatio(dpr);
+  var s = Number(strokeWidth);
+  if (!isFinite(s) || s <= 0) return { width: 0, inset: 0 };
+  var physical = Math.max(1, Math.round(s * dpr));
+  var width = physical / dpr;
+  return { width: width, inset: width / 2 };
+}
+
+function cutSize(cut, width, height, inset) {
+  var c = Number(cut);
+  var w = Number(width);
+  var h = Number(height);
+  var o = Number(inset);
+  if (!isFinite(c) || c < 0) c = 0;
+  if (!isFinite(w) || !isFinite(h) || w <= 0 || h <= 0) return 0;
+  if (!isFinite(o) || o < 0) o = 0;
+  var max = Math.min(w, h) / 2 - o;
+  if (!isFinite(max) || max < 0) return 0;
+  return Math.max(0, Math.min(c, max));
+}
+
+function colorAlpha(color) {
+  if (color == null) return 0;
+  if (typeof color === "object" && color.a !== undefined) {
+    var objectAlpha = Number(color.a);
+    return isFinite(objectAlpha) ? objectAlpha : 0;
+  }
+  var s = String(color)
+    .replace(/^\s+|\s+$/g, "")
+    .toLowerCase();
+  if (!s || s === "transparent") return 0;
+  if (s.charAt(0) === "#") {
+    var hex = s.slice(1);
+    if (hex.length === 8) return parseInt(hex.slice(0, 2), 16) / 255;
+    if (hex.length === 4) return parseInt(hex.charAt(0) + hex.charAt(0), 16) / 255;
+    if (hex.length === 6 || hex.length === 3) return 1;
+    return 0;
+  }
+  var rgba = s.match(/^rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*(?:,\s*([\d.]+))?\s*\)$/);
+  if (rgba) return rgba[1] === undefined ? 1 : Number(rgba[1]);
+  return 1;
+}
+
+function shouldPaint(color) {
+  return colorAlpha(color) > 0;
+}
+
+function clampByte(n) {
+  n = Math.round(Number(n));
+  if (!isFinite(n) || n < 0) return 0;
+  if (n > 255) return 255;
+  return n;
+}
+
+function cssColor(color) {
+  if (color && typeof color === "object" && color.r !== undefined) {
+    var a = Number(color.a);
+    if (!isFinite(a)) a = 1;
+    if (a < 0) a = 0;
+    if (a > 1) a = 1;
+    return (
+      "rgba(" +
+      clampByte(color.r * 255) +
+      ", " +
+      clampByte(color.g * 255) +
+      ", " +
+      clampByte(color.b * 255) +
+      ", " +
+      a +
+      ")"
+    );
+  }
+  var s = String(color || "transparent");
+  if (s.charAt(0) === "#" && s.length === 9) {
+    var hex = s.slice(1);
+    return (
+      "rgba(" +
+      parseInt(hex.slice(2, 4), 16) +
+      ", " +
+      parseInt(hex.slice(4, 6), 16) +
+      ", " +
+      parseInt(hex.slice(6, 8), 16) +
+      ", " +
+      parseInt(hex.slice(0, 2), 16) / 255 +
+      ")"
+    );
+  }
+  return s;
+}
+
+function defaultCorners() {
+  return {
+    cutTopLeft: true,
+    cutTopRight: false,
+    cutBottomRight: true,
+    cutBottomLeft: false,
+  };
+}
+
+function pathPoints(width, height, cut, corners, strokeWidth, dpr) {
+  var w = Number(width);
+  var h = Number(height);
+  if (!isFinite(w) || !isFinite(h) || w <= 0 || h <= 0) return [];
+  var metrics = strokeMetrics(strokeWidth, dpr);
+  var o = metrics.inset;
+  var c = snap(cutSize(cut, w, h, o), dpr);
+  var flags = corners || defaultCorners();
+  var tl = !!flags.cutTopLeft;
+  var tr = !!flags.cutTopRight;
+  var br = !!flags.cutBottomRight;
+  var bl = !!flags.cutBottomLeft;
+  // Inset is already on the stroke centre. Rounding it to a whole item
+  // pixel would land a 1px hairline between two pixels and smear it.
+  var l = o;
+  var t = o;
+  var r = w - o;
+  var b = h - o;
+  var pts = [];
+  pts.push([l + (tl ? c : 0), t]);
+  pts.push([r - (tr ? c : 0), t]);
+  if (tr) pts.push([r, t + c]);
+  pts.push([r, b - (br ? c : 0)]);
+  if (br) pts.push([r - c, b]);
+  pts.push([l + (bl ? c : 0), b]);
+  if (bl) pts.push([l, b - c]);
+  pts.push([l, t + (tl ? c : 0)]);
+  return pts;
+}

--- a/services/Theme.qml
+++ b/services/Theme.qml
@@ -55,6 +55,11 @@ QtObject {
   readonly property string iconStar: "star-line"
   readonly property string iconStarOn: "star-fill"
   readonly property int radius: 0
+  // A cut corner, not a radius. The visual language note above forbids
+  // rounding cards and this does not round them. Sized off the font so it
+  // tracks density the way pad and gap already do. PrefsButton uses chamferSm.
+  readonly property int chamfer: Math.max(5, Math.round(fontSize * 0.62))
+  readonly property int chamferSm: Math.max(3, Math.round(fontSize * 0.36))
   // Sidebar status badges. A step above caption so the glyph reads at a
   // glance. Status ink is Theme.urgent / Theme.muted, not a private green.
   readonly property int badgeSize: Math.max(12, fontSize + 1)

--- a/tests/chamfer.test.js
+++ b/tests/chamfer.test.js
@@ -1,0 +1,164 @@
+const fs = require("fs");
+const path = require("path");
+const { load, assert, assertEqual } = require("./harness");
+
+const chamfer = load("services/Chamfer.js");
+const chamferQml = fs.readFileSync(path.join(__dirname, "..", "components", "Chamfer.qml"), "utf8");
+const buttonSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsButton.qml"),
+  "utf8",
+);
+const dialogSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsDialog.qml"),
+  "utf8",
+);
+const confirmSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsConfirm.qml"),
+  "utf8",
+);
+const groupSrc = fs.readFileSync(
+  path.join(__dirname, "..", "components", "PrefsGroup.qml"),
+  "utf8",
+);
+const shellSrc = fs.readFileSync(path.join(__dirname, "..", "shell.qml"), "utf8");
+
+assert(chamferQml.indexOf("Canvas") !== -1, "Chamfer.qml paints on a Canvas");
+assert(chamferQml.indexOf("Chamfer.js") !== -1, "Chamfer.qml uses Chamfer.js for path math");
+assert(chamferQml.indexOf("Qt.colorEqual") === -1, "Chamfer.qml does not use Qt.colorEqual");
+assert(chamferQml.indexOf("cutTopLeft: true") !== -1, "Chamfer defaults to a top-left cut");
+assert(chamferQml.indexOf("cutBottomRight: true") !== -1, "Chamfer defaults to a bottom-right cut");
+assert(
+  chamferQml.indexOf("cutTopRight: false") !== -1,
+  "Chamfer does not cut the top-right by default",
+);
+assert(
+  chamferQml.indexOf("cutBottomLeft: false") !== -1,
+  "Chamfer does not cut the bottom-left by default",
+);
+assert(chamferQml.indexOf("Window.window") !== -1, "Chamfer reads the window devicePixelRatio");
+
+assertEqual(chamfer.devicePixelRatio(0), 1, "devicePixelRatio treats 0 as 1");
+assertEqual(chamfer.devicePixelRatio(-2), 1, "devicePixelRatio treats a negative as 1");
+assertEqual(chamfer.devicePixelRatio("nope"), 1, "devicePixelRatio treats NaN as 1");
+assertEqual(chamfer.devicePixelRatio(1.5), 1.5, "devicePixelRatio keeps a fractional ratio");
+
+assertEqual(chamfer.snap(0.49, 1), 0, "snap at 1x rounds 0.49 down");
+assertEqual(chamfer.snap(0.5, 1), 1, "snap at 1x rounds 0.5 up");
+assertEqual(chamfer.snap(0.5, 2), 0.5, "snap at 2x keeps a half item pixel");
+
+const hairline = chamfer.strokeMetrics(1, 1);
+assertEqual(hairline.width, 1, "1x hairline stays one item pixel");
+assertEqual(hairline.inset, 0.5, "1x hairline insets by half a stroke");
+const retina = chamfer.strokeMetrics(1, 2);
+assertEqual(retina.width, 1, "2x hairline stays one item pixel");
+assertEqual(retina.inset, 0.5, "2x hairline still insets by half a stroke");
+const fractional = chamfer.strokeMetrics(1, 1.5);
+assertEqual(fractional.width, 2 / 1.5, "1.5x hairline snaps to two physical pixels");
+assertEqual(fractional.inset, 1 / 1.5, "1.5x inset is half the snapped stroke");
+assertEqual(chamfer.strokeMetrics(0, 1).width, 0, "zero stroke has no width");
+assertEqual(chamfer.strokeMetrics(-1, 1).inset, 0, "negative stroke has no inset");
+
+assertEqual(chamfer.cutSize(4, 80, 28, 0.5), 4, "cutSize keeps a cut that fits");
+assertEqual(
+  chamfer.cutSize(40, 20, 28, 0.5),
+  9.5,
+  "cutSize clamps to half the short side minus inset",
+);
+assertEqual(chamfer.cutSize(-3, 80, 28, 0.5), 0, "cutSize rejects a negative cut");
+assertEqual(chamfer.cutSize(4, 0, 28, 0.5), 0, "cutSize is zero when width is zero");
+assertEqual(chamfer.cutSize(4, 4, 4, 3), 0, "cutSize is zero when inset eats the rect");
+
+assertEqual(chamfer.colorAlpha("transparent"), 0, "transparent has alpha 0");
+assertEqual(chamfer.colorAlpha("#00000000"), 0, "Qt transparent black has alpha 0");
+assertEqual(chamfer.colorAlpha("#00ffffff"), 0, "Qt transparent white has alpha 0");
+assertEqual(
+  chamfer.colorAlpha({ r: 1, g: 1, b: 1, a: 0.04 }),
+  0.04,
+  "colorAlpha reads an object alpha",
+);
+assertEqual(chamfer.colorAlpha("#cacccc"), 1, "opaque hex has alpha 1");
+assert(chamfer.shouldPaint({ r: 0.8, g: 0.8, b: 0.8, a: 0.04 }), "a 0.04 fill still paints");
+assert(!chamfer.shouldPaint("transparent"), "transparent does not paint");
+assert(!chamfer.shouldPaint("#00ffffff"), "transparent white does not paint");
+assert(!chamfer.shouldPaint(null), "a missing color does not paint");
+
+assertEqual(
+  chamfer.cssColor({ r: 1, g: 0, b: 0, a: 0.22 }),
+  "rgba(255, 0, 0, 0.22)",
+  "cssColor keeps alpha from a QML color",
+);
+assertEqual(
+  chamfer.cssColor("#80cacccc"),
+  "rgba(202, 204, 204, 0.5019607843137255)",
+  "cssColor converts Qt #AARRGGBB so Canvas does not drop alpha",
+);
+
+const defaults = chamfer.defaultCorners();
+assert(defaults.cutTopLeft && defaults.cutBottomRight, "default corners are the TL+BR diagonal");
+assert(!defaults.cutTopRight && !defaults.cutBottomLeft, "default corners leave TR and BL square");
+
+assertEqual(
+  chamfer.pathPoints(0, 28, 4, defaults, 1, 1).length,
+  0,
+  "pathPoints is empty when width is 0",
+);
+assertEqual(
+  chamfer.pathPoints(80, 0, 4, defaults, 1, 1).length,
+  0,
+  "pathPoints is empty when height is 0",
+);
+
+const box = chamfer.pathPoints(80, 28, 4, defaults, 1, 1);
+assertEqual(box.length, 6, "TL+BR path has six vertices");
+assertEqual(box[0][0], 4.5, "TL cut starts inset plus cut along the top");
+assertEqual(box[0][1], 0.5, "top edge sits on the 1x hairline");
+assertEqual(box[1][0], 79.5, "uncut top-right is the inset right edge");
+assertEqual(box[2][0], 79.5, "right edge is vertical after the top");
+assertEqual(box[2][1], 23.5, "BR cut starts inset plus cut up from the bottom");
+assertEqual(box[3][0], 75.5, "BR cut lands on the bottom edge");
+assertEqual(box[3][1], 27.5, "bottom edge sits on the 1x hairline");
+assertEqual(box[5][0], 0.5, "left edge is the inset");
+assertEqual(box[5][1], 4.5, "TL cut ends inset plus cut down from the top");
+
+const octagon = chamfer.pathPoints(
+  80,
+  28,
+  4,
+  { cutTopLeft: true, cutTopRight: true, cutBottomRight: true, cutBottomLeft: true },
+  1,
+  1,
+);
+assertEqual(octagon.length, 8, "all four cuts make eight vertices");
+
+assert(buttonSrc.indexOf("Chamfer") !== -1, "PrefsButton uses Chamfer");
+assert(buttonSrc.indexOf("Theme.chamferSm") !== -1, "PrefsButton uses the small chamfer token");
+assert(dialogSrc.indexOf("Chamfer") === -1, "PrefsDialog stays a square card");
+assert(confirmSrc.indexOf("Chamfer {") === -1, "PrefsConfirm stays a square card");
+assert(groupSrc.indexOf("Chamfer") === -1, "PrefsGroup stays a square card");
+assert(shellSrc.indexOf("Chamfer") === -1, "sidebar chrome does not use Chamfer");
+
+function walk(dir, acc) {
+  acc = acc || [];
+  fs.readdirSync(dir, { withFileTypes: true }).forEach(function (ent) {
+    if (ent.name === "node_modules") return;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(full, acc);
+    else if (ent.name.endsWith(".qml")) acc.push(full);
+  });
+  return acc;
+}
+
+const chamferUsers = walk(path.join(__dirname, ".."))
+  .map(function (file) {
+    return path.relative(path.join(__dirname, ".."), file);
+  })
+  .filter(function (rel) {
+    if (rel === "components/Chamfer.qml") return false;
+    const src = fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+    return src.indexOf("Chamfer") !== -1;
+  });
+assertEqual(
+  chamferUsers.join(","),
+  "components/PrefsButton.qml",
+  "only PrefsButton instantiates Chamfer",
+);

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -276,6 +276,8 @@ assert(
 );
 assert(
   themeQml.indexOf("readonly property int radius: 0") !== -1 &&
+    themeQml.indexOf("readonly property int chamfer:") !== -1 &&
+    themeQml.indexOf("readonly property int chamferSm:") !== -1 &&
     themeQml.indexOf("readonly property int contentMaxWidth: 1000") !== -1 &&
     themeQml.indexOf("readonly property int railWidth:") !== -1,
   "Theme keeps square chrome, a capped content column, and a sidebar rail",
@@ -297,6 +299,27 @@ assert(
 assert(
   prefsButtonSrc.indexOf("TextMetrics") !== -1 && prefsButtonSrc.indexOf("labelMetrics") !== -1,
   "PrefsButton sizes from TextMetrics so a hidden row still gets a width",
+);
+assert(
+  prefsButtonSrc.indexOf("Chamfer") !== -1 &&
+    prefsButtonSrc.indexOf("Theme.chamferSm") !== -1 &&
+    prefsButtonSrc.indexOf('color: "transparent"') !== -1 &&
+    prefsButtonSrc.indexOf("border.width: 0") !== -1,
+  "PrefsButton keeps a Rectangle root and paints a chamfered silhouette",
+);
+assert(
+  prefsButtonSrc.indexOf("Behavior on bodyColor") !== -1 &&
+    prefsButtonSrc.indexOf("Behavior on edgeColor") !== -1 &&
+    prefsButtonSrc.indexOf("mouse.containsMouse") !== -1 &&
+    prefsButtonSrc.indexOf("root.activeFocus") !== -1 &&
+    prefsButtonSrc.indexOf("Theme.fill(Theme.hoverFill)") !== -1 &&
+    prefsButtonSrc.indexOf("Theme.accentFill(Theme.primaryFill)") !== -1,
+  "PrefsButton still animates hover, focus, and primary fill on the chamfer",
+);
+assert(
+  prefsButtonSrc.indexOf("anchors.fill: parent") !== -1 &&
+    prefsButtonSrc.indexOf("hoverEnabled: true") !== -1,
+  "PrefsButton keeps a full-rect MouseArea so a transparent root still clicks",
 );
 const prefsSliderSrc = fs.readFileSync(
   path.join(__dirname, "..", "components", "PrefsSlider.qml"),

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -9,6 +9,18 @@ assert(
   "Theme.qml restarts inotifywait after 1s, not a poll",
 );
 assert(themeQml.indexOf("interval: 800") === -1, "Theme.qml has no 800ms theme poll");
+assert(
+  themeQml.indexOf("readonly property int radius: 0") !== -1 &&
+    themeQml.indexOf("readonly property int chamfer:") !== -1 &&
+    themeQml.indexOf("readonly property int chamferSm:") !== -1 &&
+    /readonly property int chamfer:\s*Math\.max\(5, Math\.round\(fontSize \* 0\.62\)\)/.test(
+      themeQml,
+    ) &&
+    /readonly property int chamferSm:\s*Math\.max\(3, Math\.round\(fontSize \* 0\.36\)\)/.test(
+      themeQml,
+    ),
+  "Theme sizes chamfer tokens off fontSize and keeps radius 0",
+);
 
 const theme = load("services/Theme.js");
 const shell = load("services/ShellConfig.js");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port of nixfred's [#35](https://github.com/csfh/atmos/pull/35) onto current `main`. Atmos stays `radius: 0` — cards, dialogs, and the sidebar stay square. PrefsButton is the only chamfered control: a 45° cut on the top-left and bottom-right, Omarchy's existing brand mark, not a rounded corner.

Based on work by Fred Nix ([@nixfred](https://github.com/nixfred)). After this merges, [#35](https://github.com/csfh/atmos/pull/35) can be closed as superseded. This branch is on `csfh/atmos`; it does not push to the fork.

## Against #35

#35 was green but conflicting (~8 commits behind). Main has since grown row lighting, keyboard nav, theme hover preview, captions, and Simple/Everything disclosure. PrefsButton's hover / focus / primary / danger colors and `Theme.motionFast` animation are unchanged; only the silhouette is swapped.

Fixes beyond a straight rebase:

1. **Hover and focus still animate.** #35 left `Behavior` on the now-transparent `Rectangle` `color` / `border.color`, so the tween never ran. Animation is on `bodyColor` / `edgeColor`, which Chamfer paints.
2. **`Qt.colorEqual("transparent")` is gone.** That compare misses Qt transparent white (`#00ffffff`) and can skip the fill if it fails. Paint uses alpha (`shouldPaint`).
3. **Canvas keeps alpha on HiDPI.** Fill/stroke go through `cssColor` (`rgba(...)`, including Qt `#AARRGGBB`) so a 0.04 fill is not dropped. Stroke width snaps to the physical pixel grid at fractional DPR; the half-stroke inset is not rounded away (that would smear a 1px hairline).
4. **Click target stays the full rect.** The root is still a transparent `Rectangle` with a full-size `MouseArea`, so the cut corners remain hittable.
5. **Path math is in `services/Chamfer.js`** so Node can test clamp / inset / skip-paint without Quickshell.

## Scope

Buttons only, via `PrefsButton`. `Theme.chamfer` / `Theme.chamferSm` are sized off `fontSize` the way `pad` and `gap` already are. No card, dialog, or sidebar selection uses Chamfer.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2af456cb-4d30-440a-97b8-a0e7633c836b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2af456cb-4d30-440a-97b8-a0e7633c836b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

