### PR TITLE
feat: change history and preview hold (from nixfred/#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Atmos. Each section is a git tag on `main` and `alpha`. Insta
 
 ## Unreleased
 
+### Added
+
+- **History** and **Preview** on System. Every real `runCommand` write is recorded in memory for this window (command, target file, source, time; newest first; cap 200). Preview holds the write and shows the command; Apply is the only path that runs held entries, and Discard clears them. Off by default and not persisted. ([#37](https://github.com/csfh/atmos/pull/37)) by Fred Nix ([@nixfred](https://github.com/nixfred)).
+
 ### Fixed
 
 - A second Atmos from a different path (install plus a checkout) is refused. Quickshell only keys single-instance on the config path; an app-level flock in `$XDG_RUNTIME_DIR` now dies with the process, and the loser cannot write. ([#27](https://github.com/csfh/atmos/issues/27))

--- a/bin/atmos
+++ b/bin/atmos
@@ -29,7 +29,7 @@ fi
 
 HUB=${PAGE%%/*}
 if [[ -n $PAGE && $HUB != favorites && $HUB != appearance && $HUB != display && $HUB != windows && $HUB != workspaces && $HUB != bar && $HUB != notifications && $HUB != profiles && $HUB != input && $HUB != keybindings && $HUB != accessibility && $HUB != sound && $HUB != capture && $HUB != hardware && $HUB != drivers && $HUB != disks && $HUB != network && $HUB != bluetooth && $HUB != power && $HUB != idle && $HUB != defaults && $HUB != applications && $HUB != software && $HUB != hooks && $HUB != system && $HUB != tweaks && $HUB != export && $HUB != accounts && $HUB != security && $HUB != services ]]; then
-  echo "Usage: atmos [favorites|appearance|display|hardware|drivers|windows|workspaces|input|keybindings|accessibility|sound|capture|disks|bar|notifications|profiles|defaults|applications|software|network|bluetooth|power|idle|security|accounts|hooks|tweaks|services|system|export][/theme|background|boot|gpu|cpu|npu|machine|speedtest|wifi|bindings|rules|startup|environment|kernel|diagnostics]" >&2
+  echo "Usage: atmos [favorites|appearance|display|hardware|drivers|windows|workspaces|input|keybindings|accessibility|sound|capture|disks|bar|notifications|profiles|defaults|applications|software|network|bluetooth|power|idle|security|accounts|hooks|tweaks|services|system|export][/theme|background|boot|gpu|cpu|npu|machine|speedtest|wifi|bindings|rules|startup|environment|kernel|diagnostics|history]" >&2
   exit 1
 fi
 

--- a/pages/SystemPage.qml
+++ b/pages/SystemPage.qml
@@ -19,6 +19,7 @@ PrefsPage {
       if (id === "machine") stack.push(machinePage)
       else if (id === "environment") stack.push(environmentPage)
       else if (id === "kernel") stack.push(kernelPage)
+      else if (id === "history") stack.push(historyPage)
       else if (id === "diagnostics") stack.push(diagnosticsPage)
       return
     }
@@ -39,6 +40,7 @@ PrefsPage {
   Component { id: environmentPage; Sys.EnvironmentPage {} }
   Component { id: kernelPage; Sys.KernelPage {} }
   Component { id: machinePage; Sys.MachinePage {} }
+  Component { id: historyPage; Sys.HistoryPage {} }
 
   PrefsConfirm {
     id: channelConfirm
@@ -781,6 +783,18 @@ PrefsPage {
       PrefsButton {
         text: "Open…"
         onClicked: root.openSubpage("kernel")
+      }
+    }
+
+    SettingRow {
+      label: "History"
+      description: "Every change this window made, and a preview mode that shows a change before it happens. In memory for this session, not a disk log."
+      query: root.query
+      keywords: ["history", "undo", "changes", "preview", "audit"]
+
+      PrefsButton {
+        text: "Open…"
+        onClicked: root.openSubpage("history")
       }
     }
 

--- a/pages/system/HistoryPage.qml
+++ b/pages/system/HistoryPage.qml
@@ -1,0 +1,121 @@
+import QtQuick
+import "../../components"
+import "../../services"
+import "../../services/History.js" as HistoryJs
+
+// What Atmos changed, and what it is about to change.
+//
+// The question this answers is the one you ask at the worst moment: "what
+// did I touch yesterday that broke my touchpad." Atmos is unusually well
+// placed to answer it, because every mutation already funnels through one
+// function and the import planner already knows how to describe a change
+// before it happens.
+//
+// Preview is the same machinery pointed forwards. With it on, a write is
+// held and shown rather than made, so you can flip a control and read the
+// command it would run. Nothing held ever executes on its own -- Apply is
+// the only path, and Discard is one click.
+//
+// The list is in memory for this window. Another Atmos window has its own.
+
+PrefsPage {
+  id: root
+  hubId: "system/history"
+  title: "History"
+  description: "Every change this window made, newest first, in memory for the session. Turn on Preview to see a change before it happens instead of after."
+
+  readonly property var counts: HistoryJs.countsBySource(Omarchy.changeHistory)
+
+  PrefsGroup {
+    title: "Preview"
+    query: root.query
+    detail: "While Preview is on, Atmos shows you what a control would run and does not run it. Apply releases everything held; Discard throws it away. Nothing held runs on its own. The flag is not saved across a restart."
+
+    SettingRow {
+      label: "Preview changes"
+      description: Preview.active
+        ? "On. Controls will not write. Anything you change is held below."
+        : "Off. Controls write immediately, as normal."
+      query: root.query
+      keywords: ["dry", "run", "diff", "safe", "preview"]
+
+      PrefsToggle {
+        checked: Preview.active
+        onToggled: function (value) {
+          Preview.active = value
+          if (!value) Omarchy.discardHeld()
+        }
+      }
+    }
+
+    SettingRow {
+      label: "Held"
+      description: Omarchy.heldChanges.length === 1
+        ? "1 change is waiting. Nothing has been written."
+        : Omarchy.heldChanges.length + " changes are waiting. Nothing has been written."
+      query: root.query
+      available: Omarchy.heldChanges.length > 0
+      stretchControl: true
+
+      Row {
+        spacing: Theme.space
+        PrefsButton {
+          text: "Apply"
+          primary: true
+          onClicked: Omarchy.applyHeld()
+        }
+        PrefsButton {
+          text: "Discard"
+          onClicked: Omarchy.discardHeld()
+        }
+      }
+    }
+
+    Repeater {
+      model: Omarchy.heldChanges
+
+      delegate: SettingRow {
+        required property var modelData
+        label: modelData && modelData.file ? modelData.file : (modelData ? modelData.key : "")
+        description: modelData ? modelData.text : ""
+        query: root.query
+        valueText: "held"
+      }
+    }
+  }
+
+  PrefsGroup {
+    title: "Changes"
+    query: root.query
+    detail: "Recorded in memory for this window. Atmos keeps the most recent 200. Another window has its own list; nothing is written to disk."
+
+    SettingRow {
+      label: "Nothing yet"
+      description: "Change something and it will show up here with the command it ran."
+      query: root.query
+      available: Omarchy.changeHistory.length === 0
+    }
+
+    SettingRow {
+      label: "By you"
+      description: "Changes made from a control in this window."
+      query: root.query
+      available: Omarchy.changeHistory.length > 0
+      valueText: String(HistoryJs.countFor(root.counts, "you"))
+    }
+
+    Repeater {
+      model: Omarchy.changeHistory
+
+      delegate: SettingRow {
+        required property var modelData
+        label: modelData && modelData.file
+          ? modelData.file
+          : (modelData && modelData.key ? modelData.key : "change")
+        description: modelData ? modelData.text : ""
+        query: root.query
+        valueText: modelData ? HistoryJs.relativeTime(modelData.at) : ""
+      }
+    }
+  }
+}

--- a/pages/system/qmldir
+++ b/pages/system/qmldir
@@ -2,3 +2,4 @@ DiagnosticsPage 1.0 DiagnosticsPage.qml
 EnvironmentPage 1.0 EnvironmentPage.qml
 KernelPage 1.0 KernelPage.qml
 MachinePage 1.0 MachinePage.qml
+HistoryPage 1.0 HistoryPage.qml

--- a/services/History.js
+++ b/services/History.js
@@ -1,0 +1,176 @@
+// A record of what Atmos changed.
+//
+// Every mutation in Atmos goes through Omarchy.runCommand, which makes it
+// the one honest place to record from. Recording per page or per control
+// would mean trusting that every future control remembered to log, and the
+// entries that got missed would be exactly the ones nobody thought about --
+// which are the ones you most want when something breaks.
+//
+// Two features share this file because they are the same question asked at
+// two different times. Preview asks "what would this do" before it happens;
+// history asks "what did that do" after. Both need the command rendered as
+// something a person can read.
+//
+// History and held writes live in memory on the Omarchy singleton of this
+// window. After multi-window Atmos, each launch is its own process, so the
+// list is per-window and is not a disk audit log.
+
+var MAX_ENTRIES = 200;
+
+// argv comes in wrapped for the shell more often than not, because Atmos
+// detaches long-running writers. The wrapper is noise to a reader, so strip
+// it and show the command that was actually meant.
+function unwrap(argv) {
+  var list = Array.isArray(argv) ? argv.slice() : [];
+  if (list.length >= 3 && list[0] === "bash" && list[1] === "-c") {
+    // bash -c SCRIPT NAME ARGS... The interesting part is ARGS, but only
+    // when the script really is one of Atmos's own wrappers.
+    var script = String(list[2] || "");
+    // Match the wrapper shape, not the word. A plain substring test for
+    // "exec" fires on any script that merely contains it -- "echo execute
+    // me" was enough -- and then the command is rendered as whatever
+    // happened to be in that argument slot.
+    var isWrapper = /exec\s+"\$@"|exec\s+"\$1"|"\$@"\s*>/.test(script);
+    if (!isWrapper) return list.slice(2);
+    // A wrapper that shifts has consumed $1, so the real command starts one
+    // later. Without this the stub directory that shift exists to remove is
+    // exactly what gets displayed.
+    var start = /(^|;|\s)shift(\s|;|$)/.test(script) ? 5 : 4;
+    var rest = list.slice(start);
+    return rest.length > 0 ? rest : list.slice(2);
+  }
+  return list;
+}
+
+function describe(argv) {
+  var list = unwrap(argv);
+  var out = [];
+  for (var i = 0; i < list.length; i++) {
+    var part = String(list[i] === undefined || list[i] === null ? "" : list[i]);
+    // A value with a space in it reads as two arguments unless it is quoted.
+    if (part.indexOf(" ") !== -1) part = '"' + part + '"';
+    out.push(part);
+  }
+  return out.join(" ");
+}
+
+// Where a command lands, when Atmos knows. Used by preview so the answer to
+// "what will this touch" is a path and not just a command line.
+function targetFile(argv, home) {
+  var text = describe(argv);
+  var h = String(home || "");
+  // The extension has to end the path. Unanchored, ".conf" matched inside
+  // "~/.config/hypr" and reported the file as "~/.conf", and ".json" ate the
+  // c off a .jsonc file.
+  var m = text.match(/(~|\/home\/[^\s"]+)?\/[^\s"]*\.(lua|toml|json|conf|sh)(?![A-Za-z0-9])/);
+  if (!m) return "";
+  var path = m[0];
+  // Boundary, not prefix. "/home/pi" is a prefix of "/home/pieter", so a
+  // plain prefix test rewrote another user's path into "~eter/...".
+  if (h && (path === h || path.indexOf(h + "/") === 0)) return "~" + path.slice(h.length);
+  return path;
+}
+
+function entry(argv, opts, now) {
+  var o = opts || {};
+  return {
+    at: typeof now === "number" ? now : Date.now(),
+    key: String(o.key || ""),
+    text: describe(argv),
+    file: String(o.file || ""),
+    source: String(o.source || "you"),
+    sudo: o.sudo === true,
+  };
+}
+
+// Newest first, capped. A settings app does not need an unbounded audit log
+// in memory, and an unbounded one is a slow leak in a process that runs for
+// weeks.
+function push(list, item) {
+  var out = Array.isArray(list) ? list.slice() : [];
+  out.unshift(item);
+  if (out.length > MAX_ENTRIES) out = out.slice(0, MAX_ENTRIES);
+  return out;
+}
+
+function relativeTime(at, now) {
+  // Number(null) and Number("") are both 0, and 0 is finite, so an isFinite
+  // guard alone reported a missing timestamp as 1970 -- "20707d ago".
+  if (at === null || at === undefined || at === "") return "";
+  var then = Number(at);
+  var ref = typeof now === "number" ? now : Date.now();
+  if (!isFinite(then) || then <= 0) return "";
+  var secs = Math.max(0, Math.round((ref - then) / 1000));
+  if (secs < 10) return "just now";
+  if (secs < 60) return secs + "s ago";
+  var mins = Math.round(secs / 60);
+  if (mins < 60) return mins + "m ago";
+  var hours = Math.round(mins / 60);
+  if (hours < 24) return hours + "h ago";
+  return Math.round(hours / 24) + "d ago";
+}
+
+// Group by source so "what did the agent do" is answerable at a glance,
+// which is the question that matters once anything other than you can
+// propose a change.
+function countsBySource(list) {
+  var out = {};
+  var items = Array.isArray(list) ? list : [];
+  for (var i = 0; i < items.length; i++) {
+    var src = String(items[i] && items[i].source ? items[i].source : "you");
+    out["s_" + src] = (out["s_" + src] || 0) + 1;
+  }
+  return out;
+}
+
+function countFor(counts, source) {
+  var c = counts || {};
+  return c["s_" + String(source)] || 0;
+}
+
+// Apply must replay the original argv and every option runCommand accepted,
+// not a rendered string. Copy own enumerable fields so a later stdin,
+// payload, or callback is not silently dropped, then force bypassPreview
+// so the replay cannot re-hold itself.
+function replayOpts(opts) {
+  var o = opts && typeof opts === "object" ? opts : {};
+  var next = {};
+  var k;
+  for (k in o) {
+    if (!Object.prototype.hasOwnProperty.call(o, k)) continue;
+    if (k === "bypassPreview") continue;
+    next[k] = o[k];
+  }
+  next.bypassPreview = true;
+  return next;
+}
+
+// Held is newest-first for display. Replay oldest first so Apply is a
+// chronological run, not the reverse of what the person did.
+function applyHeld(held, run) {
+  var list = Array.isArray(held) ? held.slice() : [];
+  var i, item;
+  if (typeof run !== "function") return;
+  for (i = list.length - 1; i >= 0; i--) {
+    item = list[i];
+    if (!item) continue;
+    if (!Array.isArray(item.argv) || item.argv.length === 0) continue;
+    run(item.argv, replayOpts(item.opts));
+  }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    MAX_ENTRIES: MAX_ENTRIES,
+    unwrap: unwrap,
+    describe: describe,
+    targetFile: targetFile,
+    entry: entry,
+    push: push,
+    relativeTime: relativeTime,
+    countsBySource: countsBySource,
+    countFor: countFor,
+    replayOpts: replayOpts,
+    applyHeld: applyHeld,
+  };
+}

--- a/services/Hubs.js
+++ b/services/Hubs.js
@@ -378,13 +378,14 @@ function hubs() {
       icon: "settings-3-line",
       file: "SystemPage.qml",
       keywords: keywordList(
-        "crash capture diagnostics coredump weather location city forecast coordinates latitude longitude gps units celsius fahrenheit metric imperial refresh interval about logo branding fastfetch timezone tz utc region city date time zoneinfo timedatectl hostname computer machine device name hostnamectl keyboard layout keymap xkb qwerty language input localectl ntp timesync synchronize automatic clock network time locale lang utf-8 i18n translation pacman parallel downloads packages mirrors aur update channel orphan prune version printer cups print restore hyprland shell restart atmos git pull reset sentinel overrides report journal systemd portal pipewire kernel environment path editor shell",
-        ["hostname", "locale", "update", "diagnostics", "kernel", "uki", "machine"],
+        "crash capture diagnostics coredump weather location city forecast coordinates latitude longitude gps units celsius fahrenheit metric imperial refresh interval about logo branding fastfetch timezone tz utc region city date time zoneinfo timedatectl hostname computer machine device name hostnamectl keyboard layout keymap xkb qwerty language input localectl ntp timesync synchronize automatic clock network time locale lang utf-8 i18n translation pacman parallel downloads packages mirrors aur update channel orphan prune version printer cups print restore hyprland shell restart atmos git pull reset sentinel overrides report journal systemd portal pipewire kernel environment path editor shell history preview audit undo changes",
+        ["hostname", "locale", "update", "diagnostics", "kernel", "uki", "machine", "history"],
       ),
       children: [
         child("system/machine", "Machine", "system/MachinePage.qml"),
         child("system/environment", "Environment", "system/EnvironmentPage.qml"),
         child("system/kernel", "Kernel", "system/KernelPage.qml"),
+        child("system/history", "History", "system/HistoryPage.qml"),
         child("system/diagnostics", "Diagnostics", "system/DiagnosticsPage.qml"),
       ],
     },

--- a/services/Omarchy.qml
+++ b/services/Omarchy.qml
@@ -7,6 +7,7 @@ import "AtmosUpdate.js" as AtmosUpdate
 import "Diagnostics.js" as DiagnosticsJs
 import "Favorites.js" as FavoritesJs
 import "Hardware.js" as HardwareJs
+import "History.js" as HistoryJs
 import "Hooks.js" as HooksJs
 import "Hubs.js" as HubsJs
 import "HyprPrefs.js" as HyprPrefs
@@ -510,12 +511,71 @@ QtObject {
     return SnapshotGroups.normalizeGroup(g)
   }
 
+  // Every mutation passes through here, which makes it the one honest place
+  // to record from or to hold. Hooking each page instead would mean trusting
+  // every future control to remember, and the changes that got missed would
+  // be exactly the ones nobody thought about -- the ones you most want when
+  // working out what broke yesterday. The lists stay in this window's
+  // memory: after multi-window Atmos each launch is its own process.
+  property var changeHistory: []
+  property var heldChanges: []
+
+  function recordChange(argv, opts) {
+    var o = opts || {}
+    changeHistory = HistoryJs.push(
+      changeHistory,
+      HistoryJs.entry(argv, {
+        key: o.key || "",
+        file: HistoryJs.targetFile(argv, Quickshell.env("HOME")),
+        source: "you",
+        sudo: o.sudo === true
+      })
+    )
+  }
+
+  function holdChange(argv, opts) {
+    var o = opts || {}
+    var item = HistoryJs.entry(argv, {
+      key: o.key || "",
+      file: HistoryJs.targetFile(argv, Quickshell.env("HOME")),
+      source: "preview",
+      sudo: o.sudo === true
+    })
+    // The rendered text is for reading; the argv and opts are what Apply
+    // replays. Keeping only the text makes Apply a no-op that looks like it
+    // worked, which is the worst way for this to fail.
+    item.argv = argv
+    item.opts = o
+    heldChanges = HistoryJs.push(heldChanges, item)
+  }
+
+  function discardHeld() {
+    heldChanges = []
+  }
+
+  // The only path by which a held command ever runs, so "preview" cannot
+  // quietly become "apply later". Replay copies every option the original
+  // runCommand call carried (key, apply, refresh, sudo, stdin, payload, …)
+  // and sets bypassPreview so Apply cannot re-hold itself.
+  function applyHeld() {
+    var held = heldChanges
+    heldChanges = []
+    HistoryJs.applyHeld(held, runCommand)
+  }
+
   function runCommand(argv, opts) {
     if (!(argv instanceof Array) || argv.length === 0) return
     opts = opts || {}
+    // Preview stops the write and shows it instead. Held, not queued.
+    if (Preview.active === true && opts.bypassPreview !== true) {
+      holdChange(argv, opts)
+      return
+    }
+    recordChange(argv, opts)
     enqueueIo({
       kind: "mut",
       argv: argv,
+      stdin: opts.stdin != null ? String(opts.stdin) : "",
       key: opts.key ? String(opts.key) : "",
       apply: opts.apply && typeof opts.apply === "object" ? opts.apply : null,
       refresh: snapshotRefreshGroup(opts.refresh),

--- a/services/Preview.qml
+++ b/services/Preview.qml
@@ -1,0 +1,11 @@
+pragma Singleton
+import QtQuick
+
+// Preview mode: show a write instead of making it.
+//
+// Off by default and never persisted. A settings app that silently came back
+// refusing to save would be indistinguishable from a bug. Each Atmos window
+// is its own process, so this flag stays in that window's memory.
+QtObject {
+  property bool active: false
+}

--- a/services/qmldir
+++ b/services/qmldir
@@ -2,3 +2,4 @@ singleton Theme 1.0 Theme.qml
 singleton AccountsStore 1.0 AccountsStore.qml
 singleton Omarchy 1.0 Omarchy.qml
 singleton Disclosure 1.0 Disclosure.qml
+singleton Preview 1.0 Preview.qml

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,179 @@
+const { load, assert, assertEqual } = require("./harness");
+
+const hist = load("services/History.js");
+
+const themeWrap = [
+  "bash",
+  "-c",
+  '"$@" >/dev/null 2>&1 &',
+  "theme-set",
+  "omarchy",
+  "theme",
+  "set",
+  "nord",
+];
+assertEqual(
+  hist.describe(themeWrap),
+  "omarchy theme set nord",
+  "unwrap drops the theme detach wrapper",
+);
+
+const shiftWrap = [
+  "bash",
+  "-c",
+  'PATH="$1:$PATH"; shift; exec "$@"',
+  "prefs-job",
+  "/tmp/atmos-stubs",
+  "omarchy",
+  "theme",
+  "set",
+  "nord",
+];
+assertEqual(
+  hist.describe(shiftWrap),
+  "omarchy theme set nord",
+  "unwrap skips the stub directory a shift removes",
+);
+assert(
+  hist.unwrap(shiftWrap).indexOf("/tmp/atmos-stubs") === -1,
+  "shift wrapper does not display the stub directory",
+);
+
+const execOne = ["bash", "-c", 'exec "$1"', "prefs-one", "omarchy", "restart", "shell"];
+assertEqual(hist.describe(execOne), "omarchy restart shell", 'unwrap matches exec "$1"');
+
+assertEqual(
+  hist.describe(["bash", "-c", "echo execute me", "name", "not-the-command"]),
+  '"echo execute me" name not-the-command',
+  "a script that only mentions exec is not treated as a wrapper",
+);
+
+assertEqual(hist.describe(null), "", "describe junk null");
+assertEqual(hist.describe(undefined), "", "describe junk undefined");
+assertEqual(hist.describe({}), "", "describe junk object");
+assertEqual(
+  hist.describe(["omarchy", null, "theme"]),
+  "omarchy  theme",
+  "describe keeps a hole for null argv",
+);
+assertEqual(hist.unwrap("omarchy").length, 0, "unwrap junk string is empty");
+assertEqual(hist.targetFile(["echo", "hi"], "/home/pi"), "", "targetFile junk argv is empty");
+
+assertEqual(
+  hist.targetFile(["write", "/home/pieter/.config/hypr/looknfeel.lua"], "/home/pi"),
+  "/home/pieter/.config/hypr/looknfeel.lua",
+  "/home/pi is not a prefix of /home/pieter",
+);
+assertEqual(
+  hist.targetFile(["write", "/home/pi/.config/hypr/looknfeel.lua"], "/home/pi"),
+  "~/.config/hypr/looknfeel.lua",
+  "/home/pi plus slash rewrites to ~",
+);
+assertEqual(
+  hist.targetFile(["cat", "~/.config/hypr/hyprland.lua"], "/home/pieter"),
+  "~/.config/hypr/hyprland.lua",
+  "targetFile keeps a ~ path",
+);
+assert(
+  hist.targetFile(["open", "~/.config/hypr"], "/home/pi") === "",
+  "unanchored .conf does not steal ~/.conf from ~/.config",
+);
+assertEqual(
+  hist.targetFile(["edit", "/tmp/theme.jsonc"], "/home/pi"),
+  "",
+  ".json does not eat the c off .jsonc",
+);
+
+const now = 1_700_000_000_000;
+assertEqual(hist.relativeTime(null, now), "", "relativeTime null is empty");
+assertEqual(hist.relativeTime(undefined, now), "", "relativeTime undefined is empty");
+assertEqual(hist.relativeTime("", now), "", "relativeTime empty string is empty");
+assertEqual(hist.relativeTime(0, now), "", "relativeTime 0 is empty, not 1970");
+assertEqual(hist.relativeTime("0", now), "", "relativeTime string 0 is empty");
+assertEqual(hist.relativeTime(false, now), "", "relativeTime false is empty");
+assertEqual(hist.relativeTime(now - 4000, now), "just now", "relativeTime under 10s");
+assertEqual(hist.relativeTime(now - 15000, now), "15s ago", "relativeTime seconds");
+assertEqual(hist.relativeTime(now - 5 * 60 * 1000, now), "5m ago", "relativeTime minutes");
+assertEqual(hist.relativeTime(now - 3 * 60 * 60 * 1000, now), "3h ago", "relativeTime hours");
+assertEqual(hist.relativeTime(now - 48 * 60 * 60 * 1000, now), "2d ago", "relativeTime days");
+
+const counts = hist.countsBySource([
+  { source: "you" },
+  { source: "constructor" },
+  { source: "toString" },
+  { source: "constructor" },
+  {},
+]);
+assertEqual(hist.countFor(counts, "you"), 2, "missing source counts as you");
+assertEqual(
+  hist.countFor(counts, "constructor"),
+  2,
+  "prototype-named source constructor is counted",
+);
+assertEqual(hist.countFor(counts, "toString"), 1, "prototype-named source toString is counted");
+assertEqual(hist.countFor(counts, "missing"), 0, "countFor misses");
+assertEqual(hist.countFor(null, "you"), 0, "countFor null counts");
+
+let list = [];
+for (let i = 0; i < hist.MAX_ENTRIES + 5; i++) {
+  list = hist.push(list, { at: i, key: String(i) });
+}
+assertEqual(list.length, hist.MAX_ENTRIES, "push caps at MAX_ENTRIES");
+assertEqual(list[0].key, String(hist.MAX_ENTRIES + 4), "push keeps the newest first");
+assertEqual(list[list.length - 1].key, "5", "push drops the oldest past the cap");
+
+const replayed = hist.replayOpts({
+  key: "theme",
+  apply: { theme: "nord" },
+  refresh: "none",
+  sudo: true,
+  stdin: "secret\n",
+  payload: { raw: 1 },
+});
+assertEqual(replayed.bypassPreview, true, "replayOpts sets bypassPreview");
+assertEqual(replayed.key, "theme", "replayOpts keeps key");
+assertEqual(replayed.apply.theme, "nord", "replayOpts keeps apply");
+assertEqual(replayed.refresh, "none", "replayOpts keeps refresh");
+assertEqual(replayed.sudo, true, "replayOpts keeps sudo");
+assertEqual(replayed.stdin, "secret\n", "replayOpts keeps stdin");
+assertEqual(replayed.payload.raw, 1, "replayOpts keeps payload");
+
+const original = { key: "hyprLook", bypassPreview: false };
+const copied = hist.replayOpts(original);
+assertEqual(copied.bypassPreview, true, "replayOpts overrides a false bypass");
+assertEqual(original.bypassPreview, false, "replayOpts does not mutate the held opts");
+
+const calls = [];
+hist.applyHeld(
+  [
+    { argv: ["omarchy", "theme", "set", "nord"], opts: { key: "theme", apply: { theme: "nord" } } },
+    {
+      argv: ["bash", "set-idle.sh", "300", "600"],
+      opts: { key: "idle", refresh: "none", stdin: "" },
+    },
+    { text: "omarchy theme set rose", opts: { key: "missing-argv" } },
+    { argv: [], opts: { key: "empty" } },
+    null,
+  ],
+  function (argv, opts) {
+    calls.push({ argv: argv, opts: opts });
+  },
+);
+assertEqual(calls.length, 2, "applyHeld skips missing or empty argv");
+assertEqual(calls[0].argv.join(" "), "bash set-idle.sh 300 600", "applyHeld replays oldest first");
+assertEqual(
+  calls[1].argv.join(" "),
+  "omarchy theme set nord",
+  "applyHeld then replays the newer hold",
+);
+assertEqual(calls[0].opts.bypassPreview, true, "applyHeld bypasses preview on the first replay");
+assertEqual(calls[1].opts.bypassPreview, true, "applyHeld bypasses preview on every replay");
+assertEqual(calls[0].opts.key, "idle", "applyHeld forwards key");
+assertEqual(calls[0].opts.refresh, "none", "applyHeld forwards refresh");
+assertEqual(calls[0].opts.stdin, "", "applyHeld forwards stdin");
+assertEqual(calls[1].opts.apply.theme, "nord", "applyHeld forwards apply");
+
+hist.applyHeld(null, function () {
+  calls.push({ argv: ["should-not-run"] });
+});
+assertEqual(calls.length, 2, "applyHeld on junk held list is a no-op");

--- a/tests/hubs.test.js
+++ b/tests/hubs.test.js
@@ -29,6 +29,7 @@ assertEqual(hubs.hubTitle("idle"), "Idle", "idle hub title is Idle");
 assertEqual(hubs.hubTitle("export"), "Omafile", "export hub title is Omafile");
 assertEqual(hubs.hubTitle("system/kernel"), "Kernel", "kernel is a System child");
 assertEqual(hubs.hubTitle("system/machine"), "Machine", "machine is a System child");
+assertEqual(hubs.hubTitle("system/history"), "History", "history is a System child");
 assert(
   hubs.hubById("export").keywords.indexOf("omafile") !== -1 &&
     hubs.hubById("export").keywords.indexOf("import") !== -1 &&

--- a/tests/repo.test.js
+++ b/tests/repo.test.js
@@ -1340,6 +1340,23 @@ assert(
     systemSrc.indexOf("stack.push(machinePage)") !== -1,
   "System opens the Machine child page",
 );
+assert(
+  systemSrc.indexOf('label: "History"') !== -1 &&
+    systemSrc.indexOf('openSubpage("history")') !== -1 &&
+    systemSrc.indexOf('id === "history"') !== -1 &&
+    systemSrc.indexOf("stack.push(historyPage)") !== -1,
+  "System opens the History child page when stack is set",
+);
+const historyPageSrc = fs.readFileSync(
+  path.join(__dirname, "..", "pages", "system", "HistoryPage.qml"),
+  "utf8",
+);
+assert(
+  historyPageSrc.indexOf('hubId: "system/history"') !== -1 &&
+    historyPageSrc.indexOf("Omarchy.applyHeld()") !== -1 &&
+    historyPageSrc.indexOf("Omarchy.discardHeld()") !== -1,
+  "History page applies and discards held writes",
+);
 const machinePageSrc = fs.readFileSync(
   path.join(__dirname, "..", "pages", "system", "MachinePage.qml"),
   "utf8",
@@ -1746,6 +1763,32 @@ assert(
   "runJob honors snapshot groups through normalizeGroup",
 );
 assert(runJobBody.indexOf("opts.apply") !== -1, "runJob copies opts.apply onto the job");
+assert(
+  runCommandBody.indexOf("Preview.active") !== -1 &&
+    runCommandBody.indexOf("bypassPreview") !== -1 &&
+    runCommandBody.indexOf("holdChange") !== -1 &&
+    runCommandBody.indexOf("recordChange") !== -1,
+  "runCommand holds in Preview and records a real write",
+);
+assert(
+  omarchySrc.indexOf("HistoryJs.applyHeld(held, runCommand)") !== -1,
+  "applyHeld replays through History.js so every option is forwarded",
+);
+assert(
+  runCommandBody.indexOf("opts.stdin") !== -1 &&
+    runCommandBody.indexOf("opts.key") !== -1 &&
+    runCommandBody.indexOf("opts.apply") !== -1 &&
+    runCommandBody.indexOf("opts.refresh") !== -1 &&
+    runCommandBody.indexOf("opts.sudo") !== -1,
+  "runCommand still forwards key, apply, refresh, sudo, and stdin",
+);
+const previewQml = fs.readFileSync(path.join(__dirname, "..", "services", "Preview.qml"), "utf8");
+assert(
+  previewQml.indexOf("property bool active: false") !== -1 &&
+    previewQml.indexOf("FileView") === -1 &&
+    previewQml.indexOf("StandardPaths") === -1,
+  "Preview starts off and is not persisted",
+);
 assert(shellSrc.indexOf("inotifywait") === -1, "inotifywait is not in shell.qml");
 assert(
   omarchySrc.indexOf("syncThemeFromDiskIfStale") === -1 &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port of nixfred’s [#37](https://github.com/csfh/atmos/pull/37) onto current `main`: **History** and **Preview**, one mechanism through `Omarchy.runCommand`.

Preview (off by default, not persisted) holds a write and shows the command. Nothing held runs on its own. **Apply** is the only path that releases held entries (`bypassPreview`); **Discard** clears them.

History records a real write: command text, target file, source, time. Newest first, capped at 200. In memory for this window — after multi-window Atmos (#55) each launch is its own process, so the list is per-window and is not a disk audit log.

**Credit:** original idea, `History.js` unwrap/describe traps, Preview hold, and page wiring by [nixfred](https://github.com/nixfred) in #37. After this merges, #37 can close as superseded.

### Beyond a straight port

- Rebased onto latest `main` (Machine #54, multi-window #55, chamfer). `openSubpage` pushes History when `stack` is set, same pattern as Machine, so `atmos system/history` opens History instead of System.
- `applyHeld` copies every original option (`key`, `apply`, `refresh`, `sudo`, `stdin`, `payload`, and any other own field) through `HistoryJs.replayOpts`, then sets `bypassPreview`. Apply is a full replay, not the four-field subset from #37. Held entries still carry argv+opts, not rendered text alone.
- Apply replays **oldest first** (display is newest-first). #37 applied in display order.
- `runCommand` still enqueues `key` / `apply` / `refresh` / `sudo`, and now also forwards `stdin` onto the mut job when present.
- `tests/history.test.js` that #37’s body claimed but the fork did not include: unwrap of both wrapper shapes, shift stub directory, `/home/pi` vs `/home/pieter`, junk argv, prototype-named sources, `relativeTime` edges (null / 0 / 1970), `MAX_ENTRIES` cap, `applyHeld` bypass and option forwarding.

Suite green locally (`./tests/run`).

## CLA

- [x] I agree to the [CLA](/CLA.md). This contribution becomes the property of Christoffer Hallas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52e06c6f-9244-4756-9adb-e335b897372e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52e06c6f-9244-4756-9adb-e335b897372e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

