### PR TITLE
feat: Machine dashboard page (from nixfred/#36)

### DIFF
--- a/pages/SystemPage.qml
+++ b/pages/SystemPage.qml
@@ -15,14 +15,15 @@ PrefsPage {
   property var navigator: null
 
   function openSubpage(id) {
-    if (root.navigator && root.navigator.go) {
-      root.navigator.go("system/" + id)
+    if (stack) {
+      if (id === "machine") stack.push(machinePage)
+      else if (id === "environment") stack.push(environmentPage)
+      else if (id === "kernel") stack.push(kernelPage)
+      else if (id === "diagnostics") stack.push(diagnosticsPage)
       return
     }
-    if (!stack) return
-    if (id === "diagnostics") stack.push(diagnosticsPage)
-    else if (id === "environment") stack.push(environmentPage)
-    else if (id === "kernel") stack.push(kernelPage)
+    if (root.navigator && root.navigator.go)
+      root.navigator.go("system/" + id)
   }
 
   readonly property string diagnosticsDescription: {
@@ -37,6 +38,7 @@ PrefsPage {
   Component { id: diagnosticsPage; Sys.DiagnosticsPage {} }
   Component { id: environmentPage; Sys.EnvironmentPage {} }
   Component { id: kernelPage; Sys.KernelPage {} }
+  Component { id: machinePage; Sys.MachinePage {} }
 
   PrefsConfirm {
     id: channelConfirm
@@ -743,6 +745,18 @@ PrefsPage {
     title: "Diagnostics"
     query: root.query
     detail: "Health, failed units, Hyprland errors, and a copyable report. Crash capture lives on that page."
+
+    SettingRow {
+      label: "Machine"
+      description: "What this computer is and how it is doing, in one screen."
+      query: root.query
+      keywords: ["machine", "hardware", "battery", "dashboard", "cpu", "memory"]
+
+      PrefsButton {
+        text: "Open…"
+        onClicked: root.openSubpage("machine")
+      }
+    }
 
     SettingRow {
       label: "Environment"

--- a/pages/system/MachinePage.qml
+++ b/pages/system/MachinePage.qml
@@ -1,0 +1,192 @@
+import QtQuick
+import "../../components"
+import "../../services"
+import "../../services/Hardware.js" as HardwareJs
+
+// Glanceable dashboard for this computer. Diagnostics is the report you
+// copy when something is wrong. This page answers what the machine is and
+// how it is doing, from snapshot and hardware inventory Atmos already has.
+// Unknown stays unknown: a missing charge is not shown as 0%.
+
+PrefsPage {
+  id: root
+  hubId: "system/machine"
+  title: "Machine"
+  description: "What this computer is, and how it is doing right now."
+
+  readonly property var hw: HardwareJs.normalize(Omarchy.hardware)
+  readonly property string chargeLimitNote: Omarchy.chargeLimitAvailable && Omarchy.chargeLimit > 0
+    ? "Charge limited to " + Omarchy.chargeLimit + "%."
+    : ""
+
+  function orUnknown(text) {
+    var s = String(text || "").replace(/^\s+|\s+$/g, "")
+    return s.length > 0 ? s : "unknown"
+  }
+
+  function batteryValue(item) {
+    return HardwareJs.batterySummary(item) || "unknown"
+  }
+
+  function batteryHasCapacity(item) {
+    return !!(item && item.capacity)
+  }
+
+  readonly property string modelLine: {
+    var vendor = String(Omarchy.dmiVendor || "").replace(/^\s+|\s+$/g, "")
+    var product = String(Omarchy.dmiProduct || "").replace(/^\s+|\s+$/g, "")
+    if (!vendor && !product) return "unknown"
+    if (vendor && product && product.toLowerCase().indexOf(vendor.toLowerCase()) === 0)
+      return product
+    return (vendor + " " + product).replace(/^\s+|\s+$/g, "")
+  }
+
+  PrefsGroup {
+    title: "This computer"
+    query: root.query
+    detail: "Identity as the firmware reports it. Hardware has the full DMI dump."
+
+    SettingRow {
+      label: "Model"
+      description: "Vendor and product from DMI."
+      hint: "/sys/class/dmi/id"
+      query: root.query
+      keywords: ["machine", "model", "dmi", "vendor", "product"]
+      valueText: root.modelLine
+    }
+
+    SettingRow {
+      label: "Family"
+      description: "The line this machine belongs to, when firmware names one."
+      hint: "/sys/class/dmi/id"
+      query: root.query
+      keywords: ["family", "dmi"]
+      available: String(Omarchy.dmiFamily || "").length > 0
+      valueText: root.orUnknown(Omarchy.dmiFamily)
+    }
+
+    SettingRow {
+      label: "Processor"
+      description: "What is doing the work."
+      hint: "lscpu"
+      query: root.query
+      keywords: ["cpu", "processor"]
+      valueText: root.orUnknown(Omarchy.cpuIdentity)
+    }
+
+    SettingRow {
+      label: "Graphics"
+      description: "The GPU the compositor is drawing on."
+      hint: "drm"
+      query: root.query
+      keywords: ["gpu", "graphics"]
+      valueText: root.orUnknown(Omarchy.gpuIdentity)
+    }
+
+    SettingRow {
+      label: "Neural engine"
+      description: "Only shown when the machine actually has one."
+      query: root.query
+      keywords: ["npu", "neural"]
+      available: String(Omarchy.npuIdentity || "").length > 0
+      valueText: root.orUnknown(Omarchy.npuIdentity)
+    }
+  }
+
+  PrefsGroup {
+    title: "Right now"
+    query: root.query
+    detail: root.chargeLimitNote
+      ? ("Live from the same snapshot the rest of Atmos reads. " + root.chargeLimitNote)
+      : "Live from the same snapshot the rest of Atmos reads."
+
+    SettingRow {
+      label: "Processor load"
+      description: "As the kernel reports it."
+      hint: "/proc/stat"
+      query: root.query
+      keywords: ["load", "cpu", "usage"]
+      available: String(Omarchy.cpuStat || "").length > 0
+      valueText: root.orUnknown(Omarchy.cpuStat)
+    }
+
+    SettingRow {
+      label: "Memory"
+      description: "In use against what is fitted."
+      hint: "/proc/meminfo"
+      query: root.query
+      keywords: ["memory", "ram"]
+      available: String(Omarchy.memoryStat || "").length > 0
+      valueText: root.orUnknown(Omarchy.memoryStat)
+    }
+
+    Repeater {
+      model: root.hw.batteries
+
+      SettingRow {
+        required property var modelData
+        stretchControl: true
+        label: (modelData && modelData.name) || "Battery"
+        description: root.chargeLimitNote || "Charge from sysfs. Profiles stay on Power."
+        hint: "/sys/class/power_supply"
+        query: root.query
+        keywords: ["battery", "charge", "capacity"]
+        valueText: root.batteryValue(modelData)
+
+        PrefsProgress {
+          width: parent.width
+          visible: root.batteryHasCapacity(modelData)
+          from: 0
+          to: 100
+          value: modelData && modelData.capacity ? modelData.capacity : 0
+        }
+      }
+    }
+
+    SettingRow {
+      label: "Battery"
+      description: root.chargeLimitNote || "The inventory has not filled charge or status yet."
+      hint: "/sys/class/power_supply"
+      query: root.query
+      keywords: ["battery", "charge", "capacity"]
+      available: Omarchy.batteryPresent && root.hw.batteries.length === 0
+      valueText: "unknown"
+    }
+  }
+
+  PrefsGroup {
+    title: "Storage"
+    query: root.query
+    detail: "Every mounted filesystem Atmos can see. Disks has the device detail."
+
+    Repeater {
+      model: Array.isArray(Omarchy.disks) ? Omarchy.disks : []
+
+      SettingRow {
+        required property var modelData
+        stretchControl: true
+        sectionHelp: false
+        label: String(modelData && modelData.name ? modelData.name : "disk")
+        description: String(modelData && modelData.mount ? modelData.mount : "")
+        hint: "df"
+        query: root.query
+        keywords: ["disk", "storage", "df", "filesystem"]
+
+        PrefsUsageBar {
+          width: parent.width
+          used: modelData && modelData.used ? Number(modelData.used) : 0
+          size: modelData && modelData.size ? Number(modelData.size) : 0
+          avail: modelData && modelData.avail ? Number(modelData.avail) : 0
+        }
+      }
+    }
+
+    SettingRow {
+      label: "No filesystems reported"
+      description: "The snapshot has not answered yet, or nothing is mounted that Atmos tracks."
+      query: root.query
+      keywords: ["disk", "storage"]
+      available: !Array.isArray(Omarchy.disks) || Omarchy.disks.length === 0
+    }
+  }
+}

--- a/pages/system/qmldir
+++ b/pages/system/qmldir
@@ -1,3 +1,4 @@
 DiagnosticsPage 1.0 DiagnosticsPage.qml
 EnvironmentPage 1.0 EnvironmentPage.qml
 KernelPage 1.0 KernelPage.qml
+MachinePage 1.0 MachinePage.qml

--- a/services/Hubs.js
+++ b/services/Hubs.js
@@ -379,9 +379,10 @@ function hubs() {
       file: "SystemPage.qml",
       keywords: keywordList(
         "crash capture diagnostics coredump weather location city forecast coordinates latitude longitude gps units celsius fahrenheit metric imperial refresh interval about logo branding fastfetch timezone tz utc region city date time zoneinfo timedatectl hostname computer machine device name hostnamectl keyboard layout keymap xkb qwerty language input localectl ntp timesync synchronize automatic clock network time locale lang utf-8 i18n translation pacman parallel downloads packages mirrors aur update channel orphan prune version printer cups print restore hyprland shell restart atmos git pull reset sentinel overrides report journal systemd portal pipewire kernel environment path editor shell",
-        ["hostname", "locale", "update", "diagnostics", "kernel", "uki"],
+        ["hostname", "locale", "update", "diagnostics", "kernel", "uki", "machine"],
       ),
       children: [
+        child("system/machine", "Machine", "system/MachinePage.qml"),
         child("system/environment", "Environment", "system/EnvironmentPage.qml"),
         child("system/kernel", "Kernel", "system/KernelPage.qml"),
         child("system/diagnostics", "Diagnostics", "system/DiagnosticsPage.qml"),

--- a/tests/hardware.test.js
+++ b/tests/hardware.test.js
@@ -172,6 +172,13 @@ assert(
     -1,
   "batterySummary names capacity",
 );
+assertEqual(hw.batterySummary({}), "", "batterySummary is empty when charge is unknown");
+assertEqual(hw.batterySummary({ capacity: 0 }), "", "batterySummary does not invent 0%");
+assert(
+  hw.batterySummary({ status: "Discharging" }).indexOf("Discharging") !== -1 &&
+    hw.batterySummary({ status: "Discharging" }).indexOf("0%") === -1,
+  "batterySummary keeps status without inventing capacity",
+);
 assertEqual(
   hw
     .boardSummary({ vendor: "Framework", name: "Mainboard", version: "A7" })

--- a/tests/hubs.test.js
+++ b/tests/hubs.test.js
@@ -28,6 +28,7 @@ assert(catalog.length > 0, "hubs() returns the catalog");
 assertEqual(hubs.hubTitle("idle"), "Idle", "idle hub title is Idle");
 assertEqual(hubs.hubTitle("export"), "Omafile", "export hub title is Omafile");
 assertEqual(hubs.hubTitle("system/kernel"), "Kernel", "kernel is a System child");
+assertEqual(hubs.hubTitle("system/machine"), "Machine", "machine is a System child");
 assert(
   hubs.hubById("export").keywords.indexOf("omafile") !== -1 &&
     hubs.hubById("export").keywords.indexOf("import") !== -1 &&
@@ -132,6 +133,7 @@ const pageFiles = [
   "system/DiagnosticsPage.qml",
   "system/EnvironmentPage.qml",
   "system/KernelPage.qml",
+  "system/MachinePage.qml",
   "applications/StartupPage.qml",
   "WorkspacesPage.qml",
   "TweaksPage.qml",

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1335,6 +1335,32 @@ assert(
   "System opens the Diagnostics child page",
 );
 assert(
+  systemSrc.indexOf('label: "Machine"') !== -1 &&
+    systemSrc.indexOf('openSubpage("machine")') !== -1 &&
+    systemSrc.indexOf('id === "machine"') !== -1 &&
+    systemSrc.indexOf("stack.push(machinePage)") !== -1,
+  "System opens the Machine child page",
+);
+const machinePageSrc = fs.readFileSync(
+  path.join(__dirname, "..", "pages", "system", "MachinePage.qml"),
+  "utf8",
+);
+assert(
+  machinePageSrc.indexOf("HardwareJs.batterySummary") !== -1 &&
+    machinePageSrc.indexOf('hubId: "system/machine"') !== -1,
+  "Machine uses Hardware batterySummary for live charge",
+);
+assert(
+  machinePageSrc.indexOf('valueText: "present"') === -1 &&
+    machinePageSrc.indexOf('"charge limited to "') === -1,
+  "Machine does not treat present/limit as the primary battery readout",
+);
+assert(
+  machinePageSrc.indexOf("batteryValue") !== -1 &&
+    machinePageSrc.indexOf('|| "unknown"') !== -1,
+  "Machine keeps unknown charge as unknown",
+);
+assert(
   systemSrc.indexOf('label: "Crash capture"') === -1,
   "Crash capture moved off System onto Diagnostics",
 );

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1356,8 +1356,7 @@ assert(
   "Machine does not treat present/limit as the primary battery readout",
 );
 assert(
-  machinePageSrc.indexOf("batteryValue") !== -1 &&
-    machinePageSrc.indexOf('|| "unknown"') !== -1,
+  machinePageSrc.indexOf("batteryValue") !== -1 && machinePageSrc.indexOf('|| "unknown"') !== -1,
   "Machine keeps unknown charge as unknown",
 );
 assert(

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -227,6 +227,12 @@ assert(
 );
 assert(
   qmlCatalog.some(function (row) {
+    return row.label === "Processor load" && row.hub === "system/machine";
+  }),
+  "qml catalog sends Machine dashboard rows to the machine subpage",
+);
+assert(
+  qmlCatalog.some(function (row) {
     return row.label === "Wi-Fi radio" && row.hub === "network/wifi";
   }),
   "qml catalog sends Wi-Fi rows to the wifi subpage",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port of nixfred’s [#36](https://github.com/csfh/atmos/pull/36) onto current `main`: a System → Machine child that is a glanceable dashboard, not a report. Diagnostics stays the copyable health report.

Identity (DMI / CPU / GPU / NPU), live load and memory, battery, and mounted-filesystem usage bars. No new probes — a view over snapshot and hardware inventory Atmos already collects.

**Credit:** original page and hub wiring by [nixfred](https://github.com/nixfred) in #36. After this merges, #36 can close as superseded.

### Beyond a straight port

- Battery is the live charge/status string from `HardwareJs.batterySummary` (same helper Hardware uses). Multiple batteries use a repeater. A capacity bar (`PrefsProgress`) shows only when inventory has a real capacity — never a confident 0% for missing data. Charge-limit stays secondary section detail.
- `openSubpage` pushes the child when `stack` is set, so `atmos system/machine` actually opens Machine instead of bouncing through `navigator.go` and landing on System. Environment / Kernel / Diagnostics use the same push path.
- House style on current main: `SettingRow`, `hubId: "system/machine"`, catalogue tests for the new child.

`bin/atmos` already listed `machine` as a suffix; the suite catalogue now has a matching `system/machine` child.

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5755f94f-5682-44a7-81ed-2beec18c37da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5755f94f-5682-44a7-81ed-2beec18c37da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

